### PR TITLE
Fix SQLAlchemy import failure on Python 3.13

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.27.1
-SQLAlchemy==2.0.25
+SQLAlchemy==2.0.43
 pydantic==1.10.17
 alembic==1.12.1
 python-multipart==0.0.9


### PR DESCRIPTION
## Summary
- bump SQLAlchemy to 2.0.43 to restore compatibility with Python 3.13

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d0e8351eb083209822e00e4e5e0363