### PR TITLE
Add competency evaluation admin console and quota management

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,10 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("OPENAI_API_KEY", "chatgpt_api_key"),
     )
+    secret_encryption_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("SECRET_ENCRYPTION_KEY", "secret_encryption_key"),
+    )
     allowed_origins: list[str] = Field(
         default_factory=lambda: ["http://localhost:4200"],
         validation_alias=AliasChoices("ALLOWED_ORIGINS", "allowed_origins"),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,11 +8,15 @@ from .database import Base, engine
 from .migrations import run_startup_migrations
 from .routers import (
     activity,
+    admin_settings,
+    admin_users,
     analysis,
     analytics,
     auth,
     cards,
     comments,
+    competencies,
+    competency_evaluations,
     error_categories,
     filters,
     initiatives,
@@ -49,6 +53,10 @@ app.include_router(statuses.router)
 app.include_router(preferences.router)
 app.include_router(comments.router)
 app.include_router(activity.router)
+app.include_router(admin_users.router)
+app.include_router(admin_settings.router)
+app.include_router(competencies.router)
+app.include_router(competency_evaluations.router)
 app.include_router(error_categories.router)
 app.include_router(filters.router)
 app.include_router(initiatives.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -70,6 +70,18 @@ class User(Base, TimestampMixin):
     saved_filters: Mapped[list["SavedFilter"]] = relationship(
         "SavedFilter", back_populates="owner", cascade="all, delete-orphan"
     )
+    api_credentials: Mapped[list["ApiCredential"]] = relationship(
+        "ApiCredential", back_populates="created_by_user", cascade="all, delete-orphan"
+    )
+    competency_evaluations: Mapped[list["CompetencyEvaluation"]] = relationship(
+        "CompetencyEvaluation", back_populates="user", cascade="all, delete-orphan"
+    )
+    daily_evaluation_quotas: Mapped[list["DailyEvaluationQuota"]] = relationship(
+        "DailyEvaluationQuota", back_populates="owner", cascade="all, delete-orphan"
+    )
+    quota_override: Mapped[Optional["UserQuotaOverride"]] = relationship(
+        "UserQuotaOverride", back_populates="user", cascade="all, delete-orphan", uselist=False
+    )
 
 
 class SessionToken(Base, TimestampMixin):
@@ -471,3 +483,187 @@ class SimilarityFeedback(Base, TimestampMixin):
     notes: Mapped[str | None] = mapped_column(Text)
 
     card: Mapped[Card] = relationship("Card")
+
+
+class Competency(Base, TimestampMixin):
+    __tablename__ = "competencies"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    level: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    rubric: Mapped[dict] = mapped_column(JSON, default=dict)
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    criteria: Mapped[list["CompetencyCriterion"]] = relationship(
+        "CompetencyCriterion",
+        back_populates="competency",
+        cascade="all, delete-orphan",
+        order_by="CompetencyCriterion.order_index",
+    )
+    evaluations: Mapped[list["CompetencyEvaluation"]] = relationship(
+        "CompetencyEvaluation", back_populates="competency", cascade="all, delete-orphan"
+    )
+    jobs: Mapped[list["CompetencyEvaluationJob"]] = relationship(
+        "CompetencyEvaluationJob", back_populates="competency", cascade="all, delete-orphan"
+    )
+
+
+class CompetencyCriterion(Base, TimestampMixin):
+    __tablename__ = "competency_criteria"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    competency_id: Mapped[str] = mapped_column(
+        String, ForeignKey("competencies.id", ondelete="CASCADE"), nullable=False
+    )
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    weight: Mapped[float | None] = mapped_column(Float)
+    intentionality_prompt: Mapped[str | None] = mapped_column(Text)
+    behavior_prompt: Mapped[str | None] = mapped_column(Text)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    order_index: Mapped[int] = mapped_column(Integer, default=0)
+
+    competency: Mapped[Competency] = relationship("Competency", back_populates="criteria")
+    evaluation_items: Mapped[list["CompetencyEvaluationItem"]] = relationship(
+        "CompetencyEvaluationItem", back_populates="criterion", cascade="all, delete-orphan"
+    )
+
+
+class CompetencyEvaluation(Base, TimestampMixin):
+    __tablename__ = "competency_evaluations"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    competency_id: Mapped[str] = mapped_column(
+        String, ForeignKey("competencies.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id: Mapped[str] = mapped_column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    period_start: Mapped[date] = mapped_column(Date, nullable=False)
+    period_end: Mapped[date] = mapped_column(Date, nullable=False)
+    scale: Mapped[int] = mapped_column(Integer, nullable=False)
+    score_value: Mapped[int] = mapped_column(Integer, nullable=False)
+    score_label: Mapped[str] = mapped_column(String, nullable=False)
+    rationale: Mapped[str | None] = mapped_column(Text)
+    attitude_actions: Mapped[list[str]] = mapped_column(JSON, default=list)
+    behavior_actions: Mapped[list[str]] = mapped_column(JSON, default=list)
+    ai_model: Mapped[str | None] = mapped_column(String)
+    triggered_by: Mapped[str] = mapped_column(String, default="manual")
+    job_id: Mapped[str | None] = mapped_column(
+        String, ForeignKey("competency_evaluation_jobs.id", ondelete="SET NULL"), nullable=True
+    )
+    context: Mapped[dict] = mapped_column(JSON, default=dict)
+
+    competency: Mapped[Competency] = relationship("Competency", back_populates="evaluations")
+    user: Mapped[User] = relationship("User", back_populates="competency_evaluations")
+    job: Mapped[Optional["CompetencyEvaluationJob"]] = relationship(
+        "CompetencyEvaluationJob", back_populates="evaluations"
+    )
+    items: Mapped[list["CompetencyEvaluationItem"]] = relationship(
+        "CompetencyEvaluationItem", back_populates="evaluation", cascade="all, delete-orphan"
+    )
+
+
+class CompetencyEvaluationItem(Base, TimestampMixin):
+    __tablename__ = "competency_evaluation_items"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    evaluation_id: Mapped[str] = mapped_column(
+        String, ForeignKey("competency_evaluations.id", ondelete="CASCADE"), nullable=False
+    )
+    criterion_id: Mapped[str | None] = mapped_column(
+        String, ForeignKey("competency_criteria.id", ondelete="SET NULL"), nullable=True
+    )
+    score_value: Mapped[int] = mapped_column(Integer, nullable=False)
+    score_label: Mapped[str] = mapped_column(String, nullable=False)
+    rationale: Mapped[str | None] = mapped_column(Text)
+    attitude_actions: Mapped[list[str]] = mapped_column(JSON, default=list)
+    behavior_actions: Mapped[list[str]] = mapped_column(JSON, default=list)
+
+    evaluation: Mapped[CompetencyEvaluation] = relationship("CompetencyEvaluation", back_populates="items")
+    criterion: Mapped[Optional[CompetencyCriterion]] = relationship(
+        "CompetencyCriterion", back_populates="evaluation_items"
+    )
+
+
+class CompetencyEvaluationJob(Base, TimestampMixin):
+    __tablename__ = "competency_evaluation_jobs"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    competency_id: Mapped[str | None] = mapped_column(
+        String, ForeignKey("competencies.id", ondelete="SET NULL"), nullable=True
+    )
+    user_id: Mapped[str | None] = mapped_column(String, ForeignKey("users.id", ondelete="SET NULL"))
+    status: Mapped[str] = mapped_column(String, default="pending")
+    scope: Mapped[str] = mapped_column(String, default="user")
+    target_period_start: Mapped[date | None] = mapped_column(Date)
+    target_period_end: Mapped[date | None] = mapped_column(Date)
+    triggered_by: Mapped[str] = mapped_column(String, default="manual")
+    triggered_by_id: Mapped[str | None] = mapped_column(String, ForeignKey("users.id", ondelete="SET NULL"))
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    error_message: Mapped[str | None] = mapped_column(Text)
+    summary_stats: Mapped[dict] = mapped_column(JSON, default=dict)
+
+    competency: Mapped[Optional[Competency]] = relationship("Competency", back_populates="jobs")
+    triggered_by_user: Mapped[Optional[User]] = relationship(
+        "User", foreign_keys=[triggered_by_id]
+    )
+    target_user: Mapped[Optional[User]] = relationship(
+        "User", foreign_keys=[user_id]
+    )
+    evaluations: Mapped[list[CompetencyEvaluation]] = relationship(
+        "CompetencyEvaluation", back_populates="job", cascade="all, delete-orphan"
+    )
+
+
+class DailyEvaluationQuota(Base):
+    __tablename__ = "daily_evaluation_quotas"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    owner_id: Mapped[str] = mapped_column(
+        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    quota_date: Mapped[date] = mapped_column(Date, nullable=False)
+    executed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    owner: Mapped[User] = relationship("User", back_populates="daily_evaluation_quotas")
+
+    __table_args__ = (
+        UniqueConstraint("owner_id", "quota_date", name="uq_daily_evaluation_quota_owner_date"),
+    )
+
+
+class QuotaDefaults(Base, TimestampMixin):
+    __tablename__ = "quota_defaults"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    card_daily_limit: Mapped[int] = mapped_column(Integer, nullable=False, default=25)
+    evaluation_daily_limit: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+
+
+class UserQuotaOverride(Base, TimestampMixin):
+    __tablename__ = "user_quota_overrides"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(
+        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, unique=True
+    )
+    card_daily_limit: Mapped[int | None] = mapped_column(Integer)
+    evaluation_daily_limit: Mapped[int | None] = mapped_column(Integer)
+    updated_by: Mapped[str | None] = mapped_column(String)
+
+    user: Mapped[User] = relationship("User", back_populates="quota_override")
+
+
+class ApiCredential(Base, TimestampMixin):
+    __tablename__ = "api_credentials"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    provider: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    encrypted_secret: Mapped[str] = mapped_column(Text, nullable=False)
+    secret_hint: Mapped[str | None] = mapped_column(String)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_by_id: Mapped[str | None] = mapped_column(String, ForeignKey("users.id", ondelete="SET NULL"))
+
+    created_by_user: Mapped[Optional[User]] = relationship("User", back_populates="api_credentials")

--- a/backend/app/routers/admin_settings.py
+++ b/backend/app/routers/admin_settings.py
@@ -1,0 +1,160 @@
+"""Administrative endpoints for configuration management."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..config import settings
+from ..database import get_db
+from ..utils.crypto import SecretCipher
+from ..utils.dependencies import require_admin
+from ..utils.quotas import (
+    get_quota_defaults,
+    get_user_quota,
+    set_quota_defaults,
+    upsert_user_quota,
+)
+
+router = APIRouter(prefix="/admin", tags=["admin", "settings"])
+
+
+def _cipher() -> SecretCipher:
+    key = settings.secret_encryption_key or settings.chatgpt_api_key or "todo-generator"
+    return SecretCipher(key)
+
+
+@router.get("/api-credentials/{provider}", response_model=schemas.ApiCredentialRead)
+def get_api_credential(
+    provider: str,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> models.ApiCredential:
+    credential = (
+        db.query(models.ApiCredential)
+        .filter(models.ApiCredential.provider == provider)
+        .first()
+    )
+    if not credential:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credential not found")
+    return credential
+
+
+@router.put("/api-credentials/{provider}", response_model=schemas.ApiCredentialRead)
+def upsert_api_credential(
+    provider: str,
+    payload: schemas.ApiCredentialUpdate,
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(require_admin),
+) -> models.ApiCredential:
+    credential = (
+        db.query(models.ApiCredential)
+        .filter(models.ApiCredential.provider == provider)
+        .first()
+    )
+
+    cipher = _cipher()
+    encrypted_secret = cipher.encrypt(payload.secret)
+    secret_hint = payload.secret[-4:] if payload.secret else None
+
+    if credential is None:
+        credential = models.ApiCredential(
+            provider=provider,
+            encrypted_secret=encrypted_secret,
+            secret_hint=secret_hint,
+            is_active=True if payload.is_active is None else payload.is_active,
+            created_by_user=admin_user,
+        )
+    else:
+        credential.encrypted_secret = encrypted_secret
+        credential.secret_hint = secret_hint
+        if payload.is_active is not None:
+            credential.is_active = payload.is_active
+        credential.created_by_user = credential.created_by_user or admin_user
+
+    db.add(credential)
+    db.commit()
+    db.refresh(credential)
+    return credential
+
+
+@router.delete("/api-credentials/{provider}", status_code=status.HTTP_204_NO_CONTENT)
+def deactivate_api_credential(
+    provider: str,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> Response:
+    credential = (
+        db.query(models.ApiCredential)
+        .filter(models.ApiCredential.provider == provider)
+        .first()
+    )
+    if not credential:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credential not found")
+
+    credential.is_active = False
+    db.add(credential)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/quotas/defaults", response_model=schemas.QuotaDefaultsRead)
+def get_defaults(
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> models.QuotaDefaults:
+    defaults = get_quota_defaults(db)
+    return defaults
+
+
+@router.put("/quotas/defaults", response_model=schemas.QuotaDefaultsRead)
+def update_defaults(
+    payload: schemas.QuotaDefaultsUpdate,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> models.QuotaDefaults:
+    defaults = set_quota_defaults(
+        db,
+        card_limit=payload.card_daily_limit,
+        evaluation_limit=payload.evaluation_daily_limit,
+    )
+    db.add(defaults)
+    db.commit()
+    db.refresh(defaults)
+    return defaults
+
+
+@router.get("/quotas/{user_id}", response_model=schemas.UserQuotaRead)
+def get_user_quota_override(
+    user_id: str,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> models.UserQuotaOverride:
+    override = get_user_quota(db, user_id)
+    if not override:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quota override not found")
+    return override
+
+
+@router.put("/quotas/{user_id}", response_model=schemas.UserQuotaRead)
+def update_user_quota_override(
+    user_id: str,
+    payload: schemas.UserQuotaUpdate,
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(require_admin),
+) -> models.UserQuotaOverride:
+    override = upsert_user_quota(
+        db,
+        user_id=user_id,
+        card_limit=payload.card_daily_limit,
+        evaluation_limit=payload.evaluation_daily_limit,
+        updated_by=admin_user.id,
+    )
+    db.add(override)
+    db.commit()
+    db.refresh(override)
+    return override
+
+
+__all__ = ["router"]

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -1,0 +1,103 @@
+"""Administrative endpoints for managing users."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..database import get_db
+from ..utils.dependencies import require_admin
+from ..utils.quotas import (
+    get_card_daily_limit,
+    get_evaluation_daily_limit,
+    get_user_quota,
+    upsert_user_quota,
+)
+
+router = APIRouter(prefix="/admin/users", tags=["admin", "users"])
+
+
+@router.get("", response_model=list[schemas.AdminUserRead])
+def list_users(
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> list[schemas.AdminUserRead]:
+    users = (
+        db.query(models.User)
+        .order_by(models.User.created_at.asc())
+        .all()
+    )
+
+    response: list[schemas.AdminUserRead] = []
+    for user in users:
+        response.append(
+            schemas.AdminUserRead(
+                id=user.id,
+                email=user.email,
+                is_admin=user.is_admin,
+                is_active=user.is_active,
+                card_daily_limit=get_card_daily_limit(db, user.id),
+                evaluation_daily_limit=get_evaluation_daily_limit(db, user.id),
+                created_at=user.created_at,
+                updated_at=user.updated_at,
+            )
+        )
+    return response
+
+
+@router.patch("/{user_id}", response_model=schemas.AdminUserRead)
+def update_user(
+    user_id: str,
+    payload: schemas.AdminUserUpdate,
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(require_admin),
+) -> schemas.AdminUserRead:
+    user = db.get(models.User, user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    data = payload.model_dump(exclude_unset=True)
+
+    if "is_admin" in data:
+        user.is_admin = bool(data["is_admin"])
+    if "is_active" in data:
+        user.is_active = bool(data["is_active"])
+
+    if "card_daily_limit" in data or "evaluation_daily_limit" in data:
+        override = get_user_quota(db, user.id)
+        card_limit = (
+            data.get("card_daily_limit")
+            if "card_daily_limit" in data
+            else (override.card_daily_limit if override else None)
+        )
+        evaluation_limit = (
+            data.get("evaluation_daily_limit")
+            if "evaluation_daily_limit" in data
+            else (override.evaluation_daily_limit if override else None)
+        )
+        upsert_user_quota(
+            db,
+            user_id=user.id,
+            card_limit=card_limit,
+            evaluation_limit=evaluation_limit,
+            updated_by=admin_user.id,
+        )
+
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    return schemas.AdminUserRead(
+        id=user.id,
+        email=user.email,
+        is_admin=user.is_admin,
+        is_active=user.is_active,
+        card_daily_limit=get_card_daily_limit(db, user.id),
+        evaluation_daily_limit=get_evaluation_daily_limit(db, user.id),
+        created_at=user.created_at,
+        updated_at=user.updated_at,
+    )
+
+
+__all__ = ["router"]

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -5,95 +5,34 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Iterable, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
-from sqlalchemy import func, insert, or_, select, update
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from .. import models, schemas
 from ..auth import get_current_user
 from ..database import get_db
 from ..utils.activity import record_activity
-
-DAILY_CARD_CREATION_LIMIT = 25
-_DAILY_CARD_LIMIT_MESSAGE = (
-    f"Daily card creation limit of {DAILY_CARD_CREATION_LIMIT} reached."
-)
+from ..utils.quotas import get_card_daily_limit, reserve_daily_quota
 
 
 def _reserve_daily_card_quota(db: Session, *, owner_id: str, quota_day: date) -> None:
-    quota_cls = models.DailyCardQuota
-
-    def _try_increment() -> bool:
-        result = db.execute(
-            update(quota_cls)
-            .where(
-                quota_cls.owner_id == owner_id,
-                quota_cls.quota_date == quota_day,
-                quota_cls.created_count < DAILY_CARD_CREATION_LIMIT,
-            )
-            .values(created_count=quota_cls.created_count + 1)
-        )
-        return bool(result.rowcount)
-
-    if _try_increment():
+    limit = get_card_daily_limit(db, owner_id)
+    if limit <= 0:
         return
 
-    dialect_name = db.bind.dialect.name if db.bind else ""
-    if dialect_name == "sqlite":
-        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-
-        insert_stmt = (
-            sqlite_insert(quota_cls)
-            .values(owner_id=owner_id, quota_date=quota_day, created_count=1)
-            .on_conflict_do_nothing(
-                index_elements=[quota_cls.owner_id, quota_cls.quota_date]
-            )
-        )
-    elif dialect_name == "postgresql":
-        from sqlalchemy.dialects.postgresql import insert as pg_insert
-
-        insert_stmt = (
-            pg_insert(quota_cls)
-            .values(owner_id=owner_id, quota_date=quota_day, created_count=1)
-            .on_conflict_do_nothing(
-                index_elements=[quota_cls.owner_id, quota_cls.quota_date]
-            )
-        )
-    else:
-        insert_stmt = insert(quota_cls).values(
-            owner_id=owner_id,
-            quota_date=quota_day,
-            created_count=1,
-        )
-
-    try:
-        insert_result = db.execute(insert_stmt)
-    except IntegrityError:
-        db.rollback()
-    else:
-        if insert_result.rowcount:
-            return
-
-    if _try_increment():
-        return
-
-    existing_count = db.execute(
-        select(quota_cls.created_count).where(
-            quota_cls.owner_id == owner_id,
-            quota_cls.quota_date == quota_day,
-        )
-    ).scalar_one_or_none()
-
-    if existing_count is None or existing_count < DAILY_CARD_CREATION_LIMIT:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Unable to reserve daily card quota.",
-        )
-
-    raise HTTPException(
-        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-        detail=_DAILY_CARD_LIMIT_MESSAGE,
+    reserved = reserve_daily_quota(
+        db,
+        owner_id=owner_id,
+        quota_day=quota_day,
+        limit=limit,
+        quota_model=models.DailyCardQuota,
+        counter_field="created_count",
     )
+    if not reserved:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Daily card creation limit of {limit} reached.",
+        )
 
 
 router = APIRouter(prefix="/cards", tags=["cards"])
@@ -327,11 +266,14 @@ def create_card(
         .scalar()
     ) or 0
 
-    if created_count >= DAILY_CARD_CREATION_LIMIT:
+    card_limit = get_card_daily_limit(db, current_user.id)
+    if card_limit > 0 and created_count >= card_limit:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail=_DAILY_CARD_LIMIT_MESSAGE,
+            detail=f"Daily card creation limit of {card_limit} reached.",
         )
+
+    _reserve_daily_card_quota(db, owner_id=current_user.id, quota_day=now.date())
 
     if payload.status_id:
         _ensure_owned_status(db, status_id=payload.status_id, owner_id=current_user.id)

--- a/backend/app/routers/competencies.py
+++ b/backend/app/routers/competencies.py
@@ -1,0 +1,213 @@
+"""Admin endpoints for competency management."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..database import get_db
+from ..services.competency_evaluator import CompetencyEvaluator
+from ..utils.dependencies import require_admin
+from ..utils.quotas import (
+    get_evaluation_daily_limit,
+    reserve_daily_quota,
+)
+
+router = APIRouter(prefix="/admin/competencies", tags=["admin", "competencies"])
+
+
+@router.get("", response_model=list[schemas.CompetencyRead])
+def list_competencies(
+    level: Optional[str] = Query(default=None),
+    is_active: Optional[bool] = Query(default=None),
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> list[models.Competency]:
+    query = db.query(models.Competency)
+    if level:
+        query = query.filter(models.Competency.level == level)
+    if is_active is not None:
+        query = query.filter(models.Competency.is_active == is_active)
+
+    competencies = (
+        query.order_by(models.Competency.sort_order.asc(), models.Competency.created_at.asc())
+        .all()
+    )
+    return competencies
+
+
+@router.get("/{competency_id}", response_model=schemas.CompetencyRead)
+def get_competency(
+    competency_id: str,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> models.Competency:
+    competency = db.get(models.Competency, competency_id)
+    if not competency:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Competency not found")
+    return competency
+
+
+@router.post("", response_model=schemas.CompetencyRead, status_code=status.HTTP_201_CREATED)
+def create_competency(
+    payload: schemas.CompetencyCreate,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> models.Competency:
+    competency = models.Competency(
+        name=payload.name,
+        level=payload.level,
+        description=payload.description,
+        rubric=payload.rubric,
+        sort_order=payload.sort_order,
+        is_active=payload.is_active,
+    )
+
+    for index, criterion in enumerate(payload.criteria):
+        competency.criteria.append(
+            models.CompetencyCriterion(
+                title=criterion.title,
+                description=criterion.description,
+                weight=criterion.weight,
+                intentionality_prompt=criterion.intentionality_prompt,
+                behavior_prompt=criterion.behavior_prompt,
+                is_active=criterion.is_active,
+                order_index=criterion.order_index if criterion.order_index is not None else index,
+            )
+        )
+
+    db.add(competency)
+    db.commit()
+    db.refresh(competency)
+    return competency
+
+
+@router.patch("/{competency_id}", response_model=schemas.CompetencyRead)
+def update_competency(
+    competency_id: str,
+    payload: schemas.CompetencyUpdate,
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> models.Competency:
+    competency = db.get(models.Competency, competency_id)
+    if not competency:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Competency not found")
+
+    if payload.name is not None:
+        competency.name = payload.name
+    if payload.level is not None:
+        competency.level = payload.level
+    if payload.description is not None:
+        competency.description = payload.description
+    if payload.rubric is not None:
+        competency.rubric = payload.rubric
+    if payload.sort_order is not None:
+        competency.sort_order = payload.sort_order
+    if payload.is_active is not None:
+        competency.is_active = payload.is_active
+
+    if payload.criteria is not None:
+        competency.criteria.clear()
+        for index, criterion in enumerate(payload.criteria):
+            competency.criteria.append(
+                models.CompetencyCriterion(
+                    title=criterion.title,
+                    description=criterion.description,
+                    weight=criterion.weight,
+                    intentionality_prompt=criterion.intentionality_prompt,
+                    behavior_prompt=criterion.behavior_prompt,
+                    is_active=criterion.is_active,
+                    order_index=criterion.order_index if criterion.order_index is not None else index,
+                )
+            )
+
+    db.add(competency)
+    db.commit()
+    db.refresh(competency)
+    return competency
+
+
+@router.post("/{competency_id}/evaluate", response_model=schemas.CompetencyEvaluationRead)
+def trigger_evaluation(
+    competency_id: str,
+    payload: schemas.EvaluationTriggerRequest,
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(require_admin),
+) -> models.CompetencyEvaluation:
+    competency = db.get(models.Competency, competency_id)
+    if not competency:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Competency not found")
+
+    user = db.get(models.User, payload.user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    today = date.today()
+    period_end = payload.period_end or today
+    period_start = payload.period_start or period_end.replace(day=1)
+
+    if period_start > period_end:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid period range")
+
+    limit = get_evaluation_daily_limit(db, user.id)
+    quota_reserved = reserve_daily_quota(
+        db,
+        owner_id=user.id,
+        quota_day=today,
+        limit=limit,
+        quota_model=models.DailyEvaluationQuota,
+        counter_field="executed_count",
+    )
+    if not quota_reserved:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Daily competency evaluation limit of {limit} reached.",
+        )
+
+    job = models.CompetencyEvaluationJob(
+        competency=competency,
+        user_id=user.id,
+        status="running",
+        scope="user",
+        target_period_start=period_start,
+        target_period_end=period_end,
+        triggered_by=payload.triggered_by,
+        triggered_by_user=admin_user,
+        started_at=datetime.now(timezone.utc),
+    )
+    db.add(job)
+    db.flush()
+
+    evaluator = CompetencyEvaluator(db)
+
+    try:
+        evaluation = evaluator.evaluate(
+            user=user,
+            competency=competency,
+            period_start=period_start,
+            period_end=period_end,
+            triggered_by=payload.triggered_by,
+            job=job,
+        )
+    except Exception as exc:  # pragma: no cover - defensive handling
+        job.status = "failed"
+        job.completed_at = datetime.now(timezone.utc)
+        job.error_message = str(exc)
+        db.add(job)
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))
+
+    job.status = "succeeded"
+    job.completed_at = datetime.now(timezone.utc)
+    job.summary_stats = {"evaluations": 1}
+    db.add(job)
+    db.commit()
+    db.refresh(evaluation)
+    return evaluation
+
+
+__all__ = ["router"]

--- a/backend/app/routers/competency_evaluations.py
+++ b/backend/app/routers/competency_evaluations.py
@@ -1,0 +1,65 @@
+"""Endpoints for retrieving competency evaluation history."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session, joinedload, selectinload
+
+from .. import models, schemas
+from ..auth import get_current_user
+from ..database import get_db
+from ..utils.dependencies import require_admin
+
+router = APIRouter(tags=["competencies"])
+
+
+def _evaluation_query(db: Session):
+    return (
+        db.query(models.CompetencyEvaluation)
+        .options(
+            joinedload(models.CompetencyEvaluation.competency),
+            selectinload(models.CompetencyEvaluation.items),
+        )
+        .order_by(models.CompetencyEvaluation.created_at.desc())
+    )
+
+
+@router.get("/admin/evaluations", response_model=list[schemas.CompetencyEvaluationRead])
+def admin_list_evaluations(
+    user_id: Optional[str] = Query(default=None),
+    competency_id: Optional[str] = Query(default=None),
+    period_start: Optional[date] = Query(default=None),
+    period_end: Optional[date] = Query(default=None),
+    db: Session = Depends(get_db),
+    _: models.User = Depends(require_admin),
+) -> list[models.CompetencyEvaluation]:
+    query = _evaluation_query(db)
+
+    if user_id:
+        query = query.filter(models.CompetencyEvaluation.user_id == user_id)
+    if competency_id:
+        query = query.filter(models.CompetencyEvaluation.competency_id == competency_id)
+    if period_start:
+        query = query.filter(models.CompetencyEvaluation.period_start >= period_start)
+    if period_end:
+        query = query.filter(models.CompetencyEvaluation.period_end <= period_end)
+
+    evaluations = query.all()
+    return evaluations
+
+
+@router.get("/users/me/evaluations", response_model=list[schemas.CompetencyEvaluationRead])
+def my_evaluations(
+    limit: int = Query(default=20, ge=1, le=50),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> list[models.CompetencyEvaluation]:
+    query = _evaluation_query(db).filter(models.CompetencyEvaluation.user_id == current_user.id)
+    evaluations = query.limit(limit).all()
+    return evaluations
+
+
+__all__ = ["router"]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Dict, List, Literal, Mapping, Optional
 from uuid import uuid4
 import unicodedata
@@ -626,6 +626,195 @@ class ReportGenerateRequest(BaseModel):
 
 class ReportGenerateResponse(GeneratedReportRead):
     pass
+
+
+# --- Competency management schemas ----------------------------------------------------------
+
+
+class CompetencyCriterionBase(BaseModel):
+    title: str
+    description: Optional[str] = None
+    weight: Optional[float] = None
+    intentionality_prompt: Optional[str] = None
+    behavior_prompt: Optional[str] = None
+    is_active: bool = True
+    order_index: Optional[int] = None
+
+
+class CompetencyCriterionCreate(CompetencyCriterionBase):
+    pass
+
+
+class CompetencyCriterionUpdate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    weight: Optional[float] = None
+    intentionality_prompt: Optional[str] = None
+    behavior_prompt: Optional[str] = None
+    is_active: Optional[bool] = None
+    order_index: Optional[int] = None
+
+
+class CompetencyCriterionRead(CompetencyCriterionBase):
+    id: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CompetencyBase(BaseModel):
+    name: str
+    level: Literal["junior", "intermediate"]
+    description: Optional[str] = None
+    rubric: Dict[str, Any] = Field(default_factory=dict)
+    sort_order: int = 0
+    is_active: bool = True
+
+
+class CompetencyCreate(CompetencyBase):
+    criteria: List[CompetencyCriterionCreate] = Field(default_factory=list)
+
+
+class CompetencyUpdate(BaseModel):
+    name: Optional[str] = None
+    level: Optional[Literal["junior", "intermediate"]] = None
+    description: Optional[str] = None
+    rubric: Optional[Dict[str, Any]] = None
+    sort_order: Optional[int] = None
+    is_active: Optional[bool] = None
+    criteria: Optional[List[CompetencyCriterionCreate]] = None
+
+
+class CompetencyRead(CompetencyBase):
+    id: str
+    created_at: datetime
+    updated_at: datetime
+    criteria: List[CompetencyCriterionRead] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CompetencySummary(BaseModel):
+    id: str
+    name: str
+    level: Literal["junior", "intermediate"]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CompetencyEvaluationItemRead(BaseModel):
+    id: str
+    criterion_id: Optional[str] = None
+    score_value: int
+    score_label: str
+    rationale: Optional[str] = None
+    attitude_actions: List[str] = Field(default_factory=list)
+    behavior_actions: List[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CompetencyEvaluationRead(BaseModel):
+    id: str
+    competency_id: str
+    user_id: str
+    period_start: date
+    period_end: date
+    scale: int
+    score_value: int
+    score_label: str
+    rationale: Optional[str] = None
+    attitude_actions: List[str] = Field(default_factory=list)
+    behavior_actions: List[str] = Field(default_factory=list)
+    ai_model: Optional[str] = None
+    triggered_by: str
+    created_at: datetime
+    updated_at: datetime
+    competency: Optional[CompetencySummary] = None
+    items: List[CompetencyEvaluationItemRead] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class EvaluationTriggerRequest(BaseModel):
+    user_id: str
+    period_start: Optional[date] = None
+    period_end: Optional[date] = None
+    triggered_by: Literal["manual", "auto"] = "manual"
+
+    @model_validator(mode="after")
+    def ensure_period(cls, values: "EvaluationTriggerRequest") -> "EvaluationTriggerRequest":
+        if values.period_start and values.period_end:
+            if values.period_start > values.period_end:
+                raise ValueError("period_start must be on or before period_end")
+        return values
+
+
+class AdminUserRead(BaseModel):
+    id: str
+    email: EmailStr
+    is_admin: bool
+    is_active: bool
+    card_daily_limit: Optional[int] = None
+    evaluation_daily_limit: Optional[int] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdminUserUpdate(BaseModel):
+    is_admin: Optional[bool] = None
+    is_active: Optional[bool] = None
+    card_daily_limit: Optional[int] = Field(default=None, ge=0)
+    evaluation_daily_limit: Optional[int] = Field(default=None, ge=0)
+
+
+class ApiCredentialRead(BaseModel):
+    provider: str
+    secret_hint: Optional[str] = None
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ApiCredentialUpdate(BaseModel):
+    secret: str
+    is_active: Optional[bool] = None
+
+
+class QuotaDefaultsRead(BaseModel):
+    card_daily_limit: int
+    evaluation_daily_limit: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class QuotaDefaultsUpdate(BaseModel):
+    card_daily_limit: int = Field(ge=0)
+    evaluation_daily_limit: int = Field(ge=0)
+
+
+class UserQuotaRead(BaseModel):
+    user_id: str
+    card_daily_limit: Optional[int] = None
+    evaluation_daily_limit: Optional[int] = None
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserQuotaUpdate(BaseModel):
+    card_daily_limit: Optional[int] = Field(default=None, ge=0)
+    evaluation_daily_limit: Optional[int] = Field(default=None, ge=0)
+
+
+# --------------------------------------------------------------------------------------------
 
 
 # Resolve forward references for nested models defined later in the module.

--- a/backend/app/services/competency_evaluator.py
+++ b/backend/app/services/competency_evaluator.py
@@ -1,0 +1,210 @@
+"""Service responsible for competency evaluations."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+from typing import Iterable
+
+from sqlalchemy.orm import Session
+
+from .. import models
+
+
+class CompetencyEvaluator:
+    """Encapsulates the competency evaluation workflow."""
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def evaluate(
+        self,
+        *,
+        user: models.User,
+        competency: models.Competency,
+        period_start: date,
+        period_end: date,
+        triggered_by: str,
+        job: models.CompetencyEvaluationJob | None = None,
+    ) -> models.CompetencyEvaluation:
+        start_dt, end_dt = self._to_datetime_range(period_start, period_end)
+        metrics = self._collect_metrics(user=user, start=start_dt, end=end_dt)
+        scale = 3 if competency.level.lower() == "junior" else 5
+        score_value, score_label = self._determine_score(scale=scale, metrics=metrics)
+
+        evaluation = models.CompetencyEvaluation(
+            competency=competency,
+            user=user,
+            period_start=period_start,
+            period_end=period_end,
+            scale=scale,
+            score_value=score_value,
+            score_label=score_label,
+            rationale=self._build_rationale(competency, metrics, score_label),
+            attitude_actions=self._build_actions(competency, metrics, focus="attitude"),
+            behavior_actions=self._build_actions(competency, metrics, focus="behavior"),
+            ai_model="rule-based",
+            triggered_by=triggered_by,
+            job=job,
+            context={"metrics": metrics},
+        )
+
+        self._db.add(evaluation)
+        self._db.flush()
+
+        criteria = list(competency.criteria)
+        if not criteria:
+            criteria = []
+
+        for criterion in criteria or [None]:
+            item = models.CompetencyEvaluationItem(
+                evaluation=evaluation,
+                criterion=criterion,
+                score_value=score_value,
+                score_label=score_label,
+                rationale=self._build_criterion_rationale(criterion, metrics, score_label),
+                attitude_actions=self._build_actions(competency, metrics, focus="attitude"),
+                behavior_actions=self._build_actions(competency, metrics, focus="behavior"),
+            )
+            self._db.add(item)
+
+        self._db.flush()
+        return evaluation
+
+    def _collect_metrics(
+        self,
+        *,
+        user: models.User,
+        start: datetime,
+        end: datetime,
+    ) -> dict[str, int]:
+        cards = (
+            self._db.query(models.Card)
+            .filter(
+                models.Card.owner_id == user.id,
+                models.Card.created_at >= start,
+                models.Card.created_at <= end,
+            )
+            .all()
+        )
+
+        subtasks = (
+            self._db.query(models.Subtask)
+            .join(models.Card, models.Subtask.card_id == models.Card.id)
+            .filter(
+                models.Card.owner_id == user.id,
+                models.Subtask.created_at >= start,
+                models.Subtask.created_at <= end,
+            )
+            .all()
+        )
+
+        completed_cards = sum(1 for card in cards if self._is_done(card.status_id, card.status))
+        completed_subtasks = sum(
+            1 for subtask in subtasks if self._is_status_done(subtask.status)
+        )
+
+        return {
+            "cards_created": len(cards),
+            "cards_completed": completed_cards,
+            "subtasks_created": len(subtasks),
+            "subtasks_completed": completed_subtasks,
+        }
+
+    def _determine_score(
+        self,
+        *,
+        scale: int,
+        metrics: dict[str, int],
+    ) -> tuple[int, str]:
+        completed = metrics.get("cards_completed", 0) + metrics.get("subtasks_completed", 0)
+
+        if scale == 3:
+            if completed >= 12:
+                return 3, "達成"
+            if completed >= 5:
+                return 2, "部分達成"
+            return 1, "未達"
+
+        # Five-point scale for intermediate level
+        if completed >= 20:
+            return 5, "卓越"
+        if completed >= 12:
+            return 4, "良好"
+        if completed >= 6:
+            return 3, "標準"
+        if completed >= 3:
+            return 2, "要改善"
+        return 1, "未達"
+
+    def _build_rationale(
+        self,
+        competency: models.Competency,
+        metrics: dict[str, int],
+        score_label: str,
+    ) -> str:
+        return (
+            f"{competency.name}に対する今月の評価は『{score_label}』です。"
+            f"カード完了数は{metrics.get('cards_completed', 0)}件、"
+            f"サブタスク完了数は{metrics.get('subtasks_completed', 0)}件でした。"
+        )
+
+    def _build_criterion_rationale(
+        self,
+        criterion: models.CompetencyCriterion | None,
+        metrics: dict[str, int],
+        score_label: str,
+    ) -> str:
+        if criterion is None:
+            return (
+                f"全体評価は『{score_label}』です。"
+                f"カード{metrics.get('cards_completed', 0)}件、"
+                f"サブタスク{metrics.get('subtasks_completed', 0)}件を完了しました。"
+            )
+
+        base = f"評価項目『{criterion.title}』では『{score_label}』と判定しました。"
+        return (
+            base
+            + f"対象期間中の成果はカード完了{metrics.get('cards_completed', 0)}件、"
+            f"サブタスク完了{metrics.get('subtasks_completed', 0)}件です。"
+        )
+
+    def _build_actions(
+        self,
+        competency: models.Competency,
+        metrics: dict[str, int],
+        *,
+        focus: str,
+    ) -> list[str]:
+        remaining = max(metrics.get("cards_created", 0) - metrics.get("cards_completed", 0), 0)
+        if focus == "attitude":
+            return [
+                f"{competency.name}に沿って完了までやり切る姿勢を維持しましょう。残タスクは{remaining}件です。",
+                "週次で成果を振り返り、改善ポイントを共有しましょう。",
+            ]
+
+        return [
+            "未完了タスクに着手する前に優先順位を再確認してください。",
+            "サブタスクを細分化し、1日単位で進捗を可視化しましょう。",
+        ]
+
+    def _is_done(self, status_id: str | None, status: models.Status | None) -> bool:
+        if status is None:
+            return False
+        if getattr(status, "category", "") == "done":
+            return True
+        name = (status.name or "").strip().lower()
+        return name in {"done", "completed", "完了"}
+
+    def _is_status_done(self, value: str | None) -> bool:
+        if not value:
+            return False
+        normalized = value.strip().lower()
+        return normalized in {"done", "completed", "完了"}
+
+    def _to_datetime_range(self, start: date, end: date) -> tuple[datetime, datetime]:
+        start_dt = datetime.combine(start, time.min).replace(tzinfo=timezone.utc)
+        end_dt = datetime.combine(end, time.max).replace(tzinfo=timezone.utc)
+        return start_dt, end_dt
+
+
+__all__: Iterable[str] = ["CompetencyEvaluator"]

--- a/backend/app/utils/crypto.py
+++ b/backend/app/utils/crypto.py
@@ -1,0 +1,46 @@
+"""Utility helpers for reversible secret handling."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Optional
+
+
+class SecretCipher:
+    """Simple XOR-based cipher for at-rest secret obfuscation."""
+
+    def __init__(self, key: str | None) -> None:
+        self._key_bytes: Optional[bytes]
+        if key:
+            digest = hashlib.sha256(key.encode("utf-8")).digest()
+            self._key_bytes = digest
+        else:
+            self._key_bytes = None
+
+    def encrypt(self, value: str) -> str:
+        if not value:
+            return ""
+
+        raw = value.encode("utf-8")
+        if not self._key_bytes:
+            return base64.urlsafe_b64encode(raw).decode("ascii")
+
+        key = self._key_bytes
+        transformed = bytes(byte ^ key[index % len(key)] for index, byte in enumerate(raw))
+        return base64.urlsafe_b64encode(transformed).decode("ascii")
+
+    def decrypt(self, payload: str) -> str:
+        if not payload:
+            return ""
+
+        decoded = base64.urlsafe_b64decode(payload.encode("ascii"))
+        if not self._key_bytes:
+            return decoded.decode("utf-8")
+
+        key = self._key_bytes
+        restored = bytes(byte ^ key[index % len(key)] for index, byte in enumerate(decoded))
+        return restored.decode("utf-8")
+
+
+__all__ = ["SecretCipher"]

--- a/backend/app/utils/dependencies.py
+++ b/backend/app/utils/dependencies.py
@@ -1,0 +1,20 @@
+"""Reusable FastAPI dependency utilities."""
+
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, status
+
+from ..auth import get_current_user
+from ..models import User
+
+
+def require_admin(current_user: User = Depends(get_current_user)) -> User:
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Administrator privileges are required.",
+        )
+    return current_user
+
+
+__all__ = ["require_admin"]

--- a/backend/app/utils/quotas.py
+++ b/backend/app/utils/quotas.py
@@ -1,0 +1,191 @@
+"""Helper utilities for daily quota management."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import insert, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from .. import models
+
+DEFAULT_CARD_DAILY_LIMIT = 25
+DEFAULT_EVALUATION_DAILY_LIMIT = 3
+
+
+def _ensure_defaults(db: Session) -> models.QuotaDefaults:
+    defaults = (
+        db.query(models.QuotaDefaults).order_by(models.QuotaDefaults.id.asc()).first()
+    )
+    if defaults:
+        return defaults
+
+    defaults = models.QuotaDefaults(
+        card_daily_limit=DEFAULT_CARD_DAILY_LIMIT,
+        evaluation_daily_limit=DEFAULT_EVALUATION_DAILY_LIMIT,
+    )
+    db.add(defaults)
+    db.flush()
+    return defaults
+
+
+def get_card_daily_limit(db: Session, user_id: str) -> int:
+    override = db.query(models.UserQuotaOverride).filter_by(user_id=user_id).one_or_none()
+    if override and override.card_daily_limit is not None:
+        return max(int(override.card_daily_limit), 0)
+
+    defaults = _ensure_defaults(db)
+    return max(int(defaults.card_daily_limit or DEFAULT_CARD_DAILY_LIMIT), 0)
+
+
+def get_evaluation_daily_limit(db: Session, user_id: str) -> int:
+    override = db.query(models.UserQuotaOverride).filter_by(user_id=user_id).one_or_none()
+    if override and override.evaluation_daily_limit is not None:
+        return max(int(override.evaluation_daily_limit), 0)
+
+    defaults = _ensure_defaults(db)
+    return max(int(defaults.evaluation_daily_limit or DEFAULT_EVALUATION_DAILY_LIMIT), 0)
+
+
+def reserve_daily_quota(
+    db: Session,
+    *,
+    owner_id: str,
+    quota_day: date,
+    limit: int,
+    quota_model: type[models.DailyCardQuota] | type[models.DailyEvaluationQuota],
+    counter_field: str,
+) -> bool:
+    """Attempt to reserve quota entry for the provided owner."""
+
+    if limit <= 0:
+        return True
+
+    counter_column = getattr(quota_model, counter_field)
+
+    def _attempt_increment() -> bool:
+        result = db.execute(
+            update(quota_model)
+            .where(
+                quota_model.owner_id == owner_id,
+                quota_model.quota_date == quota_day,
+                counter_column < limit,
+            )
+            .values({counter_field: counter_column + 1})
+        )
+        return bool(result.rowcount)
+
+    if _attempt_increment():
+        return True
+
+    insert_stmt = insert(quota_model).values(
+        owner_id=owner_id,
+        quota_date=quota_day,
+        **{counter_field: 1},
+    )
+
+    try:
+        insert_result = db.execute(insert_stmt)
+    except IntegrityError:
+        db.rollback()
+    else:
+        if insert_result.rowcount:
+            return True
+
+    return _attempt_increment()
+
+
+def reset_daily_quota(
+    db: Session,
+    *,
+    owner_id: str,
+    quota_day: date,
+    quota_model: type[models.DailyCardQuota] | type[models.DailyEvaluationQuota],
+    counter_field: str,
+) -> None:
+    db.execute(
+        update(quota_model)
+        .where(quota_model.owner_id == owner_id, quota_model.quota_date == quota_day)
+        .values({counter_field: 0})
+    )
+
+
+def get_quota_defaults(db: Session) -> models.QuotaDefaults:
+    return _ensure_defaults(db)
+
+
+def set_quota_defaults(db: Session, *, card_limit: int, evaluation_limit: int) -> models.QuotaDefaults:
+    defaults = _ensure_defaults(db)
+    defaults.card_daily_limit = max(int(card_limit), 0)
+    defaults.evaluation_daily_limit = max(int(evaluation_limit), 0)
+    db.add(defaults)
+    return defaults
+
+
+def upsert_user_quota(
+    db: Session,
+    *,
+    user_id: str,
+    card_limit: int | None,
+    evaluation_limit: int | None,
+    updated_by: str | None,
+) -> models.UserQuotaOverride:
+    override = db.query(models.UserQuotaOverride).filter_by(user_id=user_id).one_or_none()
+    if override is None:
+        override = models.UserQuotaOverride(
+            user_id=user_id,
+            card_daily_limit=card_limit if card_limit is None else max(int(card_limit), 0),
+            evaluation_daily_limit=
+                evaluation_limit if evaluation_limit is None else max(int(evaluation_limit), 0),
+            updated_by=updated_by,
+        )
+        db.add(override)
+        return override
+
+    override.card_daily_limit = (
+        None if card_limit is None else max(int(card_limit), 0)
+    )
+    override.evaluation_daily_limit = (
+        None if evaluation_limit is None else max(int(evaluation_limit), 0)
+    )
+    override.updated_by = updated_by
+    db.add(override)
+    return override
+
+
+def get_user_quota(db: Session, user_id: str) -> models.UserQuotaOverride | None:
+    return db.query(models.UserQuotaOverride).filter_by(user_id=user_id).one_or_none()
+
+
+def get_daily_usage(
+    db: Session,
+    *,
+    quota_model: type[models.DailyCardQuota] | type[models.DailyEvaluationQuota],
+    owner_id: str,
+    quota_day: date,
+) -> int:
+    result = db.execute(
+        select(getattr(quota_model, "created_count", getattr(quota_model, "executed_count", 0))).where(
+            quota_model.owner_id == owner_id,
+            quota_model.quota_date == quota_day,
+        )
+    ).scalar_one_or_none()
+    if result is None:
+        return 0
+    return int(result)
+
+
+__all__ = [
+    "DEFAULT_CARD_DAILY_LIMIT",
+    "DEFAULT_EVALUATION_DAILY_LIMIT",
+    "get_card_daily_limit",
+    "get_evaluation_daily_limit",
+    "get_quota_defaults",
+    "reserve_daily_quota",
+    "reset_daily_quota",
+    "set_quota_defaults",
+    "upsert_user_quota",
+    "get_user_quota",
+    "get_daily_usage",
+]

--- a/backend/tests/test_cards.py
+++ b/backend/tests/test_cards.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from app.config import settings
-from app.routers.cards import DAILY_CARD_CREATION_LIMIT
+from app.utils.quotas import DEFAULT_CARD_DAILY_LIMIT
 
 DEFAULT_PASSWORD = "Register123!"
 
@@ -160,7 +160,7 @@ def test_card_creation_daily_limit(client: TestClient) -> None:
     headers = register_and_login(client, email)
     status_id = create_status(client, headers)
 
-    for index in range(DAILY_CARD_CREATION_LIMIT):
+    for index in range(DEFAULT_CARD_DAILY_LIMIT):
         response = client.post(
             "/cards",
             json={"title": f"Card {index}", "status_id": status_id},
@@ -177,7 +177,7 @@ def test_card_creation_daily_limit(client: TestClient) -> None:
     assert extra_response.status_code == 429
     assert (
         extra_response.json()["detail"]
-        == f"Daily card creation limit of {DAILY_CARD_CREATION_LIMIT} reached."
+        == f"Daily card creation limit of {DEFAULT_CARD_DAILY_LIMIT} reached."
     )
 
 
@@ -212,7 +212,7 @@ def test_card_creation_daily_limit(client: TestClient) -> None:
     headers = register_and_login(client, email)
     status_id = create_status(client, headers)
 
-    for index in range(DAILY_CARD_CREATION_LIMIT):
+    for index in range(DEFAULT_CARD_DAILY_LIMIT):
         response = client.post(
             "/cards",
             json={"title": f"Task {index}", "status_id": status_id},
@@ -228,7 +228,7 @@ def test_card_creation_daily_limit(client: TestClient) -> None:
     assert limit_response.status_code == 429
     assert (
         limit_response.json()["detail"]
-        == f"Daily card creation limit of {DAILY_CARD_CREATION_LIMIT} reached."
+        == f"Daily card creation limit of {DEFAULT_CARD_DAILY_LIMIT} reached."
     )
 
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -36,8 +36,12 @@ export const appRoutes: Routes = [
       },
       {
         path: 'settings',
-        canActivate: [adminGuard],
         loadComponent: () => import('@features/settings/page').then((mod) => mod.SettingsPage),
+      },
+      {
+        path: 'admin',
+        canActivate: [adminGuard],
+        loadComponent: () => import('@features/admin/page').then((mod) => mod.AdminPage),
       },
       {
         path: '**',

--- a/frontend/src/app/core/api/admin-api.service.ts
+++ b/frontend/src/app/core/api/admin-api.service.ts
@@ -1,0 +1,78 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { buildApiUrl } from './api.config';
+import {
+  AdminUser,
+  AdminUserUpdate,
+  ApiCredential,
+  ApiCredentialUpdate,
+  Competency,
+  CompetencyEvaluation,
+  CompetencyInput,
+  EvaluationTriggerRequest,
+  QuotaDefaults,
+  QuotaDefaultsUpdate,
+} from '@core/models';
+
+@Injectable({ providedIn: 'root' })
+export class AdminApiService {
+  private readonly http = inject(HttpClient);
+
+  public listCompetencies(): Observable<Competency[]> {
+    return this.http.get<Competency[]>(buildApiUrl('/admin/competencies'));
+  }
+
+  public createCompetency(payload: CompetencyInput): Observable<Competency> {
+    return this.http.post<Competency>(buildApiUrl('/admin/competencies'), payload);
+  }
+
+  public updateCompetency(
+    id: string,
+    payload: Partial<CompetencyInput>,
+  ): Observable<Competency> {
+    return this.http.patch<Competency>(buildApiUrl(`/admin/competencies/${id}`), payload);
+  }
+
+  public triggerEvaluation(
+    competencyId: string,
+    payload: EvaluationTriggerRequest,
+  ): Observable<CompetencyEvaluation> {
+    return this.http.post<CompetencyEvaluation>(
+      buildApiUrl(`/admin/competencies/${competencyId}/evaluate`),
+      payload,
+    );
+  }
+
+  public listEvaluations(): Observable<CompetencyEvaluation[]> {
+    return this.http.get<CompetencyEvaluation[]>(buildApiUrl('/admin/evaluations'));
+  }
+
+  public listUsers(): Observable<AdminUser[]> {
+    return this.http.get<AdminUser[]>(buildApiUrl('/admin/users'));
+  }
+
+  public updateUser(id: string, payload: AdminUserUpdate): Observable<AdminUser> {
+    return this.http.patch<AdminUser>(buildApiUrl(`/admin/users/${id}`), payload);
+  }
+
+  public getApiCredential(provider: string): Observable<ApiCredential> {
+    return this.http.get<ApiCredential>(buildApiUrl(`/admin/api-credentials/${provider}`));
+  }
+
+  public upsertApiCredential(
+    provider: string,
+    payload: ApiCredentialUpdate,
+  ): Observable<ApiCredential> {
+    return this.http.put<ApiCredential>(buildApiUrl(`/admin/api-credentials/${provider}`), payload);
+  }
+
+  public getQuotaDefaults(): Observable<QuotaDefaults> {
+    return this.http.get<QuotaDefaults>(buildApiUrl('/admin/quotas/defaults'));
+  }
+
+  public updateQuotaDefaults(payload: QuotaDefaultsUpdate): Observable<QuotaDefaults> {
+    return this.http.put<QuotaDefaults>(buildApiUrl('/admin/quotas/defaults'), payload);
+  }
+}

--- a/frontend/src/app/core/layout/shell/shell.html
+++ b/frontend/src/app/core/layout/shell/shell.html
@@ -119,7 +119,7 @@
               type="button"
               class="shell-icon-action focus-ring"
               (click)="openSettings()"
-              aria-label="ワークスペース設定を開く"
+              aria-label="管理者設定を開く"
             >
               <span class="shell-icon-action__icon">
                 <svg

--- a/frontend/src/app/core/layout/shell/shell.ts
+++ b/frontend/src/app/core/layout/shell/shell.ts
@@ -89,10 +89,11 @@ export class Shell {
       { path: '/board', label: 'ボード' },
       { path: '/input', label: 'タスク起票' },
       { path: '/analytics', label: '分析' },
+      { path: '/settings', label: 'ワークスペース設定' },
     ];
 
     if (this.isAdmin()) {
-      links.push({ path: '/settings', label: 'ワークスペース設定' });
+      links.push({ path: '/admin', label: '管理コンソール' });
     }
 
     return links;
@@ -119,7 +120,7 @@ export class Shell {
   };
 
   public readonly openSettings = (): void => {
-    void this.router.navigateByUrl('/settings');
+    void this.router.navigateByUrl('/admin');
   };
 
   public constructor() {

--- a/frontend/src/app/core/models/admin.ts
+++ b/frontend/src/app/core/models/admin.ts
@@ -1,0 +1,136 @@
+export type IsoDateString = string;
+
+export type CompetencyLevel = 'junior' | 'intermediate';
+
+export interface CompetencyCriterion {
+  id: string;
+  title: string;
+  description?: string | null;
+  weight?: number | null;
+  intentionality_prompt?: string | null;
+  behavior_prompt?: string | null;
+  is_active: boolean;
+  order_index?: number | null;
+  created_at: IsoDateString;
+  updated_at: IsoDateString;
+}
+
+export interface CompetencyCriterionInput {
+  title: string;
+  description?: string | null;
+  weight?: number | null;
+  intentionality_prompt?: string | null;
+  behavior_prompt?: string | null;
+  is_active?: boolean;
+  order_index?: number | null;
+}
+
+export interface Competency {
+  id: string;
+  name: string;
+  level: CompetencyLevel;
+  description?: string | null;
+  rubric: Record<string, unknown>;
+  sort_order: number;
+  is_active: boolean;
+  criteria: CompetencyCriterion[];
+  created_at: IsoDateString;
+  updated_at: IsoDateString;
+}
+
+export interface CompetencyInput {
+  name: string;
+  level: CompetencyLevel;
+  description?: string | null;
+  rubric?: Record<string, unknown>;
+  sort_order?: number;
+  is_active?: boolean;
+  criteria: CompetencyCriterionInput[];
+}
+
+export interface CompetencySummary {
+  id: string;
+  name: string;
+  level: CompetencyLevel;
+}
+
+export interface CompetencyEvaluationItem {
+  id: string;
+  criterion_id?: string | null;
+  score_value: number;
+  score_label: string;
+  rationale?: string | null;
+  attitude_actions: string[];
+  behavior_actions: string[];
+  created_at: IsoDateString;
+  updated_at: IsoDateString;
+}
+
+export interface CompetencyEvaluation {
+  id: string;
+  competency_id: string;
+  user_id: string;
+  period_start: IsoDateString;
+  period_end: IsoDateString;
+  scale: number;
+  score_value: number;
+  score_label: string;
+  rationale?: string | null;
+  attitude_actions: string[];
+  behavior_actions: string[];
+  ai_model?: string | null;
+  triggered_by: string;
+  created_at: IsoDateString;
+  updated_at: IsoDateString;
+  competency?: CompetencySummary | null;
+  items: CompetencyEvaluationItem[];
+}
+
+export interface EvaluationTriggerRequest {
+  user_id: string;
+  competency_id?: string;
+  period_start?: IsoDateString | null;
+  period_end?: IsoDateString | null;
+  triggered_by?: 'manual' | 'auto';
+}
+
+export interface AdminUser {
+  id: string;
+  email: string;
+  is_admin: boolean;
+  is_active: boolean;
+  card_daily_limit: number | null;
+  evaluation_daily_limit: number | null;
+  created_at: IsoDateString;
+  updated_at: IsoDateString;
+}
+
+export interface AdminUserUpdate {
+  is_admin?: boolean;
+  is_active?: boolean;
+  card_daily_limit?: number | null;
+  evaluation_daily_limit?: number | null;
+}
+
+export interface ApiCredential {
+  provider: string;
+  secret_hint?: string | null;
+  is_active: boolean;
+  created_at: IsoDateString;
+  updated_at: IsoDateString;
+}
+
+export interface ApiCredentialUpdate {
+  secret: string;
+  is_active?: boolean;
+}
+
+export interface QuotaDefaults {
+  card_daily_limit: number;
+  evaluation_daily_limit: number;
+}
+
+export interface QuotaDefaultsUpdate {
+  card_daily_limit: number;
+  evaluation_daily_limit: number;
+}

--- a/frontend/src/app/core/models/index.ts
+++ b/frontend/src/app/core/models/index.ts
@@ -1,5 +1,6 @@
 export * from './analysis';
 export * from './auth';
+export * from './admin';
 export * from './board';
 export * from './card';
 export * from './continuous-improvement';

--- a/frontend/src/app/features/admin/page.html
+++ b/frontend/src/app/features/admin/page.html
@@ -1,0 +1,422 @@
+<div class="admin-page">
+  <header class="admin-header">
+    <h1 class="admin-title">管理コンソール</h1>
+    <p class="admin-description">コンピテンシー設定・判定・ユーザ権限・API キーをまとめて管理できます。</p>
+  </header>
+
+  @if (error(); as message) {
+    <div class="admin-alert admin-alert--error" role="alert">
+      <span>{{ message }}</span>
+      <button type="button" class="admin-alert__close" (click)="clearError()">閉じる</button>
+    </div>
+  }
+
+  @if (feedback(); as message) {
+    <div class="admin-alert admin-alert--success" role="status">
+      <span>{{ message }}</span>
+      <button type="button" class="admin-alert__close" (click)="resetFeedback()">閉じる</button>
+    </div>
+  }
+
+  <nav class="admin-tabs" aria-label="管理メニュー">
+    <button
+      type="button"
+      class="admin-tabs__button"
+      [class.admin-tabs__button--active]="activeTab() === 'competencies'"
+      (click)="setActiveTab('competencies')"
+    >
+      コンピテンシー
+    </button>
+    <button
+      type="button"
+      class="admin-tabs__button"
+      [class.admin-tabs__button--active]="activeTab() === 'evaluations'"
+      (click)="setActiveTab('evaluations')"
+    >
+      判定と履歴
+    </button>
+    <button
+      type="button"
+      class="admin-tabs__button"
+      [class.admin-tabs__button--active]="activeTab() === 'users'"
+      (click)="setActiveTab('users')"
+    >
+      ユーザ管理
+    </button>
+    <button
+      type="button"
+      class="admin-tabs__button"
+      [class.admin-tabs__button--active]="activeTab() === 'settings'"
+      (click)="setActiveTab('settings')"
+    >
+      API・日次上限
+    </button>
+  </nav>
+
+  @if (activeTab() === 'competencies') {
+    <section class="admin-section">
+      <header class="admin-section__header">
+        <h2>登録済みコンピテンシー</h2>
+      </header>
+
+      @if (competencies().length === 0) {
+        <p class="admin-empty">まだコンピテンシーが登録されていません。右側のフォームから追加できます。</p>
+      } @else {
+        <ul class="admin-list">
+          @for (competency of competencies(); track competency.id) {
+            <li class="admin-list__item">
+              <div class="admin-list__heading">
+                <div>
+                  <strong class="admin-list__title">{{ competency.name }}</strong>
+                  <span class="admin-badge">
+                    {{ competency.level === 'junior' ? '初級 (3段階)' : '中級 (5段階)' }}
+                  </span>
+                </div>
+                <label class="admin-toggle">
+                  <input
+                    type="checkbox"
+                    [checked]="competency.is_active"
+                    (change)="toggleCompetencyActive(competency, $any($event.target).checked)"
+                    aria-label="{{ competency.name }} を有効化"
+                  />
+                  <span>有効</span>
+                </label>
+              </div>
+              <p class="admin-list__description">
+                {{ competency.description || '説明は登録されていません。' }}
+              </p>
+              <div class="admin-list__meta">
+                <span>評価項目: {{ competency.criteria.length }}件</span>
+                <span>最終更新: {{ competency.updated_at | date: 'medium' }}</span>
+              </div>
+            </li>
+          }
+        </ul>
+      }
+    </section>
+
+    <section class="admin-section">
+      <header class="admin-section__header">
+        <h2>コンピテンシーを登録</h2>
+        <p class="admin-section__subtitle">名称・レベル・評価項目を設定して AI 判定対象を作成します。</p>
+      </header>
+
+      <form class="admin-form" (submit)="createCompetency($event)">
+        <div class="admin-form__grid">
+          <label class="admin-field">
+            <span>名称</span>
+            <input
+              type="text"
+              name="competency-name"
+              [ngModel]="newCompetency().name"
+              (ngModelChange)="updateNewCompetencyField('name', $event)"
+              required
+            />
+          </label>
+          <label class="admin-field">
+            <span>レベル</span>
+            <select
+              name="competency-level"
+              [ngModel]="newCompetency().level"
+              (ngModelChange)="updateNewCompetencyField('level', $event)"
+            >
+              <option value="junior">初級 (3段階)</option>
+              <option value="intermediate">中級 (5段階)</option>
+            </select>
+          </label>
+          <label class="admin-field admin-field--full">
+            <span>説明</span>
+            <textarea
+              name="competency-description"
+              rows="3"
+              [ngModel]="newCompetency().description"
+              (ngModelChange)="updateNewCompetencyField('description', $event)"
+              placeholder="評価の観点や期待する行動を記載できます"
+            ></textarea>
+          </label>
+        </div>
+
+        <label class="admin-toggle">
+          <input
+            type="checkbox"
+            [checked]="newCompetency().is_active ?? true"
+            (change)="updateNewCompetencyField('is_active', $any($event.target).checked)"
+          />
+          <span>作成後すぐに判定対象として有効にする</span>
+        </label>
+
+        <div class="admin-criteria">
+          <div class="admin-criteria__header">
+            <h3>評価項目</h3>
+            <button type="button" class="admin-button admin-button--ghost" (click)="addCriterion()">
+              + 評価項目を追加
+            </button>
+          </div>
+
+          @for (criterion of newCompetency().criteria; track $index) {
+            <div class="admin-criteria__row">
+              <label class="admin-field">
+                <span>項目名</span>
+                <input
+                  type="text"
+                  [attr.name]="'criterion-' + $index + '-title'"
+                  [ngModel]="criterion.title"
+                  (ngModelChange)="updateCriterionField($index, 'title', $event)"
+                  placeholder="例: 問題発見力"
+                />
+              </label>
+              <label class="admin-field admin-field--full">
+                <span>説明</span>
+                <textarea
+                  rows="2"
+                  [attr.name]="'criterion-' + $index + '-description'"
+                  [ngModel]="criterion.description"
+                  (ngModelChange)="updateCriterionField($index, 'description', $event)"
+                  placeholder="評価基準や期待値を記載します"
+                ></textarea>
+              </label>
+              <button
+                type="button"
+                class="admin-button admin-button--ghost"
+                (click)="removeCriterion($index)"
+                [disabled]="newCompetency().criteria.length === 1"
+                aria-label="評価項目を削除"
+              >
+                削除
+              </button>
+            </div>
+          }
+        </div>
+
+        <button type="submit" class="admin-button admin-button--primary" [disabled]="loading()">
+          コンピテンシーを登録
+        </button>
+      </form>
+    </section>
+  }
+
+  @if (activeTab() === 'evaluations') {
+    <section class="admin-section">
+      <header class="admin-section__header">
+        <h2>手動判定</h2>
+        <p class="admin-section__subtitle">対象ユーザとコンピテンシーを選択し、AI 判定を即時実行します。</p>
+      </header>
+
+      <form class="admin-form" (submit)="triggerEvaluation($event)">
+        <div class="admin-form__grid">
+          <label class="admin-field">
+            <span>対象ユーザ</span>
+            <select [(ngModel)]="evaluationUserId" name="evaluation-user" required>
+              <option value="">選択してください</option>
+              @for (user of users(); track user.id) {
+                <option [value]="user.id">{{ user.email }}</option>
+              }
+            </select>
+          </label>
+          <label class="admin-field">
+            <span>コンピテンシー</span>
+            <select [(ngModel)]="evaluationCompetencyId" name="evaluation-competency" required>
+              <option value="">選択してください</option>
+              @for (competency of competencies(); track competency.id) {
+                <option [value]="competency.id">{{ competency.name }}</option>
+              }
+            </select>
+          </label>
+          <label class="admin-field">
+            <span>評価開始日</span>
+            <input type="date" [(ngModel)]="evaluationPeriodStart" name="evaluation-period-start" />
+          </label>
+          <label class="admin-field">
+            <span>評価終了日</span>
+            <input type="date" [(ngModel)]="evaluationPeriodEnd" name="evaluation-period-end" />
+          </label>
+        </div>
+
+        <button type="submit" class="admin-button admin-button--primary" [disabled]="loading()">
+          判定を実行
+        </button>
+      </form>
+    </section>
+
+    <section class="admin-section">
+      <header class="admin-section__header">
+        <h2>評価履歴</h2>
+        <p class="admin-section__subtitle">最新の評価結果を一覧で確認できます。</p>
+      </header>
+
+      @if (evaluations().length === 0) {
+        <p class="admin-empty">まだ評価結果はありません。手動判定を実行するか、月次バッチを待機してください。</p>
+      } @else {
+        <ul class="admin-evaluations">
+          @for (evaluation of evaluations(); track evaluation.id) {
+            <li class="admin-evaluations__item">
+              <header class="admin-evaluations__header">
+                <div>
+                  <strong>{{ evaluation.competency?.name || '不明なコンピテンシー' }}</strong>
+                  <span class="admin-badge">{{ evaluation.score_label }}</span>
+                </div>
+                <span class="admin-evaluations__meta">
+                  対象: {{ userEmail(evaluation.user_id) }} ／ 期間: {{ evaluation.period_start | date: 'yyyy/MM/dd' }} -
+                  {{ evaluation.period_end | date: 'yyyy/MM/dd' }}
+                </span>
+              </header>
+              <p class="admin-evaluations__rationale">{{ evaluation.rationale || 'AI からの根拠は取得できませんでした。' }}</p>
+              @if (evaluation.items.length > 0) {
+                <ul class="admin-evaluations__items">
+                  @for (item of evaluation.items; track item.id) {
+                    <li>
+                      <strong>{{ item.score_label }}</strong>
+                      <p>{{ item.rationale || '根拠は未入力です。' }}</p>
+                    </li>
+                  }
+                </ul>
+              }
+            </li>
+          }
+        </ul>
+      }
+    </section>
+  }
+
+  @if (activeTab() === 'users') {
+    <section class="admin-section">
+      <header class="admin-section__header">
+        <h2>ユーザ一覧</h2>
+        <p class="admin-section__subtitle">権限や日次上限を調整すると即時に反映されます。</p>
+      </header>
+
+      @if (users().length === 0) {
+        <p class="admin-empty">ユーザが登録されていません。</p>
+      } @else {
+        <div class="admin-table__wrapper">
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th scope="col">メールアドレス</th>
+                <th scope="col">管理者</th>
+                <th scope="col">有効</th>
+                <th scope="col">カード起票/日</th>
+                <th scope="col">判定回数/日</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (user of users(); track user.id) {
+                <tr>
+                  <td>{{ user.email }}</td>
+                  <td class="admin-table__cell--center">
+                    <input
+                      type="checkbox"
+                      [checked]="user.is_admin"
+                      (change)="toggleAdmin(user, $any($event.target).checked)"
+                      aria-label="{{ user.email }} の管理者権限を切り替え"
+                    />
+                  </td>
+                  <td class="admin-table__cell--center">
+                    <input
+                      type="checkbox"
+                      [checked]="user.is_active"
+                      (change)="toggleActive(user, $any($event.target).checked)"
+                      aria-label="{{ user.email }} の有効状態を切り替え"
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="number"
+                      min="0"
+                      [attr.name]="'card-limit-' + user.id"
+                      [ngModel]="user.card_daily_limit ?? ''"
+                      (ngModelChange)="onCardLimitChange(user, $event)"
+                      (blur)="saveUserQuota(user)"
+                      placeholder="デフォルト"
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="number"
+                      min="0"
+                      [attr.name]="'evaluation-limit-' + user.id"
+                      [ngModel]="user.evaluation_daily_limit ?? ''"
+                      (ngModelChange)="onEvaluationLimitChange(user, $event)"
+                      (blur)="saveUserQuota(user)"
+                      placeholder="デフォルト"
+                    />
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+        <p class="admin-hint">空欄の場合はデフォルト日次上限が適用されます。</p>
+      }
+    </section>
+  }
+
+  @if (activeTab() === 'settings') {
+    <section class="admin-section">
+      <header class="admin-section__header">
+        <h2>AI API トークン</h2>
+        <p class="admin-section__subtitle">OpenAI などの API キーを安全に保管し、判定処理に利用します。</p>
+      </header>
+
+      @if (apiCredential(); as credential) {
+        <p class="admin-hint">
+          現在のキー末尾: {{ credential.secret_hint || '****' }} ／ 更新日: {{ credential.updated_at | date: 'medium' }}
+        </p>
+      } @else {
+        <p class="admin-empty">登録済みの API トークンはありません。</p>
+      }
+
+      <form class="admin-form" (submit)="updateApiCredential($event)">
+        <label class="admin-field admin-field--full">
+          <span>新しい API トークン</span>
+          <input
+            type="text"
+            name="api-secret"
+            autocomplete="off"
+            [(ngModel)]="apiSecret"
+            placeholder="sk-..."
+            required
+          />
+        </label>
+        <button type="submit" class="admin-button admin-button--primary" [disabled]="loading()">
+          保存
+        </button>
+      </form>
+    </section>
+
+    <section class="admin-section">
+      <header class="admin-section__header">
+        <h2>デフォルト日次上限</h2>
+        <p class="admin-section__subtitle">ユーザ個別の設定が無い場合に適用される日次上限を変更します。</p>
+      </header>
+
+      <form class="admin-form" (submit)="updateQuotaDefaults($event)">
+        <div class="admin-form__grid">
+          <label class="admin-field">
+            <span>カード起票数</span>
+            <input
+              type="number"
+              min="0"
+              name="default-card-limit"
+              [(ngModel)]="defaultCardLimit"
+              required
+            />
+          </label>
+          <label class="admin-field">
+            <span>コンピテンシー判定数</span>
+            <input
+              type="number"
+              min="0"
+              name="default-evaluation-limit"
+              [(ngModel)]="defaultEvaluationLimit"
+              required
+            />
+          </label>
+        </div>
+        <button type="submit" class="admin-button admin-button--primary" [disabled]="loading()">
+          更新
+        </button>
+      </form>
+    </section>
+  }
+</div>

--- a/frontend/src/app/features/admin/page.scss
+++ b/frontend/src/app/features/admin/page.scss
@@ -1,0 +1,335 @@
+.admin-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.admin-title {
+  margin: 0;
+  font-size: clamp(1.5rem, 1.2rem + 1vw, 2rem);
+  font-weight: 600;
+}
+
+.admin-description {
+  margin: 0;
+  color: var(--color-muted, #64748b);
+}
+
+.admin-alert {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.admin-alert--error {
+  background: rgba(248, 113, 113, 0.14);
+  color: #991b1b;
+}
+
+.admin-alert--success {
+  background: rgba(34, 197, 94, 0.16);
+  color: #065f46;
+}
+
+.admin-alert__close {
+  appearance: none;
+  border: none;
+  background: transparent;
+  font-size: 0.85rem;
+  color: inherit;
+  cursor: pointer;
+}
+
+.admin-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.admin-tabs__button {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  background: var(--surface-subtle, #f1f5f9);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.admin-tabs__button--active {
+  background: var(--accent, #0ea5e9);
+  color: #fff;
+}
+
+.admin-section {
+  background: var(--surface, #ffffff);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: var(--shadow-sm, 0 4px 10px rgba(15, 23, 42, 0.06));
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.admin-section__subtitle {
+  margin: 0;
+  color: var(--color-muted, #64748b);
+  font-size: 0.9rem;
+}
+
+.admin-empty {
+  margin: 0;
+  color: var(--color-muted, #64748b);
+  font-size: 0.95rem;
+}
+
+.admin-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted, #64748b);
+}
+
+.admin-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.admin-list__item {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.9rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.admin-list__heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.admin-list__title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.admin-list__description {
+  margin: 0;
+  color: var(--color-muted, #64748b);
+  font-size: 0.95rem;
+}
+
+.admin-list__meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: var(--color-muted, #64748b);
+}
+
+.admin-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  background: rgba(14, 165, 233, 0.15);
+  color: #0369a1;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-left: 0.5rem;
+}
+
+.admin-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.admin-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-form__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.admin-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.admin-field input,
+.admin-field select,
+.admin-field textarea {
+  width: 100%;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.95rem;
+}
+
+.admin-field textarea {
+  resize: vertical;
+}
+
+.admin-field--full {
+  grid-column: 1 / -1;
+}
+
+.admin-button {
+  align-self: flex-start;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.55rem 1.2rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.admin-button--primary {
+  background: var(--accent, #0ea5e9);
+  color: #fff;
+}
+
+.admin-button--ghost {
+  background: rgba(148, 163, 184, 0.15);
+  color: inherit;
+}
+
+.admin-criteria {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.admin-criteria__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.admin-criteria__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+  align-items: flex-end;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.8rem;
+  background: var(--surface-subtle, #f8fafc);
+}
+
+.admin-criteria__row .admin-button {
+  justify-self: start;
+}
+
+.admin-evaluations {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.admin-evaluations__item {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.9rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.admin-evaluations__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.admin-evaluations__meta {
+  font-size: 0.85rem;
+  color: var(--color-muted, #64748b);
+}
+
+.admin-evaluations__rationale {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted, #475569);
+}
+
+.admin-evaluations__items {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--color-muted, #64748b);
+  font-size: 0.9rem;
+}
+
+.admin-table__wrapper {
+  overflow-x: auto;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+  text-align: left;
+}
+
+.admin-table__cell--center {
+  text-align: center;
+}
+
+.admin-table input[type='number'] {
+  width: 100%;
+  max-width: 8rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  padding: 0.4rem 0.5rem;
+}
+
+@media (max-width: 768px) {
+  .admin-section {
+    padding: 1rem;
+  }
+
+  .admin-criteria__row {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-form__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/app/features/admin/page.ts
+++ b/frontend/src/app/features/admin/page.ts
@@ -1,0 +1,428 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import { AdminApiService } from '@core/api/admin-api.service';
+import {
+  AdminUser,
+  AdminUserUpdate,
+  ApiCredential,
+  Competency,
+  CompetencyCriterionInput,
+  CompetencyEvaluation,
+  CompetencyInput,
+  QuotaDefaults,
+} from '@core/models';
+
+type AdminTab = 'competencies' | 'evaluations' | 'users' | 'settings';
+
+@Component({
+  selector: 'app-admin-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './page.html',
+  styleUrl: './page.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminPage {
+  private readonly api = inject(AdminApiService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  public readonly activeTab = signal<AdminTab>('competencies');
+  public readonly competencies = signal<Competency[]>([]);
+  public readonly users = signal<AdminUser[]>([]);
+  public readonly evaluations = signal<CompetencyEvaluation[]>([]);
+  public readonly quotaDefaults = signal<QuotaDefaults | null>(null);
+  public readonly apiCredential = signal<ApiCredential | null>(null);
+  public readonly loading = signal(false);
+  public readonly feedback = signal<string | null>(null);
+  public readonly error = signal<string | null>(null);
+
+  public readonly newCompetency = signal<CompetencyInput>({
+    name: '',
+    level: 'junior',
+    description: '',
+    is_active: true,
+    criteria: [{ title: '', description: '' }],
+  });
+
+  public evaluationUserId = '';
+  public evaluationCompetencyId = '';
+  public evaluationPeriodStart = '';
+  public evaluationPeriodEnd = '';
+  public apiSecret = '';
+  public defaultCardLimit: number | null = null;
+  public defaultEvaluationLimit: number | null = null;
+
+  public constructor() {
+    this.bootstrap();
+  }
+
+  public setActiveTab(tab: AdminTab): void {
+    this.activeTab.set(tab);
+  }
+
+  public resetFeedback(): void {
+    this.feedback.set(null);
+  }
+
+  public clearError(): void {
+    this.error.set(null);
+  }
+
+  public updateNewCompetencyField<K extends keyof CompetencyInput>(
+    field: K,
+    value: CompetencyInput[K],
+  ): void {
+    this.newCompetency.update((current) => ({
+      ...current,
+      [field]: value,
+    }));
+  }
+
+  public updateCriterionField(
+    index: number,
+    field: keyof CompetencyCriterionInput,
+    value: unknown,
+  ): void {
+    this.newCompetency.update((current) => {
+      const next = current.criteria.map((criterion, idx) =>
+        idx === index ? { ...criterion, [field]: value } : criterion,
+      );
+      return {
+        ...current,
+        criteria: next,
+      };
+    });
+  }
+
+  public addCriterion(): void {
+    this.newCompetency.update((current) => ({
+      ...current,
+      criteria: [...current.criteria, { title: '', description: '' }],
+    }));
+  }
+
+  public removeCriterion(index: number): void {
+    this.newCompetency.update((current) => ({
+      ...current,
+      criteria: current.criteria.filter((_, idx) => idx !== index),
+    }));
+  }
+
+  public createCompetency(event: SubmitEvent): void {
+    event.preventDefault();
+    this.clearError();
+
+    const value = this.newCompetency();
+    const name = value.name.trim();
+    if (name.length === 0) {
+      this.error.set('コンピテンシー名を入力してください。');
+      return;
+    }
+
+    const payload: CompetencyInput = {
+      name,
+      level: value.level,
+      description: value.description?.trim() ?? '',
+      sort_order: value.sort_order ?? 0,
+      is_active: value.is_active ?? true,
+      rubric: value.rubric ?? {},
+      criteria: value.criteria
+        .map((criterion, index) => ({
+          title: (criterion.title ?? '').trim(),
+          description: criterion.description?.toString().trim() ?? undefined,
+          is_active: criterion.is_active ?? true,
+          order_index: criterion.order_index ?? index,
+          weight: criterion.weight ?? undefined,
+          intentionality_prompt: criterion.intentionality_prompt?.toString().trim() || undefined,
+          behavior_prompt: criterion.behavior_prompt?.toString().trim() || undefined,
+        }))
+        .filter((criterion) => criterion.title.length > 0),
+    };
+
+    this.loading.set(true);
+    this.api
+      .createCompetency(payload)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (competency) => {
+          this.loading.set(false);
+          this.competencies.update((list) => [...list, competency]);
+          this.resetCompetencyForm();
+          this.notify('コンピテンシーを登録しました。');
+        },
+        error: (err) => {
+          this.loading.set(false);
+          this.handleError(err, 'コンピテンシーの登録に失敗しました。');
+        },
+      });
+  }
+
+  public resetCompetencyForm(): void {
+    this.newCompetency.set({
+      name: '',
+      level: 'junior',
+      description: '',
+      is_active: true,
+      criteria: [{ title: '', description: '' }],
+    });
+  }
+
+  public toggleCompetencyActive(competency: Competency, active: boolean): void {
+    this.api
+      .updateCompetency(competency.id, { is_active: active })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (updated) => {
+          this.replaceCompetency(updated);
+          this.notify('コンピテンシーの状態を更新しました。');
+        },
+        error: (err) => this.handleError(err, 'コンピテンシーの更新に失敗しました。'),
+      });
+  }
+
+  public triggerEvaluation(event: SubmitEvent): void {
+    event.preventDefault();
+    this.clearError();
+
+    if (!this.evaluationUserId || !this.evaluationCompetencyId) {
+      this.error.set('ユーザとコンピテンシーを選択してください。');
+      return;
+    }
+
+    const payload = {
+      user_id: this.evaluationUserId,
+      period_start: this.evaluationPeriodStart || undefined,
+      period_end: this.evaluationPeriodEnd || undefined,
+      triggered_by: 'manual' as const,
+    };
+
+    this.loading.set(true);
+    this.api
+      .triggerEvaluation(this.evaluationCompetencyId, payload)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (evaluation) => {
+          this.loading.set(false);
+          this.evaluations.update((items) => [evaluation, ...items].slice(0, 25));
+          this.notify('評価を実行しました。');
+        },
+        error: (err) => {
+          this.loading.set(false);
+          this.handleError(err, '評価の実行に失敗しました。');
+        },
+      });
+  }
+
+  public toggleAdmin(user: AdminUser, next: boolean): void {
+    this.updateUser(user, { is_admin: next });
+  }
+
+  public toggleActive(user: AdminUser, next: boolean): void {
+    this.updateUser(user, { is_active: next });
+  }
+
+  public saveUserQuota(user: AdminUser): void {
+    this.updateUser(user, {
+      card_daily_limit: user.card_daily_limit ?? null,
+      evaluation_daily_limit: user.evaluation_daily_limit ?? null,
+    });
+  }
+
+  public updateApiCredential(event: SubmitEvent): void {
+    event.preventDefault();
+    this.clearError();
+
+    const secret = this.apiSecret.trim();
+    if (!secret) {
+      this.error.set('API トークンを入力してください。');
+      return;
+    }
+
+    this.loading.set(true);
+    this.api
+      .upsertApiCredential('openai', { secret })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (credential) => {
+          this.loading.set(false);
+          this.apiCredential.set(credential);
+          this.apiSecret = '';
+          this.notify('API トークンを更新しました。');
+        },
+        error: (err) => {
+          this.loading.set(false);
+          this.handleError(err, 'API トークンの更新に失敗しました。');
+        },
+      });
+  }
+
+  public userEmail(userId: string): string {
+    const match = this.users().find((user) => user.id === userId);
+    return match?.email ?? userId;
+  }
+
+  public onCardLimitChange(user: AdminUser, value: string | number | null): void {
+    if (value === null || value === '') {
+      user.card_daily_limit = null;
+      return;
+    }
+    user.card_daily_limit = Number(value);
+  }
+
+  public onEvaluationLimitChange(
+    user: AdminUser,
+    value: string | number | null,
+  ): void {
+    if (value === null || value === '') {
+      user.evaluation_daily_limit = null;
+      return;
+    }
+    user.evaluation_daily_limit = Number(value);
+  }
+
+  public updateQuotaDefaults(event: SubmitEvent): void {
+    event.preventDefault();
+    this.clearError();
+
+    if (this.defaultCardLimit === null || this.defaultEvaluationLimit === null) {
+      this.error.set('日次上限を入力してください。');
+      return;
+    }
+
+    const payload = {
+      card_daily_limit: this.defaultCardLimit,
+      evaluation_daily_limit: this.defaultEvaluationLimit,
+    };
+
+    this.loading.set(true);
+    this.api
+      .updateQuotaDefaults(payload)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (defaults) => {
+          this.loading.set(false);
+          this.quotaDefaults.set(defaults);
+          this.notify('デフォルト日次上限を更新しました。');
+        },
+        error: (err) => {
+          this.loading.set(false);
+          this.handleError(err, 'デフォルト日次上限の更新に失敗しました。');
+        },
+      });
+  }
+
+  private bootstrap(): void {
+    this.loadCompetencies();
+    this.loadUsers();
+    this.loadEvaluations();
+    this.loadDefaults();
+    this.loadCredential();
+  }
+
+  private loadCompetencies(): void {
+    this.api
+      .listCompetencies()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (competencies) => this.competencies.set(competencies),
+        error: (err) => this.handleError(err, 'コンピテンシーの取得に失敗しました。'),
+      });
+  }
+
+  private loadUsers(): void {
+    this.api
+      .listUsers()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (users) => this.users.set(users),
+        error: (err) => this.handleError(err, 'ユーザ一覧の取得に失敗しました。'),
+      });
+  }
+
+  private loadEvaluations(): void {
+    this.api
+      .listEvaluations()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (evaluations) => this.evaluations.set(evaluations),
+        error: (err) => this.handleError(err, '評価履歴の取得に失敗しました。'),
+      });
+  }
+
+  private loadDefaults(): void {
+    this.api
+      .getQuotaDefaults()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (defaults) => {
+          this.quotaDefaults.set(defaults);
+          this.defaultCardLimit = defaults.card_daily_limit;
+          this.defaultEvaluationLimit = defaults.evaluation_daily_limit;
+        },
+        error: (err) => this.handleError(err, '日次上限の取得に失敗しました。'),
+      });
+  }
+
+  private loadCredential(): void {
+    this.api
+      .getApiCredential('openai')
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (credential) => this.apiCredential.set(credential),
+        error: (err: unknown) => {
+          if (err instanceof HttpErrorResponse && err.status === 404) {
+            this.apiCredential.set(null);
+            return;
+          }
+          this.handleError(err, 'API トークンの取得に失敗しました。');
+        },
+      });
+  }
+
+  private updateUser(user: AdminUser, payload: AdminUserUpdate): void {
+    this.api
+      .updateUser(user.id, payload)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (updated) => {
+          this.users.update((list) =>
+            list.map((item) => (item.id === updated.id ? updated : item)),
+          );
+          this.notify('ユーザ情報を更新しました。');
+        },
+        error: (err) => this.handleError(err, 'ユーザ情報の更新に失敗しました。'),
+      });
+  }
+
+  private replaceCompetency(updated: Competency): void {
+    this.competencies.update((list) =>
+      list.map((item) => (item.id === updated.id ? updated : item)),
+    );
+  }
+
+  private notify(message: string): void {
+    this.feedback.set(message);
+    if (typeof window !== 'undefined') {
+      window.setTimeout(() => this.feedback.set(null), 4000);
+    }
+  }
+
+  private handleError(error: unknown, fallback: string): void {
+    let message = fallback;
+    if (error instanceof HttpErrorResponse) {
+      message =
+        (typeof error.error === 'object' && error.error?.detail) || error.message || fallback;
+    }
+    this.error.set(message);
+  }
+}


### PR DESCRIPTION
## Summary
- implement competency, evaluation, and admin configuration models and routers in the backend
- add a rule-based competency evaluator service with dynamic card/evaluation quota handling and API credential storage
- build an Angular admin console plus client services for managing competencies, evaluations, users, and API/quota settings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d33794271c8320863e66740e12ec8e