### PR TITLE
feat: enable adding comments from board details

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -171,6 +171,9 @@ class Comment(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow
     )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
 
     card: Mapped[Card] = relationship("Card", back_populates="comments")
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -344,6 +344,7 @@ class CommentCreate(CommentBase):
 class CommentRead(CommentBase):
     id: str
     created_at: datetime
+    updated_at: datetime
 
     class Config:
         orm_mode = True

--- a/frontend/src/app/core/models/card.ts
+++ b/frontend/src/app/core/models/card.ts
@@ -6,6 +6,7 @@ export interface CardComment {
   readonly author: string;
   readonly message: string;
   readonly createdAt: string;
+  readonly updatedAt: string;
 }
 
 /**

--- a/frontend/src/app/core/state/workspace-store.ts
+++ b/frontend/src/app/core/state/workspace-store.ts
@@ -411,6 +411,45 @@ export class WorkspaceStore {
   };
 
   /**
+   * Appends a new comment to the specified card.
+   *
+   * @param cardId - Identifier of the card receiving the comment.
+   * @param payload - Author and message content entered by the user.
+   */
+  public readonly addComment = (
+    cardId: string,
+    payload: { author: string; message: string },
+  ): void => {
+    const author = payload.author.trim();
+    const message = payload.message.trim();
+    if (!author || !message) {
+      return;
+    }
+
+    const timestamp = new Date().toISOString();
+
+    this.cardsSignal.update((cards) =>
+      cards.map((card) =>
+        card.id === cardId
+          ? {
+              ...card,
+              comments: [
+                ...card.comments,
+                {
+                  id: createId(),
+                  author,
+                  message,
+                  createdAt: timestamp,
+                  updatedAt: timestamp,
+                },
+              ],
+            }
+          : card,
+      ),
+    );
+  };
+
+  /**
    * Creates a new card from a suggested improvement action.
    *
    * @param payload - Attributes describing the new card.

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -293,6 +293,46 @@
         </div>
         <div class="min-w-0 space-y-4">
           <p class="text-xs uppercase tracking-[0.3em] text-slate-400">コメント</p>
+          <form
+            class="grid gap-3 rounded-2xl border border-dashed border-subtle bg-surface px-5 py-5"
+            (submit)="saveComment($event)"
+          >
+            <div class="grid gap-2">
+              <label
+                class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500"
+                for="comment-author"
+                >担当者</label
+              >
+              <input
+                id="comment-author"
+                class="rounded-2xl border border-subtle bg-surface px-4 py-3 text-sm focus-ring"
+                placeholder="例: 田中太郎"
+                [value]="commentForm.controls.author.value()"
+                (input)="commentForm.controls.author.setValue($any($event.target).value)"
+              />
+            </div>
+            <div class="grid gap-2">
+              <label
+                class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500"
+                for="comment-message"
+                >コメント</label
+              >
+              <textarea
+                id="comment-message"
+                class="min-h-[80px] rounded-2xl border border-subtle bg-surface px-4 py-3 text-sm focus-ring"
+                placeholder="進捗やメモを追加しましょう"
+                [value]="commentForm.controls.message.value()"
+                (input)="commentForm.controls.message.setValue($any($event.target).value)"
+              ></textarea>
+            </div>
+            <button
+              type="submit"
+              class="surface-primary focus-ring rounded-full px-5 py-3 text-sm font-semibold disabled:pointer-events-none disabled:opacity-60"
+              [disabled]="!isCommentFormValid()"
+            >
+              コメントを追加
+            </button>
+          </form>
           @if (active.comments.length === 0) {
             <p class="rounded-2xl border border-dashed border-subtle px-4 py-6 text-sm text-slate-500">
               コメントはまだありません。
@@ -300,9 +340,14 @@
           } @else {
             <ul class="space-y-3 text-sm text-slate-600 dark:text-slate-300">
               @for (comment of active.comments; track comment.id) {
-                <li class="rounded-2xl border border-subtle bg-surface px-4 py-3">
-                  <p class="font-semibold">{{ comment.author }}</p>
-                  <p class="mt-1 break-words">{{ comment.message }}</p>
+                <li class="space-y-2 rounded-2xl border border-subtle bg-surface px-4 py-3">
+                  <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500">
+                    <span class="text-sm font-semibold text-on-surface">
+                      担当: {{ comment.author }}
+                    </span>
+                    <span>更新: {{ comment.updatedAt | date: 'yyyy/MM/dd HH:mm' }}</span>
+                  </div>
+                  <p class="break-words">{{ comment.message }}</p>
                 </li>
               }
             </ul>

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
 
@@ -157,6 +157,18 @@ export class BoardPage {
 
   public readonly searchForm = createSignalForm({ search: '' });
 
+  private lastSelectedCardId: string | null = null;
+
+  public readonly commentForm = createSignalForm({
+    author: '',
+    message: '',
+  });
+
+  public readonly isCommentFormValid = computed(() => {
+    const value = this.commentForm.value();
+    return value.author.trim().length > 0 && value.message.trim().length > 0;
+  });
+
   /**
    * Applies a text search filter to the board.
    *
@@ -232,6 +244,40 @@ export class BoardPage {
   };
 
   public readonly selectedCardSignal = this.workspace.selectedCard;
+
+  private readonly resetCommentFormEffect = effect(() => {
+    const active = this.selectedCardSignal();
+    const nextId = active?.id ?? null;
+    if (nextId === this.lastSelectedCardId) {
+      return;
+    }
+
+    this.lastSelectedCardId = nextId;
+    this.commentForm.reset({
+      author: active?.assignee ?? '',
+      message: '',
+    });
+  });
+
+  public readonly saveComment = (event: Event): void => {
+    event.preventDefault();
+
+    const active = this.selectedCardSignal();
+    if (!active || !this.isCommentFormValid()) {
+      return;
+    }
+
+    const snapshot = this.commentForm.value();
+    const author = snapshot.author.trim();
+    const message = snapshot.message.trim();
+
+    this.workspace.addComment(active.id, { author, message });
+
+    this.commentForm.reset({
+      author,
+      message: '',
+    });
+  };
 
   public readonly isActiveCard = (cardId: string): boolean =>
     this.workspace.selectedCardId() === cardId;


### PR DESCRIPTION
## Summary
- add a comment form to the board card drawer so users can capture messages with responsible owner details
- extend the workspace store to append comments with timestamps and surface the latest update time in the UI
- track comment update timestamps in the backend schema for parity with the frontend data model

## Testing
- pytest
- npm test -- --watch=false *(fails: Chrome browser binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d16a1d49f0832094a7e727280731df