### PR TITLE
Add email-based authentication and login UI

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+import string
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
+
+from .database import get_db
+from .models import SessionToken, User
+
+
+_PBKDF2_ITERATIONS = 120_000
+_TOKEN_TTL_HOURS = 24
+_AUTH_SCHEME = HTTPBearer(auto_error=False)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+def generate_password(length: int = 12) -> str:
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def hash_password(password: str) -> str:
+    salt_bytes = secrets.token_bytes(16)
+    derived = hashlib.pbkdf2_hmac(
+        "sha256", password.encode("utf-8"), salt_bytes, _PBKDF2_ITERATIONS
+    )
+    return f"{salt_bytes.hex()}${derived.hex()}"
+
+
+def verify_password(password: str, encoded: str) -> bool:
+    try:
+        salt_hex, digest_hex = encoded.split("$", 1)
+    except ValueError:
+        return False
+
+    salt = bytes.fromhex(salt_hex)
+    derived = hashlib.pbkdf2_hmac(
+        "sha256", password.encode("utf-8"), salt, _PBKDF2_ITERATIONS
+    ).hex()
+    return hmac.compare_digest(derived, digest_hex)
+
+
+def create_session_token(db: Session, user: User) -> str:
+    token_value = secrets.token_urlsafe(32)
+    expires_at = _utcnow() + timedelta(hours=_TOKEN_TTL_HOURS)
+
+    token = SessionToken(token=token_value, user_id=user.id, expires_at=expires_at)
+    db.add(token)
+    return token_value
+
+
+def get_current_user(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_AUTH_SCHEME),
+    db: Session = Depends(get_db),
+) -> User:
+    if not credentials or not credentials.credentials:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication credentials were not provided.",
+        )
+
+    raw_token = credentials.credentials
+    token: SessionToken | None = db.get(SessionToken, raw_token)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired authentication token.",
+        )
+
+    if token.expires_at:
+        expires_at = token.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at < _utcnow():
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or expired authentication token.",
+            )
+
+    user = db.get(User, token.user_id)
+    if not user or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User is inactive or does not exist.",
+        )
+
+    return user
+
+
+__all__ = [
+    "create_session_token",
+    "generate_password",
+    "get_current_user",
+    "hash_password",
+    "normalize_email",
+    "verify_password",
+]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from .routers import (
     activity,
     analytics,
     analysis,
+    auth,
     cards,
     comments,
     error_categories,
@@ -38,6 +39,7 @@ app.add_middleware(
 
 app.include_router(analysis.router)
 app.include_router(analytics.router)
+app.include_router(auth.router)
 app.include_router(cards.router)
 app.include_router(labels.router)
 app.include_router(statuses.router)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..auth import (
+    create_session_token,
+    generate_password,
+    get_current_user,
+    hash_password,
+    normalize_email,
+    verify_password,
+)
+from ..database import get_db
+from ..services.email import send_password_email
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post(
+    "/register",
+    response_model=schemas.MessageResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def register(
+    payload: schemas.RegistrationRequest,
+    db: Session = Depends(get_db),
+) -> schemas.MessageResponse:
+    email = normalize_email(payload.email)
+    existing = db.query(models.User).filter(models.User.email == email).first()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User with this email already exists.",
+        )
+
+    password = generate_password()
+    user = models.User(email=email, password_hash=hash_password(password))
+    db.add(user)
+    db.commit()
+    send_password_email(email=payload.email, password=password, reason="register")
+    return schemas.MessageResponse(message="初期パスワードをメールで送信しました。")
+
+
+@router.post("/login", response_model=schemas.TokenResponse)
+def login(
+    payload: schemas.AuthCredentials,
+    db: Session = Depends(get_db),
+) -> schemas.TokenResponse:
+    email = normalize_email(payload.email)
+    user = db.query(models.User).filter(models.User.email == email).first()
+    if not user or not verify_password(payload.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password.",
+        )
+
+    db.query(models.SessionToken).filter(models.SessionToken.user_id == user.id).delete()
+    token_value = create_session_token(db, user)
+    db.commit()
+    return schemas.TokenResponse(access_token=token_value, user=user)
+
+
+@router.post(
+    "/password-reset",
+    response_model=schemas.MessageResponse,
+    status_code=status.HTTP_200_OK,
+)
+def reset_password(
+    payload: schemas.PasswordResetRequest,
+    db: Session = Depends(get_db),
+) -> schemas.MessageResponse:
+    email = normalize_email(payload.email)
+    user = db.query(models.User).filter(models.User.email == email).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found.",
+        )
+
+    new_password = generate_password()
+    user.password_hash = hash_password(new_password)
+    db.query(models.SessionToken).filter(models.SessionToken.user_id == user.id).delete()
+    db.add(user)
+    db.commit()
+    send_password_email(email=payload.email, password=new_password, reason="reset")
+    return schemas.MessageResponse(message="初期パスワードをメールで送信しました。")
+
+
+@router.get("/me", response_model=schemas.UserRead)
+def read_current_user(
+    current_user: models.User = Depends(get_current_user),
+) -> models.User:
+    return current_user

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, root_validator
+from pydantic import BaseModel, EmailStr, Field, root_validator
 
 
 # Shared schema components
@@ -12,6 +12,39 @@ class ChecklistItem(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     label: str
     done: bool = False
+
+
+class UserRead(BaseModel):
+    id: str
+    email: EmailStr
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class AuthCredentials(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class RegistrationRequest(BaseModel):
+    email: EmailStr
+
+
+class PasswordResetRequest(BaseModel):
+    email: EmailStr
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: Literal["bearer"] = "bearer"
+    user: UserRead
+
+
+class MessageResponse(BaseModel):
+    message: str
 
 
 class LabelBase(BaseModel):
@@ -182,6 +215,7 @@ class CardUpdate(BaseModel):
 
 class CardRead(CardBase):
     id: str
+    owner_id: str
     created_at: datetime
     updated_at: datetime
     labels: List[LabelRead] = Field(default_factory=list)
@@ -189,6 +223,7 @@ class CardRead(CardBase):
     status: Optional[StatusRead] = None
     error_category: Optional[ErrorCategoryRead] = None
     initiative: Optional["ImprovementInitiativeRead"] = None
+    owner: Optional[UserRead] = None
 
     class Config:
         orm_mode = True

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class PasswordEmail:
+    to: str
+    subject: str
+    body: str
+    password: str
+    reason: str
+    created_at: datetime
+
+
+EMAIL_OUTBOX: List[PasswordEmail] = []
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def send_password_email(*, email: str, password: str, reason: str) -> None:
+    """Record a password delivery event.
+
+    In a production environment this would enqueue an email. For the
+    reference implementation we capture the intent in an in-memory outbox so
+    tests can assert on the generated password.
+    """
+
+    subject = "Todo Generator パスワード通知"
+    if reason == "reset":
+        subject = "Todo Generator パスワード再発行"
+
+    body = (
+        "Todo Generator へのアクセスに使用する初期パスワードを発行しました。\n"
+        "セキュリティのため、ログイン後は必ずパスワードの更新を行ってください。\n\n"
+        f"一時パスワード: {password}\n"
+    )
+
+    EMAIL_OUTBOX.append(
+        PasswordEmail(
+            to=email,
+            subject=subject,
+            body=body,
+            password=password,
+            reason=reason,
+            created_at=_utcnow(),
+        )
+    )
+    logger.info("Queued %s password email for %s", reason, email)
+
+
+def clear_outbox() -> None:
+    EMAIL_OUTBOX.clear()
+
+
+__all__ = ["EMAIL_OUTBOX", "PasswordEmail", "clear_outbox", "send_password_email"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.110.0
 uvicorn[standard]==0.27.1
 SQLAlchemy==2.0.43
 pydantic==1.10.17
+email-validator==2.1.1
 alembic==1.12.1
 python-multipart==0.0.9
 pytest==7.4.4

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,6 +13,7 @@ if str(BACKEND_DIR) not in sys.path:
 
 from app.database import Base, get_db
 from app.main import app
+from app.services.email import clear_outbox
 
 SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
 engine = create_engine(
@@ -41,3 +42,10 @@ def client() -> Generator[TestClient, None, None]:
         yield test_client
 
     Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def reset_email_outbox() -> Generator[None, None, None]:
+    clear_outbox()
+    yield
+    clear_outbox()

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,9 +1,10 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, withComponentInputBinding, withInMemoryScrolling } from '@angular/router';
-import { provideHttpClient, withFetch } from '@angular/common/http';
+import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 
 import { appRoutes } from './app.routes';
+import { authInterceptor } from '@core/auth/auth.interceptor';
 
 /**
  * Configures the providers required to bootstrap the Angular 20 application.
@@ -17,6 +18,6 @@ export const appConfig: ApplicationConfig = {
       withInMemoryScrolling({ scrollPositionRestoration: 'enabled' }),
     ),
     provideAnimations(),
-    provideHttpClient(withFetch()),
+    provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
   ],
 };

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,1 +1,1 @@
-<app-shell />
+<router-outlet />

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,32 +1,50 @@
 import { Routes } from '@angular/router';
 
+import { authChildGuard, authGuard } from '@core/auth/auth.guard';
+
 /**
  * Centralized route definitions. Each route lazy loads its standalone feature page.
  */
 export const appRoutes: Routes = [
   {
+    path: 'login',
+    loadComponent: () => import('@features/auth/login/page').then((mod) => mod.LoginPage),
+  },
+  {
     path: '',
-    pathMatch: 'full',
-    redirectTo: 'board',
-  },
-  {
-    path: 'board',
-    loadComponent: () => import('@features/board/page').then((mod) => mod.BoardPage),
-  },
-  {
-    path: 'input',
-    loadComponent: () => import('@features/analyze/page').then((mod) => mod.AnalyzePage),
-  },
-  {
-    path: 'analytics',
-    loadComponent: () => import('@features/analytics/page').then((mod) => mod.AnalyticsPage),
-  },
-  {
-    path: 'settings',
-    loadComponent: () => import('@features/settings/page').then((mod) => mod.SettingsPage),
+    loadComponent: () => import('@core/layout/shell/shell').then((mod) => mod.Shell),
+    canActivate: [authGuard],
+    canActivateChild: [authChildGuard],
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        redirectTo: 'board',
+      },
+      {
+        path: 'board',
+        loadComponent: () => import('@features/board/page').then((mod) => mod.BoardPage),
+      },
+      {
+        path: 'input',
+        loadComponent: () => import('@features/analyze/page').then((mod) => mod.AnalyzePage),
+      },
+      {
+        path: 'analytics',
+        loadComponent: () => import('@features/analytics/page').then((mod) => mod.AnalyticsPage),
+      },
+      {
+        path: 'settings',
+        loadComponent: () => import('@features/settings/page').then((mod) => mod.SettingsPage),
+      },
+      {
+        path: '**',
+        loadComponent: () => import('@shared/ui/not-found').then((mod) => mod.NotFoundPage),
+      },
+    ],
   },
   {
     path: '**',
-    loadComponent: () => import('@shared/ui/not-found').then((mod) => mod.NotFoundPage),
+    redirectTo: 'login',
   },
 ];

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
-import { Shell } from '@core/layout/shell/shell';
+import { RouterOutlet } from '@angular/router';
 
 /**
  * Root component wrapping the workspace shell.
@@ -8,7 +8,7 @@ import { Shell } from '@core/layout/shell/shell';
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [Shell],
+  imports: [RouterOutlet],
   templateUrl: './app.html',
   styleUrl: './app.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/core/api/api.config.ts
+++ b/frontend/src/app/core/api/api.config.ts
@@ -1,0 +1,10 @@
+export const API_BASE_URL = 'http://localhost:8000';
+
+export const buildApiUrl = (path: string): string => {
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path;
+  }
+
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return `${API_BASE_URL}${normalized}`;
+};

--- a/frontend/src/app/core/auth/auth.guard.ts
+++ b/frontend/src/app/core/auth/auth.guard.ts
@@ -1,0 +1,22 @@
+import { inject } from '@angular/core';
+import { CanActivateChildFn, CanActivateFn, Router, UrlTree } from '@angular/router';
+
+import { AuthService } from './auth.service';
+
+
+const resolveAuthState = async (): Promise<boolean | UrlTree> => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  await auth.ensureInitialized();
+
+  if (auth.isAuthenticated()) {
+    return true;
+  }
+
+  return router.parseUrl('/login');
+};
+
+export const authGuard: CanActivateFn = () => resolveAuthState();
+
+export const authChildGuard: CanActivateChildFn = () => resolveAuthState();

--- a/frontend/src/app/core/auth/auth.interceptor.ts
+++ b/frontend/src/app/core/auth/auth.interceptor.ts
@@ -1,0 +1,22 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+
+import { API_BASE_URL } from '@core/api/api.config';
+
+import { AuthService } from './auth.service';
+
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const auth = inject(AuthService);
+  const token = auth.token();
+
+  if (!token || !req.url.startsWith(API_BASE_URL)) {
+    return next(req);
+  }
+
+  const authorizedRequest = req.clone({
+    setHeaders: { Authorization: `Bearer ${token}` },
+  });
+
+  return next(authorizedRequest);
+};

--- a/frontend/src/app/core/auth/auth.service.ts
+++ b/frontend/src/app/core/auth/auth.service.ts
@@ -1,0 +1,172 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+import { buildApiUrl } from '@core/api/api.config';
+import { AuthenticatedUser, MessageResponse, TokenResponse } from '@core/models';
+
+
+const STORAGE_KEY = 'todo-generator/auth-token';
+
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly http = inject(HttpClient);
+
+  private readonly userStore = signal<AuthenticatedUser | null>(null);
+  private readonly tokenStore = signal<string | null>(null);
+  private readonly errorStore = signal<string | null>(null);
+  private readonly pendingStore = signal(false);
+  private readonly initializedStore = signal(false);
+  private readonly storage = this.resolveStorage();
+  private readonly bootstrap: Promise<void>;
+
+  public constructor() {
+    this.bootstrap = this.restoreSession();
+  }
+
+  public readonly user = computed(() => this.userStore());
+  public readonly token = computed(() => this.tokenStore());
+  public readonly error = computed(() => this.errorStore());
+  public readonly pending = computed(() => this.pendingStore());
+  public readonly isAuthenticated = computed(() => this.userStore() !== null);
+  public readonly initialized = computed(() => this.initializedStore());
+
+  public async ensureInitialized(): Promise<void> {
+    await this.bootstrap;
+  }
+
+  public clearError(): void {
+    this.errorStore.set(null);
+  }
+
+  public logout(): void {
+    this.clearSession();
+    this.errorStore.set(null);
+  }
+
+  public async login(email: string, password: string): Promise<boolean> {
+    this.pendingStore.set(true);
+    this.errorStore.set(null);
+
+    try {
+      const response = await firstValueFrom(
+        this.http.post<TokenResponse>(buildApiUrl('/auth/login'), {
+          email,
+          password,
+        }),
+      );
+      this.setSession(response.access_token, response.user);
+      return true;
+    } catch (error) {
+      this.errorStore.set(this.extractErrorMessage(error));
+      return false;
+    } finally {
+      this.pendingStore.set(false);
+    }
+  }
+
+  public async requestRegistration(email: string): Promise<string | null> {
+    this.pendingStore.set(true);
+    this.errorStore.set(null);
+
+    try {
+      const response = await firstValueFrom(
+        this.http.post<MessageResponse>(buildApiUrl('/auth/register'), { email }),
+      );
+      return response.message;
+    } catch (error) {
+      this.errorStore.set(this.extractErrorMessage(error));
+      return null;
+    } finally {
+      this.pendingStore.set(false);
+    }
+  }
+
+  public async requestPasswordReset(email: string): Promise<string | null> {
+    this.pendingStore.set(true);
+    this.errorStore.set(null);
+
+    try {
+      const response = await firstValueFrom(
+        this.http.post<MessageResponse>(buildApiUrl('/auth/password-reset'), { email }),
+      );
+      return response.message;
+    } catch (error) {
+      this.errorStore.set(this.extractErrorMessage(error));
+      return null;
+    } finally {
+      this.pendingStore.set(false);
+    }
+  }
+
+  private async restoreSession(): Promise<void> {
+    const storedToken = this.storage?.getItem(STORAGE_KEY);
+    if (!storedToken) {
+      this.initializedStore.set(true);
+      return;
+    }
+
+    this.tokenStore.set(storedToken);
+    try {
+      const user = await firstValueFrom(
+        this.http.get<AuthenticatedUser>(buildApiUrl('/auth/me')),
+      );
+      this.userStore.set(user);
+    } catch {
+      this.clearSession();
+    } finally {
+      this.initializedStore.set(true);
+    }
+  }
+
+  private resolveStorage(): Storage | null {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    try {
+      return window.localStorage;
+    } catch {
+      return null;
+    }
+  }
+
+  private setSession(token: string, user: AuthenticatedUser): void {
+    this.tokenStore.set(token);
+    this.userStore.set(user);
+    this.persistToken(token);
+  }
+
+  private clearSession(): void {
+    this.tokenStore.set(null);
+    this.userStore.set(null);
+    this.persistToken(null);
+  }
+
+  private persistToken(token: string | null): void {
+    if (!this.storage) {
+      return;
+    }
+
+    if (token) {
+      this.storage.setItem(STORAGE_KEY, token);
+    } else {
+      this.storage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  private extractErrorMessage(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      if (typeof error.error === 'string' && error.error.trim().length > 0) {
+        return error.error;
+      }
+
+      if (error.error && typeof error.error.detail === 'string') {
+        return error.error.detail;
+      }
+    }
+
+    return '予期しないエラーが発生しました。もう一度お試しください。';
+  }
+}

--- a/frontend/src/app/core/layout/shell/shell.html
+++ b/frontend/src/app/core/layout/shell/shell.html
@@ -10,18 +10,34 @@
           <h1 class="text-2xl font-semibold">ワークスペース</h1>
         </div>
       </div>
-      <nav class="flex flex-wrap items-center gap-2 text-sm">
-        @for (link of links; track link.path) {
-          <a
-            [routerLink]="link.path"
-            routerLinkActive="surface-primary-muted text-accent-strong"
-            [routerLinkActiveOptions]="{ exact: true }"
-            class="focus-ring surface-pill px-4 py-2 text-sm font-medium text-slate-600 hover:text-accent-strong dark:text-slate-300"
-          >
-            {{ link.label }}
-          </a>
-        }
-      </nav>
+      <div class="flex flex-col items-start gap-3 text-sm sm:flex-row sm:items-center sm:gap-4">
+        <nav class="flex flex-wrap items-center gap-2 text-sm">
+          @for (link of links; track link.path) {
+            <a
+              [routerLink]="link.path"
+              routerLinkActive="surface-primary-muted text-accent-strong"
+              [routerLinkActiveOptions]="{ exact: true }"
+              class="focus-ring surface-pill px-4 py-2 text-sm font-medium text-slate-600 hover:text-accent-strong dark:text-slate-300"
+            >
+              {{ link.label }}
+            </a>
+          }
+        </nav>
+        <div class="flex items-center gap-3 text-xs sm:text-sm">
+          @if (user(); as currentUser) {
+            <span class="rounded-full bg-surface px-3 py-1 font-medium text-slate-500 dark:text-slate-300">
+              {{ currentUser.email }}
+            </span>
+            <button
+              type="button"
+              (click)="logout()"
+              class="focus-ring surface-pill px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:text-accent-strong dark:text-slate-300"
+            >
+              ログアウト
+            </button>
+          }
+        </div>
+      </div>
     </div>
   </header>
 

--- a/frontend/src/app/core/layout/shell/shell.ts
+++ b/frontend/src/app/core/layout/shell/shell.ts
@@ -1,5 +1,7 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+
+import { AuthService } from '@core/auth/auth.service';
 
 /**
  * Workspace shell providing navigation and global context for all feature pages.
@@ -13,6 +15,9 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Shell {
+  private readonly auth = inject(AuthService);
+  private readonly router = inject(Router);
+
   public readonly links = [
     { path: '/board', label: 'ボード' },
     { path: '/input', label: 'インプット解析' },
@@ -21,4 +26,10 @@ export class Shell {
   ] as const;
 
   public readonly year = new Date().getFullYear();
+  public readonly user = this.auth.user;
+
+  public readonly logout = (): void => {
+    this.auth.logout();
+    void this.router.navigateByUrl('/login');
+  };
 }

--- a/frontend/src/app/core/models/auth.ts
+++ b/frontend/src/app/core/models/auth.ts
@@ -1,0 +1,16 @@
+export interface AuthenticatedUser {
+  readonly id: string;
+  readonly email: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+}
+
+export interface TokenResponse {
+  readonly access_token: string;
+  readonly token_type: 'bearer';
+  readonly user: AuthenticatedUser;
+}
+
+export interface MessageResponse {
+  readonly message: string;
+}

--- a/frontend/src/app/core/models/index.ts
+++ b/frontend/src/app/core/models/index.ts
@@ -1,4 +1,5 @@
 export * from './analysis';
+export * from './auth';
 export * from './board';
 export * from './card';
 export * from './continuous-improvement';

--- a/frontend/src/app/features/auth/login/page.html
+++ b/frontend/src/app/features/auth/login/page.html
@@ -1,0 +1,106 @@
+<div class="auth-wrapper">
+  <div class="auth-container">
+    <div class="grid gap-10 lg:grid-cols-[2fr,1fr]">
+      <section class="surface-panel login-panel px-8 py-10">
+        <h2 class="text-2xl font-semibold text-slate-800 dark:text-slate-100">ワークスペースにサインイン</h2>
+        <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          Todo Generator のカード管理ボードへアクセスするには、登録済みのメールアドレスとパスワードを入力してください。
+        </p>
+
+        @if (loginNotice(); as notice) {
+          <div class="alert notice">
+            {{ notice }}
+          </div>
+        }
+
+        @if (error(); as errorMessage) {
+          <div class="alert error">
+            {{ errorMessage }}
+          </div>
+        }
+
+        <form class="mt-6 flex flex-col gap-5" (submit)="onLoginSubmit($event)">
+          <label class="block text-sm font-medium text-slate-600 dark:text-slate-300">
+            メールアドレス
+            <input
+              type="email"
+              autocomplete="email"
+              [value]="loginForm.controls.email.value()"
+              (input)="onLoginEmailInput($event)"
+              class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-800 shadow-sm transition focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+              placeholder="you@example.com"
+            />
+          </label>
+
+          <label class="block text-sm font-medium text-slate-600 dark:text-slate-300">
+            パスワード
+            <input
+              type="password"
+              autocomplete="current-password"
+              [value]="loginForm.controls.password.value()"
+              (input)="onLoginPasswordInput($event)"
+              class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-800 shadow-sm transition focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+              placeholder="パスワード"
+            />
+          </label>
+
+          <button
+            type="submit"
+            class="focus-ring mt-2 inline-flex items-center justify-center rounded-xl bg-accent px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-accent/30 transition hover:bg-accent-strong disabled:cursor-not-allowed disabled:bg-slate-400"
+            [disabled]="pending()"
+          >
+            サインイン
+          </button>
+        </form>
+
+        <p class="mt-6 text-xs text-slate-400 dark:text-slate-500">
+          セキュリティのため、初期パスワードでログイン後は設定ページからパスワードを変更してください。
+        </p>
+      </section>
+
+      <section class="surface-panel request-panel px-8 py-8">
+        <h3 class="text-lg font-semibold text-slate-800 dark:text-slate-100">初期パスワードを取得</h3>
+        <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          新規登録またはパスワード再発行では、入力いただいたメールアドレス宛に初期パスワードを送信します。
+        </p>
+
+        @if (infoMessage(); as info) {
+          <div class="alert success">
+            {{ info }}
+          </div>
+        }
+
+        <label class="mt-6 block text-sm font-medium text-slate-600 dark:text-slate-300">
+          メールアドレス
+          <input
+            type="email"
+            autocomplete="email"
+            [value]="requestForm.controls.email.value()"
+            (input)="onRequestEmailInput($event)"
+            class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-800 shadow-sm transition focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+            placeholder="you@example.com"
+          />
+        </label>
+
+        <div class="mt-5 flex flex-col gap-3">
+          <button
+            type="button"
+            class="focus-ring inline-flex items-center justify-center rounded-xl border border-accent px-4 py-2 text-sm font-semibold text-accent transition hover:border-accent-strong hover:text-accent-strong disabled:cursor-not-allowed disabled:border-slate-400 disabled:text-slate-400"
+            [disabled]="pending()"
+            (click)="onRequestRegistration()"
+          >
+            新規登録メールを送信
+          </button>
+          <button
+            type="button"
+            class="focus-ring inline-flex items-center justify-center rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-800 disabled:cursor-not-allowed disabled:border-slate-400 disabled:text-slate-400 dark:border-slate-600 dark:text-slate-200 dark:hover:text-slate-100"
+            [disabled]="pending()"
+            (click)="onRequestPasswordReset()"
+          >
+            パスワード再発行メールを送信
+          </button>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/auth/login/page.scss
+++ b/frontend/src/app/features/auth/login/page.scss
@@ -1,0 +1,70 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(192, 38, 211, 0.12), transparent 55%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.04), rgba(15, 23, 42, 0));
+}
+
+.auth-wrapper {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 1.5rem;
+}
+
+.auth-container {
+  width: 100%;
+  max-width: 1080px;
+}
+
+.alert {
+  margin-top: 1.5rem;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.alert.notice {
+  background: rgba(59, 130, 246, 0.12);
+  color: rgb(37, 99, 235);
+}
+
+.alert.error {
+  background: rgba(248, 113, 113, 0.15);
+  color: rgb(185, 28, 28);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.alert.success {
+  background: rgba(34, 197, 94, 0.12);
+  color: rgb(22, 101, 52);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+@media (prefers-color-scheme: dark) {
+  :host {
+    background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 55%),
+      radial-gradient(circle at bottom right, rgba(147, 51, 234, 0.18), transparent 55%),
+      linear-gradient(180deg, rgba(15, 23, 42, 0.4), rgba(15, 23, 42, 0.1));
+  }
+
+  .alert.notice {
+    background: rgba(59, 130, 246, 0.2);
+    color: rgba(191, 219, 254, 0.95);
+  }
+
+  .alert.error {
+    background: rgba(248, 113, 113, 0.18);
+    color: rgba(254, 226, 226, 0.92);
+    border-color: rgba(248, 113, 113, 0.35);
+  }
+
+  .alert.success {
+    background: rgba(34, 197, 94, 0.2);
+    color: rgba(187, 247, 208, 0.95);
+    border-color: rgba(34, 197, 94, 0.35);
+  }
+}

--- a/frontend/src/app/features/auth/login/page.ts
+++ b/frontend/src/app/features/auth/login/page.ts
@@ -1,0 +1,118 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+
+import { AuthService } from '@core/auth/auth.service';
+import { createSignalForm } from '@lib/forms/signal-forms';
+
+
+@Component({
+  selector: 'app-login-page',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './page.html',
+  styleUrl: './page.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LoginPage {
+  private readonly auth = inject(AuthService);
+  private readonly router = inject(Router);
+
+  public readonly loginForm = createSignalForm({ email: '', password: '' });
+  public readonly requestForm = createSignalForm({ email: '' });
+  public readonly infoMessage = signal<string | null>(null);
+  public readonly loginNotice = signal<string | null>(null);
+
+  public readonly pending = computed(() => this.auth.pending());
+  public readonly error = computed(() => this.auth.error());
+
+  public constructor() {
+    effect(() => {
+      if (!this.auth.initialized()) {
+        return;
+      }
+
+      if (this.auth.isAuthenticated()) {
+        void this.router.navigateByUrl('/board');
+      }
+    });
+
+    void this.auth.ensureInitialized();
+  }
+
+  public async onLoginSubmit(event: Event): Promise<void> {
+    event.preventDefault();
+    this.infoMessage.set(null);
+    this.loginNotice.set(null);
+
+    const credentials = this.loginForm.value();
+    const email = credentials.email.trim();
+    const password = credentials.password;
+
+    if (!email || !password) {
+      this.loginNotice.set('メールアドレスとパスワードを入力してください。');
+      return;
+    }
+
+    const success = await this.auth.login(email, password);
+    if (success) {
+      await this.router.navigateByUrl('/board');
+    }
+  }
+
+  public onLoginEmailInput(event: Event): void {
+    const value = (event.target as HTMLInputElement | null)?.value ?? '';
+    this.loginForm.controls.email.setValue(value);
+  }
+
+  public onLoginPasswordInput(event: Event): void {
+    const value = (event.target as HTMLInputElement | null)?.value ?? '';
+    this.loginForm.controls.password.setValue(value);
+  }
+
+  public async onRequestRegistration(): Promise<void> {
+    this.infoMessage.set(null);
+    this.loginNotice.set(null);
+
+    const email = this.requestForm.value().email.trim();
+    if (!email) {
+      this.infoMessage.set('メールアドレスを入力してください。');
+      return;
+    }
+
+    const message = await this.auth.requestRegistration(email);
+    if (message) {
+      this.infoMessage.set(message);
+      this.requestForm.reset({ email: '' });
+    }
+  }
+
+  public async onRequestPasswordReset(): Promise<void> {
+    this.infoMessage.set(null);
+    this.loginNotice.set(null);
+
+    const email = this.requestForm.value().email.trim();
+    if (!email) {
+      this.infoMessage.set('メールアドレスを入力してください。');
+      return;
+    }
+
+    const message = await this.auth.requestPasswordReset(email);
+    if (message) {
+      this.infoMessage.set(message);
+      this.requestForm.reset({ email: '' });
+    }
+  }
+
+  public onRequestEmailInput(event: Event): void {
+    const value = (event.target as HTMLInputElement | null)?.value ?? '';
+    this.requestForm.controls.email.setValue(value);
+  }
+}


### PR DESCRIPTION
## Summary
- add persistent users, session tokens, and password email stubs to the FastAPI backend
- secure card CRUD by associating each record with its owner and providing authentication endpoints
- introduce Angular login/registration UI with route guards, auth service, and logout-aware shell navigation

## Testing
- pytest backend/tests
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1cddb02b0832082024f4acb2be99b