### PR TITLE
Simplify analyze form goal configuration

### DIFF
--- a/frontend/src/app/core/api/analysis-gateway.ts
+++ b/frontend/src/app/core/api/analysis-gateway.ts
@@ -40,7 +40,7 @@ export class AnalysisGateway {
           const timer = setTimeout(() => {
             try {
               const baseTitle = this.resolveBaseTitle(params);
-              const subtasks = this.resolveSubtasks(params.tone);
+              const subtasks = this.resolveSubtasks(params.autoObjective);
               const buildProposal = (index: number): AnalysisProposal => ({
                 id: createId(),
                 title: `${baseTitle} #${index + 1}`,
@@ -86,13 +86,13 @@ export class AnalysisGateway {
     request.notes.split('\n')[0]?.trim() || 'Gemini 提案';
 
   /**
-   * Builds a consistent subtask list based on the preferred tone.
+   * Builds a consistent subtask list based on the objective strategy.
    *
-   * @param tone - Desired communication tone.
+   * @param autoObjective - Whether the objective was AI generated.
    * @returns Subtask description list.
    */
-  private readonly resolveSubtasks = (tone: 'formal' | 'casual'): readonly string[] => [
-    `${tone === 'formal' ? 'フォーマル' : 'カジュアル'}なトーンで現状整理`,
+  private readonly resolveSubtasks = (autoObjective: boolean): readonly string[] => [
+    autoObjective ? 'AIが提案したゴール案を確認' : '提供されたゴールを整理',
     '重要な関係者と論点を共有',
     'リスクと成功条件を定義',
   ];

--- a/frontend/src/app/core/models/analysis.ts
+++ b/frontend/src/app/core/models/analysis.ts
@@ -4,7 +4,7 @@
 export interface AnalysisRequest extends Record<string, unknown> {
   readonly notes: string;
   readonly objective: string;
-  readonly tone: 'formal' | 'casual';
+  readonly autoObjective: boolean;
 }
 
 /**

--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -19,40 +19,65 @@
         ></textarea>
       </label>
       <div class="flex flex-col gap-4">
+        <div class="space-y-3 rounded-2xl border border-dashed border-subtle px-4 py-4">
+          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">ゴール設定</p>
+          <p class="text-[11px] text-slate-400 dark:text-slate-500">
+            解析結果で目指すゴールをどのように決めるか選択してください。
+          </p>
+          <label class="flex items-start gap-3 text-sm text-slate-600 dark:text-slate-300">
+            <input
+              type="radio"
+              name="autoObjective"
+              [checked]="isAutoObjectiveEnabled()"
+              (change)="analyzeForm.controls.autoObjective.setValue(true)"
+              class="mt-1 h-4 w-4 text-accent focus-ring"
+            />
+            <span class="space-y-1">
+              <span class="block font-semibold text-on-surface">AIにおまかせ</span>
+              <span class="block text-xs text-slate-500 dark:text-slate-400">
+                ノートの内容から Gemini がおすすめのゴールを自動設定します。
+              </span>
+            </span>
+          </label>
+          <label class="flex items-start gap-3 text-sm text-slate-600 dark:text-slate-300">
+            <input
+              type="radio"
+              name="autoObjective"
+              [checked]="!isAutoObjectiveEnabled()"
+              (change)="analyzeForm.controls.autoObjective.setValue(false)"
+              class="mt-1 h-4 w-4 text-accent focus-ring"
+            />
+            <span class="space-y-1">
+              <span class="block font-semibold text-on-surface">自分で指定</span>
+              <span class="block text-xs text-slate-500 dark:text-slate-400">
+                ゴールを詳しく入力して Gemini に具体的な提案を依頼します。
+              </span>
+            </span>
+          </label>
+        </div>
         <label class="flex flex-col gap-2">
-          <span class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">目的</span>
-          <input
-            class="rounded-2xl border border-subtle bg-surface px-4 py-3 text-sm focus-ring"
-            placeholder="最終的に達成したいゴールを記載"
+          <span class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">ゴール</span>
+          <textarea
+            class="min-h-[160px] rounded-2xl border border-subtle bg-surface px-4 py-3 text-sm focus-ring disabled:bg-surface/70"
+            placeholder="例: 新規登録フローの離脱率を20%改善する"
             [value]="analyzeForm.controls.objective.value()"
             (input)="analyzeForm.controls.objective.setValue($any($event.target).value)"
-          />
+            [disabled]="isAutoObjectiveEnabled()"
+          ></textarea>
         </label>
-        <fieldset class="space-y-3 rounded-2xl border border-dashed border-subtle px-4 py-4">
-          <legend class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">トーン</legend>
-          <label class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-300">
-            <input
-              type="radio"
-              name="tone"
-              value="formal"
-              [checked]="analyzeForm.controls.tone.value() === 'formal'"
-              (change)="analyzeForm.controls.tone.setValue('formal')"
-              class="h-4 w-4 text-accent focus-ring"
-            />
-            フォーマル – 役員向けの説明や公式ドキュメントに適した文体
-          </label>
-          <label class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-300">
-            <input
-              type="radio"
-              name="tone"
-              value="casual"
-              [checked]="analyzeForm.controls.tone.value() === 'casual'"
-              (change)="analyzeForm.controls.tone.setValue('casual')"
-              class="h-4 w-4 text-accent focus-ring"
-            />
-            カジュアル – チーム内共有やSlackポストなどフラットなコミュニケーション
-          </label>
-        </fieldset>
+        @if (isAutoObjectiveEnabled()) {
+          <div class="rounded-2xl border border-subtle bg-surface px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
+            <p class="text-sm font-semibold text-on-surface">AIおすすめのゴール候補</p>
+            <p class="mt-1 leading-relaxed">{{ autoObjectivePreview() }}</p>
+            <p class="mt-2 text-[11px] text-slate-400 dark:text-slate-500">
+              解析を実行すると、このゴールを前提に提案が生成されます。
+            </p>
+          </div>
+        } @else {
+          <p class="text-[11px] text-slate-400 dark:text-slate-500">
+            ゴールは Gemini が提案を組み立てる際の到達点になります。できるだけ具体的に記載してください。
+          </p>
+        }
       </div>
     </div>
 
@@ -100,7 +125,7 @@
             <div class="flex items-center justify-between">
               <h4 class="text-lg font-semibold text-on-surface">{{ proposal.title }}</h4>
               <span class="surface-pill px-3 py-1 text-xs font-semibold text-accent-strong">
-                信頼度 {{ (proposal.confidence * 100) | number: '1.0-0' }}%
+                おすすめ度 {{ (proposal.confidence * 100) | number: '1.0-0' }}%
               </span>
             </div>
             <p class="text-sm text-slate-600 dark:text-slate-300">{{ proposal.summary }}</p>

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -92,7 +92,7 @@
                       <span>担当: {{ card.assignee }}</span>
                     }
                     @if (card.confidence) {
-                      <span>AI信頼度: {{ (card.confidence * 100) | number: '1.0-0' }}%</span>
+                      <span>AIおすすめ度: {{ (card.confidence * 100) | number: '1.0-0' }}%</span>
                     }
                   </div>
                   <div class="flex flex-wrap gap-2 text-xs">


### PR DESCRIPTION
## Summary
- remove the unused tone selector and introduce AI/manual goal selection with a larger goal field on the analyze form
- compute automatic goal suggestions from the notes and surface a preview while handling manual input validation
- update the analysis request typing and gateway subtasks to reflect the auto-goal workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d121d557c88320ac54f8b7f429dbc8