### PR TITLE
Replace Gemini references with ChatGPT

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,10 +1,10 @@
 # Todo Generator Frontend
 
-Angular 20 single-page application that follows the product specification in the repository root README. It provides the Gemini-assisted capture flow, kanban board, analytics, and workspace configuration screens required for the Todo Generator experience.
+Angular 20 single-page application that follows the product specification in the repository root README. It provides the ChatGPT-assisted capture flow, kanban board, analytics, and workspace configuration screens required for the Todo Generator experience.
 
 ## Key Features
 
-- **Input Analyzer** – Paste free-form notes and review Gemini proposals before publishing tasks to the board.
+- **Input Analyzer** – Paste free-form notes and review ChatGPT proposals before publishing tasks to the board.
 - **Workspace Board** – Accessible CDK drag-and-drop columns grouped by status, label, or assignee with card detail drawers.
 - **Card Detail Management** – Update metadata, progress subtasks, and log comments/activity from a focused drawer UI.
 - **Analytics Dashboard** – Summaries for completion rate, story points, and distribution across statuses and labels.

--- a/frontend/public/chatgpt.svg
+++ b/frontend/public/chatgpt.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-label="Gemini icon">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-label="ChatGPT icon">
   <defs>
     <linearGradient id="g" x1="0%" x2="100%" y1="0%" y2="100%">
       <stop offset="0%" stop-color="#38bdf8" />

--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -35,7 +35,7 @@
             <span class="space-y-1">
               <span class="block font-semibold text-on-surface">AIにおまかせ</span>
               <span class="block text-xs text-slate-500 dark:text-slate-400">
-                ノートの内容から Gemini がおすすめのゴールを自動設定します。
+                ノートの内容から ChatGPT がおすすめのゴールを自動設定します。
               </span>
             </span>
           </label>
@@ -50,7 +50,7 @@
             <span class="space-y-1">
               <span class="block font-semibold text-on-surface">自分で指定</span>
               <span class="block text-xs text-slate-500 dark:text-slate-400">
-                ゴールを詳しく入力して Gemini に具体的な提案を依頼します。
+                ゴールを詳しく入力して ChatGPT に具体的な提案を依頼します。
               </span>
             </span>
           </label>
@@ -75,7 +75,7 @@
           </div>
         } @else {
           <p class="text-[11px] text-slate-400 dark:text-slate-500">
-            ゴールは Gemini が提案を組み立てる際の到達点になります。できるだけ具体的に記載してください。
+            ゴールは ChatGPT が提案を組み立てる際の到達点になります。できるだけ具体的に記載してください。
           </p>
         }
       </div>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -6,7 +6,7 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
-    <link rel="icon" type="image/svg+xml" href="/gemini.svg" />
+    <link rel="icon" type="image/svg+xml" href="/chatgpt.svg" />
   </head>
   <body class="min-h-full antialiased">
     <app-root></app-root>


### PR DESCRIPTION
## Summary
- update frontend documentation and UI copy to refer to ChatGPT instead of Gemini
- rename the favicon asset and update the reference to chatgpt.svg

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d169cddefc83208e6f527b19476e1e