### PR TITLE
Fix missing board comment form state

### DIFF
--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -197,6 +197,18 @@ export class BoardPage {
 
   public readonly searchForm = createSignalForm({ search: '' });
 
+  public readonly commentForm = createSignalForm({
+    author: '',
+    message: '',
+  });
+
+  private lastSelectedCardId: string | null = null;
+
+  public readonly isCommentFormValid = (): boolean => {
+    const snapshot = this.commentForm.value();
+    return snapshot.author.trim().length > 0 && snapshot.message.trim().length > 0;
+  };
+
   public readonly quickFilterSummarySignal = computed(() => {
     const active = this.filtersSignal().quickFilters;
     if (active.length === 0) {


### PR DESCRIPTION
## Summary
- add a signal-backed comment form to the board page component
- track the last selected card id and expose validation used by the template

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1c8e226c883208761a958059cf078