### PR TITLE
feat: refresh board workflow ux

### DIFF
--- a/frontend/src/app/core/api/analysis-gateway.ts
+++ b/frontend/src/app/core/api/analysis-gateway.ts
@@ -83,7 +83,7 @@ export class AnalysisGateway {
    * @returns Primary title text.
    */
   private readonly resolveBaseTitle = (request: AnalysisRequest): string =>
-    request.notes.split('\n')[0]?.trim() || 'Gemini 提案';
+    request.notes.split('\n')[0]?.trim() || 'ChatGPT 提案';
 
   /**
    * Builds a consistent subtask list based on the preferred tone.

--- a/frontend/src/app/core/layout/shell/shell.html
+++ b/frontend/src/app/core/layout/shell/shell.html
@@ -1,6 +1,6 @@
 <div class="flex min-h-screen flex-col bg-surface">
   <header class="border-b border-subtle bg-surface-strong backdrop-blur">
-    <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between">
+    <div class="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between">
       <div class="flex items-center gap-3">
         <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-accent text-lg font-semibold text-on-surface-inverse shadow-soft">
           TG
@@ -25,7 +25,7 @@
     </div>
   </header>
 
-  <main class="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-10 lg:flex-row">
+  <main class="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-10 lg:flex-row">
     <aside class="lg:w-72">
       @if (summarySignal(); as summary) {
         <section class="surface-panel flex flex-col gap-6 px-6 py-8">
@@ -60,9 +60,9 @@
   </main>
 
   <footer class="border-t border-subtle bg-surface-strong">
-    <div class="mx-auto flex max-w-6xl flex-col gap-2 px-6 py-6 text-xs text-slate-500 dark:text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+    <div class="mx-auto flex max-w-7xl flex-col gap-2 px-6 py-6 text-xs text-slate-500 dark:text-slate-400 sm:flex-row sm:items-center sm:justify-between">
       <p>© {{ year }} Todo Generator</p>
-      <p>Angular 20 Signal Architecture / Gemini モック統合</p>
+      <p>Angular 20 Signal Architecture / ChatGPT モック統合</p>
     </div>
   </footer>
 </div>

--- a/frontend/src/app/core/state/workspace-store.ts
+++ b/frontend/src/app/core/state/workspace-store.ts
@@ -33,7 +33,7 @@ const INITIAL_TEMPLATES: TemplatePreset[] = [
   {
     id: 'ai-template',
     name: 'AI 改善サイクル',
-    description: 'Gemini 改修用のチェックリストテンプレート',
+    description: 'ChatGPT 改修用のチェックリストテンプレート',
     defaultStatusId: 'todo',
     defaultLabelIds: ['ai'],
   },
@@ -58,7 +58,7 @@ const buildSubtasks = (titles: readonly string[]): Subtask[] =>
 const INITIAL_CARDS: Card[] = [
   {
     id: createId(),
-    title: 'Gemini プロンプトの改善',
+    title: 'ChatGPT プロンプトの改善',
     summary: '分析精度向上のための新しいプロンプト設計を検証します。',
     statusId: 'in-progress',
     labelIds: ['ai'],

--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -1,10 +1,10 @@
 <section class="space-y-10">
   <form class="surface-panel space-y-6 px-8 py-8" (submit)="handleSubmit($event)">
     <header class="space-y-2">
-      <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Gemini Analyzer</p>
+      <p class="text-xs uppercase tracking-[0.3em] text-slate-400">ChatGPT Analyzer</p>
       <h2 class="text-2xl font-semibold text-on-surface">入力テキストを解析</h2>
       <p class="text-sm text-slate-500 dark:text-slate-400">
-        作業メモやアイデアを貼り付けると、Gemini がカード候補とサブタスクを提案します。
+        作業メモやアイデアを貼り付けると、ChatGPT がカード候補とサブタスクを提案します。
       </p>
     </header>
 
@@ -70,7 +70,7 @@
     <header class="flex items-center justify-between">
       <div>
         <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Proposals</p>
-        <h3 class="text-xl font-semibold text-on-surface">Gemini の提案結果</h3>
+        <h3 class="text-xl font-semibold text-on-surface">ChatGPT の提案結果</h3>
       </div>
       <button
         type="button"
@@ -83,7 +83,7 @@
 
     @if (analysisResource.status() === 'loading') {
       <div class="surface-panel animate-pulse space-y-3 px-6 py-6 text-sm text-slate-500">
-        Gemini が提案を作成しています...
+        ChatGPT が提案を作成しています...
       </div>
     }
 

--- a/frontend/src/app/features/analyze/page.ts
+++ b/frontend/src/app/features/analyze/page.ts
@@ -7,7 +7,7 @@ import { AnalysisProposal, AnalysisRequest } from '@core/models';
 import { createSignalForm } from '@lib/forms/signal-forms';
 
 /**
- * Analyzer page allowing users to submit notes and review Gemini-style proposals.
+ * Analyzer page allowing users to submit notes and review ChatGPT-style proposals.
  */
 @Component({
   selector: 'app-analyze-page',

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -46,11 +46,20 @@
         </button>
       </div>
     </div>
+    <p class="rounded-3xl bg-accent-muted px-6 py-4 text-sm text-accent-strong shadow-soft">
+      カードをドラッグ＆ドロップしてステータスを更新できます。ステータス以外でグルーピングしている場合はカード詳細から調整してください。
+    </p>
   </header>
 
-  <div class="grid gap-6 lg:grid-cols-4">
+  <div class="board-columns" cdkDropListGroup>
     @for (column of columnsSignal(); track column.id) {
-      <section class="surface-panel flex min-h-[320px] flex-col gap-4 px-5 py-5">
+      <section
+        class="board-column"
+        cdkDropList
+        [cdkDropListData]="column.cards"
+        [cdkDropListDisabled]="groupingSignal() !== 'status'"
+        (cdkDropListDropped)="handleDrop(column.id, $event)"
+      >
         <header class="flex items-center justify-between">
           <div>
             <p class="text-xs uppercase tracking-[0.3em] text-slate-400">{{ column.id }}</p>
@@ -58,17 +67,27 @@
           </div>
           <span class="surface-pill px-3 py-1 text-xs font-semibold text-slate-500">{{ column.count }} 件</span>
         </header>
-        <div class="flex flex-1 flex-col gap-4">
+        <div class="board-card-list">
           @if (column.cards.length === 0) {
-            <p class="rounded-2xl border border-dashed border-subtle px-4 py-6 text-center text-sm text-slate-500">
-              カードがありません。
-            </p>
+            <p class="board-empty text-sm">カードがありません。{{ groupingSignal() === 'status' ? 'ここにカードをドラッグすると移動できます。' : '' }}</p>
           } @else {
             @for (cardId of column.cards; track cardId) {
               @if (cardsByIdSignal().get(cardId); as card) {
-                <article class="surface-card flex flex-col gap-3 px-4 py-4">
-                  <div class="flex items-center justify-between gap-2">
-                    <h4 class="text-base font-semibold text-on-surface">{{ card.title }}</h4>
+                <article
+                  class="board-card surface-card flex flex-col gap-4 px-5 py-5"
+                  cdkDrag
+                  [cdkDragData]="card.id"
+                  [cdkDragDisabled]="groupingSignal() !== 'status'"
+                  [style.borderColor]="statusColor(card.statusId) + '33'"
+                  [style.background]="
+                    'linear-gradient(180deg, ' + statusColor(card.statusId) + '14 0%, var(--surface) 65%)'
+                  "
+                >
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="space-y-2">
+                      <h4 class="text-base font-semibold text-on-surface">{{ card.title }}</h4>
+                      <p class="text-sm leading-6 text-slate-600 dark:text-slate-300">{{ card.summary }}</p>
+                    </div>
                     <button
                       type="button"
                       class="surface-pill focus-ring px-3 py-1 text-xs font-semibold text-slate-500"
@@ -77,16 +96,15 @@
                       詳細
                     </button>
                   </div>
-                  <p class="text-sm text-slate-600 dark:text-slate-300">{{ card.summary }}</p>
-                  <div class="flex flex-wrap gap-2 text-xs text-slate-500">
-                    <span class="surface-pill px-3 py-1" [style.color]="statusColor(card.statusId)">
+                  <div class="flex flex-wrap gap-2 text-xs font-medium text-slate-500">
+                    <span class="board-badge" [style.color]="statusColor(card.statusId)">
                       {{ statusName(card.statusId) }}
                     </span>
                     @for (labelId of card.labelIds; track labelId) {
-                      <span class="surface-pill px-3 py-1">{{ labelName(labelId) }}</span>
+                      <span class="board-badge">{{ labelName(labelId) }}</span>
                     }
                   </div>
-                  <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                  <div class="flex flex-wrap items-center gap-3 text-xs text-slate-500">
                     <span>SP: {{ card.storyPoints }}</span>
                     @if (card.assignee) {
                       <span>担当: {{ card.assignee }}</span>
@@ -95,17 +113,19 @@
                       <span>AI信頼度: {{ (card.confidence * 100) | number: '1.0-0' }}%</span>
                     }
                   </div>
-                  <div class="flex flex-wrap gap-2 text-xs">
-                    @for (status of statusesSignal(); track status.id) {
-                      <button
-                        type="button"
-                        class="surface-pill focus-ring px-3 py-1"
-                        (click)="moveCard(card.id, status.id)"
-                      >
-                        {{ status.name }}
-                      </button>
-                    }
-                  </div>
+                  @if (groupingSignal() !== 'status') {
+                    <div class="flex flex-wrap gap-2 text-xs">
+                      @for (status of statusesSignal(); track status.id) {
+                        <button
+                          type="button"
+                          class="surface-pill focus-ring px-3 py-1"
+                          (click)="moveCard(card.id, status.id)"
+                        >
+                          {{ status.name }}
+                        </button>
+                      }
+                    </div>
+                  }
                 </article>
               }
             }

--- a/frontend/src/app/features/board/page.scss
+++ b/frontend/src/app/features/board/page.scss
@@ -1,4 +1,114 @@
 :host {
   display: block;
-  padding: 1rem 0 4rem;
+  padding: 1.5rem 0 4rem;
+}
+
+.board-columns {
+  display: flex;
+  gap: 1.5rem;
+  overflow-x: auto;
+  padding: 0 1.5rem 1.5rem;
+  margin: 0 -1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .board-columns {
+    margin: 0;
+    padding-inline: 0;
+  }
+}
+
+.board-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-width: 20rem;
+  max-width: 24rem;
+  flex-shrink: 0;
+  padding: 1.5rem;
+  border-radius: 1.75rem;
+  border: 1px solid var(--border-subtle);
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.12), rgba(148, 163, 184, 0.24));
+  box-shadow: var(--shadow-soft);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.board-column header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+@media (prefers-color-scheme: dark) {
+  .board-column {
+    background: linear-gradient(180deg, rgba(30, 41, 59, 0.88), rgba(15, 23, 42, 0.92));
+  }
+}
+
+.board-column.cdk-drop-list-dragging,
+.board-column.cdk-drop-list-receiving {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-strong);
+}
+
+.board-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 12rem;
+}
+
+.board-empty {
+  border-radius: 1.5rem;
+  border: 2px dashed rgba(148, 163, 184, 0.45);
+  padding: 2rem 1.5rem;
+  text-align: center;
+  color: #64748b;
+  background: rgba(255, 255, 255, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  .board-empty {
+    background: rgba(30, 41, 59, 0.6);
+    color: #cbd5f5;
+  }
+}
+
+.board-card {
+  position: relative;
+  border-width: 1px;
+  overflow: hidden;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.board-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
+}
+
+.board-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+@media (prefers-color-scheme: dark) {
+  .board-badge {
+    background: rgba(30, 41, 59, 0.6);
+    border-color: rgba(148, 163, 184, 0.5);
+  }
+}
+
+.cdk-drag-preview {
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-strong);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0;
 }

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
 
 import { WorkspaceStore } from '@core/state/workspace-store';
 import { BoardColumnView, BoardGrouping, Card, Label, Status } from '@core/models';
@@ -13,7 +14,7 @@ const DEFAULT_STATUS_COLOR = '#94a3b8';
 @Component({
   selector: 'app-board-page',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, DragDropModule],
   templateUrl: './page.html',
   styleUrl: './page.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -97,6 +98,23 @@ export class BoardPage {
    */
   public readonly moveCard = (cardId: string, statusId: string): void => {
     this.workspace.updateCardStatus(cardId, statusId);
+  };
+
+  public readonly handleDrop = (columnId: string, event: CdkDragDrop<readonly string[]>): void => {
+    if (this.groupingSignal() !== 'status') {
+      return;
+    }
+
+    if (event.previousContainer === event.container) {
+      return;
+    }
+
+    const cardId = event.item.data as string | undefined;
+    if (!cardId) {
+      return;
+    }
+
+    this.moveCard(cardId, columnId);
   };
 
   public readonly selectedCardSignal = this.workspace.selectedCard;


### PR DESCRIPTION
## Summary
- widen the workspace shell and board layout while surfacing drag-and-drop guidance
- enable CDK drag & drop on board columns with refreshed card and column styling
- replace Gemini references with ChatGPT across analysis copy and seed data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d12114fe9083209f2986d43e35abe2