### PR TITLE
Filter low confidence analyzer templates

### DIFF
--- a/frontend/src/app/core/api/analysis-gateway.ts
+++ b/frontend/src/app/core/api/analysis-gateway.ts
@@ -49,6 +49,7 @@ export class AnalysisGateway {
                 suggestedLabelIds: index === 0 ? ['ai'] : ['frontend'],
                 subtasks,
                 confidence: 0.62 + index * 0.12,
+                templateId: index === 0 ? 'ai-template' : 'ux-template',
               });
 
               subscriber.next({

--- a/frontend/src/app/core/models/analysis.ts
+++ b/frontend/src/app/core/models/analysis.ts
@@ -18,6 +18,7 @@ export interface AnalysisProposal {
   readonly suggestedLabelIds: readonly string[];
   readonly subtasks: readonly string[];
   readonly confidence: number;
+  readonly templateId?: string | null;
 }
 
 /**

--- a/frontend/src/app/core/models/workspace.ts
+++ b/frontend/src/app/core/models/workspace.ts
@@ -27,6 +27,7 @@ export interface TemplatePreset {
   readonly description: string;
   readonly defaultStatusId: string;
   readonly defaultLabelIds: readonly string[];
+  readonly confidenceThreshold: number;
 }
 
 /**

--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -118,51 +118,57 @@
       </div>
     }
 
-    @if (analysisResource.value(); as result) {
-      <div class="grid gap-4 lg:grid-cols-2">
-        @for (proposal of result.proposals; track proposal.id) {
-          <article class="surface-panel flex flex-col gap-4 px-6 py-6">
-            <div class="flex items-center justify-between">
-              <h4 class="text-lg font-semibold text-on-surface">{{ proposal.title }}</h4>
-              <span class="surface-pill px-3 py-1 text-xs font-semibold text-accent-strong">
-                おすすめ度 {{ (proposal.confidence * 100) | number: '1.0-0' }}%
-              </span>
-            </div>
-            <p class="text-sm text-slate-600 dark:text-slate-300">{{ proposal.summary }}</p>
-            <div class="flex flex-wrap gap-2 text-xs text-slate-500">
-              <span class="surface-pill px-3 py-1">推奨ステータス: {{ proposal.suggestedStatusId }}</span>
-              <span class="surface-pill px-3 py-1">推奨ラベル: {{ proposal.suggestedLabelIds.join(', ') }}</span>
-            </div>
-            <div class="space-y-2">
-              <p class="text-xs uppercase tracking-[0.3em] text-slate-400">サブタスク案</p>
-              <ul class="space-y-2 text-sm text-slate-600 dark:text-slate-300">
-                @for (task of proposal.subtasks; track task) {
-                  <li class="flex items-center gap-2">
-                    <span class="h-2 w-2 rounded-full bg-accent"></span>
-                    <span>{{ task }}</span>
-                  </li>
-                }
-              </ul>
-            </div>
-            <button
-              type="button"
-              class="surface-primary focus-ring mt-auto self-start rounded-full px-5 py-2 text-sm font-semibold"
-              (click)="publishProposals([proposal])"
-            >
-              この提案をカード化
-            </button>
-          </article>
-        }
-      </div>
-      <div class="flex justify-end">
-        <button
-          type="button"
-          class="surface-primary focus-ring rounded-full px-6 py-3 text-sm font-semibold"
-          (click)="publishProposals(result.proposals)"
-        >
-          すべての提案をボードに追加
-        </button>
-      </div>
+    @if (analysisResource.value()) {
+      @if (hasEligibleProposals()) {
+        <div class="grid gap-4 lg:grid-cols-2">
+          @for (proposal of eligibleProposals(); track proposal.id) {
+            <article class="surface-panel flex flex-col gap-4 px-6 py-6">
+              <div class="flex items-center justify-between">
+                <h4 class="text-lg font-semibold text-on-surface">{{ proposal.title }}</h4>
+                <span class="surface-pill px-3 py-1 text-xs font-semibold text-accent-strong">
+                  おすすめ度 {{ (proposal.confidence * 100) | number: '1.0-0' }}%
+                </span>
+              </div>
+              <p class="text-sm text-slate-600 dark:text-slate-300">{{ proposal.summary }}</p>
+              <div class="flex flex-wrap gap-2 text-xs text-slate-500">
+                <span class="surface-pill px-3 py-1">推奨ステータス: {{ proposal.suggestedStatusId }}</span>
+                <span class="surface-pill px-3 py-1">推奨ラベル: {{ proposal.suggestedLabelIds.join(', ') }}</span>
+              </div>
+              <div class="space-y-2">
+                <p class="text-xs uppercase tracking-[0.3em] text-slate-400">サブタスク案</p>
+                <ul class="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                  @for (task of proposal.subtasks; track task) {
+                    <li class="flex items-center gap-2">
+                      <span class="h-2 w-2 rounded-full bg-accent"></span>
+                      <span>{{ task }}</span>
+                    </li>
+                  }
+                </ul>
+              </div>
+              <button
+                type="button"
+                class="surface-primary focus-ring mt-auto self-start rounded-full px-5 py-2 text-sm font-semibold"
+                (click)="publishProposals([proposal])"
+              >
+                この提案をカード化
+              </button>
+            </article>
+          }
+        </div>
+        <div class="flex justify-end">
+          <button
+            type="button"
+            class="surface-primary focus-ring rounded-full px-6 py-3 text-sm font-semibold"
+            (click)="publishProposals(eligibleProposals())"
+          >
+            すべての提案をボードに追加
+          </button>
+        </div>
+      } @else {
+        <div class="surface-panel px-6 py-6 text-sm text-slate-500 dark:text-slate-400">
+          おすすめ度のしきい値を下回るテンプレートの提案は表示されません。設定を調整して再度お試しください。
+        </div>
+      }
     } @else {
       <div class="surface-panel px-6 py-6 text-sm text-slate-500 dark:text-slate-400">
         提案結果はまだありません。ノートを入力して解析を実行してください。

--- a/frontend/src/app/features/analyze/page.ts
+++ b/frontend/src/app/features/analyze/page.ts
@@ -33,6 +33,19 @@ export class AnalyzePage {
     this.requestSignal,
   );
 
+  public readonly eligibleProposals = computed<readonly AnalysisProposal[]>(() => {
+    const result = this.analysisResource.value();
+    if (!result) {
+      return [];
+    }
+
+    return result.proposals.filter((proposal) => this.workspace.isProposalEligible(proposal));
+  });
+
+  public readonly hasEligibleProposals = computed(
+    () => this.eligibleProposals().length > 0,
+  );
+
   public readonly hasResult = computed(() => this.analysisResource.value() !== null);
 
   public readonly isAutoObjectiveEnabled = computed(() =>

--- a/frontend/src/app/features/settings/page.html
+++ b/frontend/src/app/features/settings/page.html
@@ -117,6 +117,9 @@
           <p class="text-sm text-slate-600 dark:text-slate-300">{{ template.description }}</p>
           <p class="text-xs text-slate-500">初期ステータス: {{ template.defaultStatusId }}</p>
           <p class="text-xs text-slate-500">初期ラベル: {{ template.defaultLabelIds.join(', ') }}</p>
+          <p class="text-xs text-slate-500">
+            最小おすすめ度: {{ (template.confidenceThreshold * 100) | number: '1.0-0' }}%
+          </p>
         </li>
       }
     </ul>


### PR DESCRIPTION
## Summary
- extend workspace templates with confidence thresholds and new management helpers in the signal store
- filter analyzer proposals below the configured template confidence thresholds before display or publication
- surface template thresholds in settings so maintainers can review defaults

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d12ee7dccc83208aa35626e79e2eac