### PR TITLE
Use PostCSS JSON config

### DIFF
--- a/frontend/.postcssrc.json
+++ b/frontend/.postcssrc.json
@@ -1,0 +1,6 @@
+{
+  "plugins": {
+    "tailwindcss": {},
+    "autoprefixer": {}
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};


### PR DESCRIPTION
## Summary
- replace the PostCSS JavaScript config with a JSON-based `.postcssrc.json` file so Node no longer emits a module-type warning

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d113c04710832087fe0098a2320071