### PR TITLE
feat: add user profile dialog and backend support

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from .routers import (
     filters,
     initiatives,
     labels,
+    profile,
     preferences,
     reports,
     statuses,
@@ -47,6 +48,7 @@ app.include_router(cards.router)
 app.include_router(labels.router)
 app.include_router(statuses.router)
 app.include_router(preferences.router)
+app.include_router(profile.router)
 app.include_router(comments.router)
 app.include_router(activity.router)
 app.include_router(error_categories.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from datetime import date, datetime, timezone
 from typing import Optional
 from uuid import uuid4
@@ -13,6 +14,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Integer,
+    LargeBinary,
     String,
     Table,
     Text,
@@ -47,6 +49,14 @@ class User(Base, TimestampMixin):
     password_hash: Mapped[str] = mapped_column(String, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    nickname: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    experience_years: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    roles: Mapped[list[str]] = mapped_column(JSON, default=list)
+    bio: Mapped[str | None] = mapped_column(Text, nullable=True)
+    location: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    portfolio_url: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    avatar_image: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    avatar_mime_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     cards: Mapped[list["Card"]] = relationship("Card", back_populates="owner", cascade="all, delete-orphan")
     tokens: Mapped[list["SessionToken"]] = relationship(
@@ -70,6 +80,14 @@ class User(Base, TimestampMixin):
     saved_filters: Mapped[list["SavedFilter"]] = relationship(
         "SavedFilter", back_populates="owner", cascade="all, delete-orphan"
     )
+
+    @property
+    def avatar_url(self) -> str | None:
+        if not self.avatar_image or not self.avatar_mime_type:
+            return None
+
+        encoded = base64.b64encode(self.avatar_image).decode("ascii")
+        return f"data:{self.avatar_mime_type};base64,{encoded}"
 
 
 class SessionToken(Base, TimestampMixin):

--- a/backend/app/routers/profile.py
+++ b/backend/app/routers/profile.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..auth import get_current_user
+from ..database import get_db
+from ..services.profile import (
+    build_user_profile,
+    normalize_nickname,
+    parse_experience_years,
+    parse_roles,
+    process_avatar_upload,
+    sanitize_bio,
+    sanitize_location,
+    sanitize_portfolio_url,
+    should_remove_avatar,
+)
+
+router = APIRouter(prefix="/profile", tags=["profile"])
+
+
+@router.get("/me", response_model=schemas.UserProfile)
+async def read_profile(
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.UserProfile:
+    return build_user_profile(current_user)
+
+
+@router.put("/me", response_model=schemas.UserProfile)
+async def update_profile(
+    nickname: str = Form(...),
+    experience_years: str | None = Form(default=None),
+    roles: str | None = Form(default=None),
+    bio: str | None = Form(default=None),
+    location: str | None = Form(default=None),
+    portfolio_url: str | None = Form(default=None),
+    remove_avatar: str | None = Form(default=None),
+    avatar: UploadFile | None = File(default=None),
+    current_user: models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> schemas.UserProfile:
+    sanitized_nickname = normalize_nickname(nickname)
+    sanitized_experience = parse_experience_years(experience_years)
+    sanitized_roles = parse_roles(roles)
+    sanitized_bio = sanitize_bio(bio)
+    sanitized_location = sanitize_location(location)
+    sanitized_portfolio = sanitize_portfolio_url(portfolio_url)
+    remove_current_avatar = should_remove_avatar(remove_avatar)
+
+    avatar_bytes: bytes | None = None
+    avatar_mime_type: str | None = None
+
+    if avatar is not None:
+        avatar_bytes, avatar_mime_type = await process_avatar_upload(avatar)
+    elif remove_current_avatar:
+        avatar_bytes, avatar_mime_type = None, None
+
+    current_user.nickname = sanitized_nickname
+    current_user.experience_years = sanitized_experience
+    current_user.roles = sanitized_roles
+    current_user.bio = sanitized_bio
+    current_user.location = sanitized_location
+    current_user.portfolio_url = sanitized_portfolio
+
+    if avatar is not None or remove_current_avatar:
+        current_user.avatar_image = avatar_bytes
+        current_user.avatar_mime_type = avatar_mime_type
+
+    db.add(current_user)
+    db.commit()
+    db.refresh(current_user)
+
+    return build_user_profile(current_user)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -25,6 +25,27 @@ class UserRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class UserProfile(UserRead):
+    nickname: Optional[str] = None
+    experience_years: Optional[int] = Field(default=None, ge=0, le=50)
+    roles: List[str] = Field(default_factory=list)
+    bio: Optional[str] = None
+    location: Optional[str] = None
+    portfolio_url: Optional[str] = None
+    avatar_url: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_roles(cls, data: Any) -> Any:
+        if isinstance(data, Mapping):
+            roles = data.get("roles")
+            if roles is None:
+                normalized = dict(data)
+                normalized["roles"] = []
+                return normalized
+        return data
+
+
 def _normalize_email_input(value: str | EmailStr) -> str:
     normalized = unicodedata.normalize("NFKC", str(value))
     return normalized.strip()
@@ -59,7 +80,7 @@ class RegistrationRequest(BaseModel):
 class TokenResponse(BaseModel):
     access_token: str
     token_type: Literal["bearer"] = "bearer"
-    user: UserRead
+    user: UserProfile
 
 
 class LabelBase(BaseModel):

--- a/backend/app/services/profile.py
+++ b/backend/app/services/profile.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+from urllib.parse import urlparse
+
+from fastapi import HTTPException, UploadFile, status
+from PIL import Image, ImageFile, UnidentifiedImageError
+
+from .. import models, schemas
+
+_MAX_NICKNAME_LENGTH = 30
+_MAX_BIO_LENGTH = 500
+_MAX_LOCATION_LENGTH = 120
+_MAX_PORTFOLIO_LENGTH = 255
+_MAX_ROLES = 5
+_MAX_ROLE_LENGTH = 32
+_MAX_EXPERIENCE_YEARS = 50
+_MAX_AVATAR_DIMENSION = 320
+_MAX_AVATAR_SIZE_BYTES = 5 * 1024 * 1024
+_ALLOWED_CONTENT_TYPES = {"image/png", "image/jpeg", "image/webp"}
+
+
+def build_user_profile(user: models.User) -> schemas.UserProfile:
+    return schemas.UserProfile.model_validate(user)
+
+
+def normalize_nickname(value: str | None) -> str:
+    if value is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="ニックネームを入力してください。",
+        )
+
+    nickname = value.strip()
+    if not nickname:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="ニックネームを入力してください。",
+        )
+
+    if len(nickname) > _MAX_NICKNAME_LENGTH:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"ニックネームは{_MAX_NICKNAME_LENGTH}文字以内で入力してください。",
+        )
+
+    return nickname
+
+
+def parse_experience_years(value: str | None) -> int | None:
+    if value is None or value == "":
+        return None
+
+    try:
+        years = int(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - kept for completeness
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="経験年数は整数で入力してください。",
+        ) from exc
+
+    if years < 0 or years > _MAX_EXPERIENCE_YEARS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"経験年数は0から{_MAX_EXPERIENCE_YEARS}の範囲で入力してください。",
+        )
+
+    return years
+
+
+def _sanitize_optional_text(value: str | None, max_length: int) -> str | None:
+    if value is None:
+        return None
+
+    text = value.strip()
+    if not text:
+        return None
+
+    if len(text) > max_length:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"{max_length}文字以内で入力してください。",
+        )
+
+    return text
+
+
+def sanitize_bio(value: str | None) -> str | None:
+    return _sanitize_optional_text(value, _MAX_BIO_LENGTH)
+
+
+def sanitize_location(value: str | None) -> str | None:
+    return _sanitize_optional_text(value, _MAX_LOCATION_LENGTH)
+
+
+def sanitize_portfolio_url(value: str | None) -> str | None:
+    url = _sanitize_optional_text(value, _MAX_PORTFOLIO_LENGTH)
+    if url is None:
+        return None
+
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="ポートフォリオURLは http または https で始まる有効なURLを入力してください。",
+        )
+
+    return url
+
+
+def parse_roles(value: str | None) -> list[str]:
+    if value is None or value == "":
+        return []
+
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="業務内容の形式が正しくありません。",
+        ) from exc
+
+    if not isinstance(parsed, list):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="業務内容は配列形式で送信してください。",
+        )
+
+    normalized: list[str] = []
+    for item in parsed:
+        if not isinstance(item, str):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="業務内容には文字列を指定してください。",
+            )
+
+        role = item.strip()
+        if not role:
+            continue
+
+        if len(role) > _MAX_ROLE_LENGTH:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"業務内容は1項目あたり{_MAX_ROLE_LENGTH}文字以内で入力してください。",
+            )
+
+        if role not in normalized:
+            normalized.append(role)
+
+        if len(normalized) > _MAX_ROLES:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"業務内容は最大{_MAX_ROLES}件まで選択できます。",
+            )
+
+    return normalized
+
+
+def should_remove_avatar(value: str | None) -> bool:
+    if value is None:
+        return False
+
+    normalized = value.strip().lower()
+    return normalized in {"1", "true", "yes", "on"}
+
+
+async def process_avatar_upload(upload: UploadFile) -> tuple[bytes, str]:
+    if upload.content_type not in _ALLOWED_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="対応していない画像形式です。png、jpeg、webpをご利用ください。",
+        )
+
+    raw_bytes = await upload.read()
+    if len(raw_bytes) > _MAX_AVATAR_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="アイコン画像のサイズは5MB以内にしてください。",
+        )
+
+    try:
+        image = Image.open(io.BytesIO(raw_bytes))
+    except UnidentifiedImageError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="画像を読み込めませんでした。ファイルを確認してください。",
+        ) from exc
+
+    image = _convert_image_to_rgba(image, raw_bytes)
+    side = min(image.width, image.height)
+    left = (image.width - side) // 2
+    top = (image.height - side) // 2
+    cropped = image.crop((left, top, left + side, top + side))
+
+    if side > _MAX_AVATAR_DIMENSION:
+        resampling = getattr(Image, "Resampling", Image)
+        cropped = cropped.resize((
+            _MAX_AVATAR_DIMENSION,
+            _MAX_AVATAR_DIMENSION,
+        ), resampling.LANCZOS)
+
+    buffer = io.BytesIO()
+    cropped.save(buffer, format="WEBP", quality=85, method=6)
+    return buffer.getvalue(), "image/webp"
+
+
+def _convert_image_to_rgba(image: Image.Image, raw_bytes: bytes) -> Image.Image:
+    try:
+        return image.convert("RGBA")
+    except OSError:
+        pass
+
+    original_setting = ImageFile.LOAD_TRUNCATED_IMAGES
+    ImageFile.LOAD_TRUNCATED_IMAGES = True
+    try:
+        retry_image = Image.open(io.BytesIO(raw_bytes))
+        retry_image.load()
+        return retry_image.convert("RGBA")
+    except (UnidentifiedImageError, OSError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="画像を読み込めませんでした。ファイルを確認してください。",
+        ) from exc
+    finally:
+        ImageFile.LOAD_TRUNCATED_IMAGES = original_setting
+
+
+__all__ = [
+    "build_user_profile",
+    "normalize_nickname",
+    "parse_experience_years",
+    "parse_roles",
+    "process_avatar_upload",
+    "sanitize_bio",
+    "sanitize_location",
+    "sanitize_portfolio_url",
+    "should_remove_avatar",
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ python-multipart==0.0.9
 pytest==7.4.4
 httpx==0.27.2
 openai>=1.40.0,<2.0.0
+Pillow==10.4.0

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import base64
+import json
+
+from fastapi.testclient import TestClient
+
+
+def _register_and_login(client: TestClient, email: str, password: str = "Password123!") -> tuple[str, dict[str, str]]:
+    response = client.post(
+        "/auth/register",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    token = payload["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    return token, headers
+
+
+def test_profile_defaults(client: TestClient, email: str) -> None:
+    _, headers = _register_and_login(client, email)
+
+    response = client.get("/profile/me", headers={"Authorization": "Bearer invalid"})
+    assert response.status_code == 401
+
+    response = client.get("/profile/me", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["nickname"] is None
+    assert data["roles"] == []
+    assert data["avatar_url"] is None
+
+
+def test_profile_update_round_trip(client: TestClient, email: str) -> None:
+    _, headers = _register_and_login(client, email)
+
+    avatar_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAAIklEQVR42mNgoBfgPxBmBhBgGAWjYBSMglEwCkbBAgBgAADX0wQKX/9S1gAAAABJRU5ErkJggg=="
+    )
+
+    payload = {
+        "nickname": "田中 太郎",
+        "experience_years": "7",
+        "roles": json.dumps(["Java", "フロント"]),
+        "bio": "Javaとフロントエンドの開発が得意です。",
+        "location": "東京都",
+        "portfolio_url": "https://example.com/portfolio",
+    }
+    files = {"avatar": ("avatar.png", avatar_bytes, "image/png")}
+
+    response = client.put("/profile/me", data=payload, files=files, headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["nickname"] == "田中 太郎"
+    assert data["experience_years"] == 7
+    assert data["roles"] == ["Java", "フロント"]
+    assert data["bio"].startswith("Javaとフロントエンド")
+    assert data["location"] == "東京都"
+    assert data["portfolio_url"] == "https://example.com/portfolio"
+    assert data["avatar_url"].startswith("data:image/webp;base64,")
+
+    follow_up = client.get("/profile/me", headers=headers)
+    assert follow_up.status_code == 200
+    follow_data = follow_up.json()
+    assert follow_data["nickname"] == "田中 太郎"
+    assert follow_data["roles"] == ["Java", "フロント"]
+
+    removal_response = client.put(
+        "/profile/me",
+        data={
+            "nickname": "田中 太郎",
+            "roles": json.dumps(["Java", "フロント"]),
+            "remove_avatar": "true",
+        },
+        headers=headers,
+    )
+    assert removal_response.status_code == 200
+    assert removal_response.json()["avatar_url"] is None
+
+
+def test_profile_roles_limit(client: TestClient, email: str) -> None:
+    _, headers = _register_and_login(client, email)
+
+    too_many_roles = [f"Role {index}" for index in range(6)]
+
+    response = client.put(
+        "/profile/me",
+        data={
+            "nickname": "開発者",
+            "roles": json.dumps(too_many_roles),
+        },
+        headers=headers,
+    )
+    assert response.status_code == 422

--- a/frontend/src/app/core/auth/auth.service.ts
+++ b/frontend/src/app/core/auth/auth.service.ts
@@ -122,6 +122,10 @@ export class AuthService {
     this.persistToken(token);
   }
 
+  public applyUserProfile(user: AuthenticatedUser): void {
+    this.userStore.set(user);
+  }
+
   private clearSession(): void {
     this.tokenStore.set(null);
     this.userStore.set(null);

--- a/frontend/src/app/core/layout/shell/shell.html
+++ b/frontend/src/app/core/layout/shell/shell.html
@@ -1,5 +1,20 @@
 <div class="flex min-h-screen flex-col bg-surface">
   <header class="shell-header">
+    @if (profileToastMessage(); as toast) {
+      <div class="shell-toast" role="status" aria-live="polite">
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          class="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 12.5 10 17l9-10" />
+        </svg>
+        <span>{{ toast }}</span>
+      </div>
+    }
     <div
       class="shell-header__content shell-container flex flex-col gap-4 py-6 lg:flex-row lg:items-center lg:justify-between"
     >
@@ -175,21 +190,37 @@
         </div>
 
         @if (user(); as currentUser) {
-          <div class="shell-user" [attr.title]="currentUser.email">
-            <span class="shell-user__icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm-7 9a7 7 0 0 1 14 0"
-                />
-              </svg>
+          <button
+            type="button"
+            class="shell-user focus-ring"
+            (click)="openProfile()"
+            aria-haspopup="dialog"
+            [attr.aria-expanded]="isProfileDialogOpen()"
+            aria-label="プロフィール設定を開く"
+          >
+            <span class="shell-user__avatar" aria-hidden="true">
+              @if (currentUser.avatar_url; as avatarUrl) {
+                <img [src]="avatarUrl" alt="" />
+              } @else {
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm-7 9a7 7 0 0 1 14 0"
+                  />
+                </svg>
+              }
             </span>
             <span class="shell-user__details">
-              <span class="shell-user__label">ログイン中</span>
-              <span class="shell-user__email">{{ currentUser.email }}</span>
+              <span class="shell-user__name">{{ currentUser.nickname ?? currentUser.email }}</span>
+              <span class="shell-user__meta">
+                @if (currentUser.roles.length) {
+                  <span class="shell-user__roles">{{ currentUser.roles.join(' / ') }}</span>
+                }
+                <span class="shell-user__email">{{ currentUser.email }}</span>
+              </span>
             </span>
-          </div>
+          </button>
         }
       </div>
     </div>
@@ -209,6 +240,10 @@
       <p>Angular 20 Signal Architecture / ChatGPT モック統合</p>
     </div>
   </footer>
+
+  @if (isProfileDialogOpen()) {
+    <app-profile-dialog (dismiss)="closeProfile()" (profileSaved)="onProfileSaved($event)" />
+  }
 
   @if (isHelpDialogOpen()) {
     <app-help-dialog (dismiss)="closeHelp()" />

--- a/frontend/src/app/core/layout/shell/shell.scss
+++ b/frontend/src/app/core/layout/shell/shell.scss
@@ -46,6 +46,31 @@
   z-index: 1;
 }
 
+.shell-toast {
+  position: absolute;
+  top: 1.25rem;
+  right: clamp(1.5rem, 5vw, 3.5rem);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(34, 197, 94, 0.4);
+  background: rgba(240, 253, 244, 0.95);
+  color: rgba(22, 101, 52, 0.92);
+  font-size: 0.82rem;
+  font-weight: 600;
+  box-shadow: 0 18px 40px -26px rgba(16, 185, 129, 0.35);
+  pointer-events: none;
+}
+
+:host-context(.dark) .shell-toast {
+  border-color: rgba(74, 222, 128, 0.45);
+  background: rgba(6, 95, 70, 0.75);
+  color: rgba(220, 252, 231, 0.92);
+  box-shadow: 0 18px 40px -24px rgba(6, 95, 70, 0.45);
+}
+
 :host-context(.dark) .shell-header {
   border-bottom-color: rgba(148, 163, 184, 0.28);
   background: linear-gradient(120deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.6));
@@ -242,63 +267,76 @@
 
 .shell-user {
   position: relative;
-  display: grid;
-  grid-template-columns: auto 1fr;
+  display: inline-flex;
   align-items: center;
-  gap: 0.8rem;
-  padding: 0.65rem 1rem;
-  border-radius: 1.8rem;
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  background: linear-gradient(140deg, rgba(255, 255, 255, 0.96), rgba(241, 245, 249, 0.78));
-  box-shadow: 0 20px 48px -32px rgba(37, 99, 235, 0.55);
-  color: #0f172a;
+  gap: 1rem;
+  padding: 0.7rem 1.2rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.95), rgba(236, 245, 255, 0.82));
+  box-shadow: 0 20px 48px -30px rgba(37, 99, 235, 0.45);
+  color: rgba(15, 23, 42, 0.92);
   font-size: 0.92rem;
-  line-height: 1.35;
-  font-weight: 500;
-  flex: 0 0 auto;
-  align-self: flex-start;
-  min-height: 2.75rem;
-  inline-size: min(100%, max-content);
-  backdrop-filter: blur(22px);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
 }
 
-.shell-user__icon {
+.shell-user:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 52px -28px rgba(37, 99, 235, 0.52);
+}
+
+.shell-user__avatar {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 2.5rem;
-  width: 2.5rem;
+  height: 2.75rem;
+  width: 2.75rem;
   border-radius: 9999px;
+  overflow: hidden;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
   color: var(--on-surface-inverse);
-  box-shadow: 0 16px 42px -28px rgba(37, 99, 235, 0.62);
+  box-shadow: 0 16px 40px -28px rgba(37, 99, 235, 0.58);
 }
 
-.shell-user__icon svg {
-  height: 1.3rem;
-  width: 1.3rem;
+.shell-user__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .shell-user__details {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.2rem;
+  gap: 0.25rem;
   min-inline-size: 0;
 }
 
-.shell-user__label {
-  font-size: 0.62rem;
-  letter-spacing: 0.26em;
-  text-transform: uppercase;
+.shell-user__name {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.92);
+}
+
+.shell-user__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.78rem;
+  color: rgba(71, 85, 105, 0.85);
+  min-inline-size: 0;
+}
+
+.shell-user__roles {
   font-weight: 600;
-  color: rgba(100, 116, 139, 0.72);
+  color: rgba(37, 99, 235, 0.85);
 }
 
 .shell-user__email {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: #1e293b;
+  font-weight: 500;
+  color: rgba(51, 65, 85, 0.92);
   overflow-wrap: anywhere;
 }
 
@@ -315,8 +353,8 @@
   }
 
   .shell-user {
-    padding: 0.7rem 1.25rem;
-    gap: 1rem;
+    padding: 0.75rem 1.4rem;
+    gap: 1.1rem;
   }
 }
 
@@ -327,22 +365,26 @@
 }
 
 :host-context(.dark) .shell-user {
-  border-color: rgba(148, 163, 184, 0.35);
-  background: linear-gradient(140deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.74));
+  border-color: rgba(148, 163, 184, 0.32);
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.78));
   color: rgba(226, 232, 240, 0.95);
-  box-shadow: 0 20px 48px -30px rgba(15, 23, 42, 0.85);
+  box-shadow: 0 20px 48px -28px rgba(15, 23, 42, 0.82);
 }
 
-:host-context(.dark) .shell-user__label {
-  color: rgba(148, 163, 184, 0.7);
+:host-context(.dark) .shell-user__avatar {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.95), rgba(59, 130, 246, 0.85));
+  color: rgba(15, 23, 42, 0.96);
+  box-shadow: 0 16px 40px -28px rgba(96, 165, 250, 0.58);
+}
+
+:host-context(.dark) .shell-user__meta {
+  color: rgba(203, 213, 225, 0.8);
+}
+
+:host-context(.dark) .shell-user__roles {
+  color: rgba(96, 165, 250, 0.85);
 }
 
 :host-context(.dark) .shell-user__email {
-  color: rgba(226, 232, 240, 0.95);
-}
-
-:host-context(.dark) .shell-user__icon {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.96), rgba(37, 99, 235, 0.9));
-  color: rgba(15, 23, 42, 0.96);
-  box-shadow: 0 16px 42px -26px rgba(96, 165, 250, 0.65);
+  color: rgba(226, 232, 240, 0.92);
 }

--- a/frontend/src/app/core/layout/shell/shell.ts
+++ b/frontend/src/app/core/layout/shell/shell.ts
@@ -11,6 +11,8 @@ import {
 import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 import { AuthService } from '@core/auth/auth.service';
+import { ProfileDialogComponent } from '@core/profile/profile-dialog';
+import { UserProfile } from '@core/profile/profile.models';
 import { HelpDialogComponent } from './help-dialog';
 
 type ThemePreference = 'light' | 'dark' | 'system';
@@ -21,7 +23,7 @@ type ThemePreference = 'light' | 'dark' | 'system';
 @Component({
   selector: 'app-shell',
   standalone: true,
-  imports: [RouterOutlet, RouterLink, RouterLinkActive, HelpDialogComponent],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, HelpDialogComponent, ProfileDialogComponent],
   templateUrl: './shell.html',
   styleUrl: './shell.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -33,6 +35,9 @@ export class Shell {
   private readonly destroyRef = inject(DestroyRef);
   private readonly themeStorageKey = 'todo-generator:theme-preference';
   private readonly helpDialogVisible = signal(false);
+  private readonly profileDialogVisible = signal(false);
+  private readonly profileToastStore = signal<string | null>(null);
+  private toastTimeoutHandle: number | null = null;
 
   private readonly themeLabels: Record<ThemePreference, string> = {
     light: 'ライトモード',
@@ -60,6 +65,8 @@ export class Shell {
       `テーマ設定。現在は${this.themeDisplayLabel()}。クリックすると${this.themeNextLabel()}に切り替わります。`,
   );
   public readonly isHelpDialogOpen = computed(() => this.helpDialogVisible());
+  public readonly isProfileDialogOpen = computed(() => this.profileDialogVisible());
+  public readonly profileToastMessage = computed(() => this.profileToastStore());
 
   private readonly syncTheme = effect(() => {
     const preference = this.theme();
@@ -101,6 +108,20 @@ export class Shell {
   public readonly year = new Date().getFullYear();
   public readonly user = this.auth.user;
 
+  public openProfile(): void {
+    this.profileDialogVisible.set(true);
+  }
+
+  public closeProfile(): void {
+    this.profileDialogVisible.set(false);
+  }
+
+  public onProfileSaved(profile: UserProfile): void {
+    this.auth.applyUserProfile(profile);
+    this.closeProfile();
+    this.showProfileToast('プロフィールを更新しました。');
+  }
+
   public toggleTheme(): void {
     this.theme.update((mode) => this.nextTheme(mode));
   }
@@ -124,6 +145,9 @@ export class Shell {
 
   public constructor() {
     this.setupSystemThemeListener();
+    this.destroyRef.onDestroy(() => {
+      this.clearToastTimer();
+    });
   }
 
   private resolveInitialTheme(): ThemePreference {
@@ -194,5 +218,30 @@ export class Shell {
     }
 
     return this.themeCycle[(index + 1) % this.themeCycle.length];
+  }
+
+  private showProfileToast(message: string): void {
+    this.profileToastStore.set(message);
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    this.clearToastTimer();
+    this.toastTimeoutHandle = window.setTimeout(() => {
+      this.profileToastStore.set(null);
+      this.toastTimeoutHandle = null;
+    }, 4000);
+  }
+
+  private clearToastTimer(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (this.toastTimeoutHandle !== null) {
+      window.clearTimeout(this.toastTimeoutHandle);
+      this.toastTimeoutHandle = null;
+    }
   }
 }

--- a/frontend/src/app/core/models/auth.ts
+++ b/frontend/src/app/core/models/auth.ts
@@ -4,6 +4,13 @@ export interface AuthenticatedUser {
   readonly is_admin: boolean;
   readonly created_at: string;
   readonly updated_at: string;
+  readonly nickname: string | null;
+  readonly experience_years: number | null;
+  readonly roles: readonly string[];
+  readonly bio: string | null;
+  readonly location: string | null;
+  readonly portfolio_url: string | null;
+  readonly avatar_url: string | null;
 }
 
 export interface TokenResponse {

--- a/frontend/src/app/core/profile/profile-dialog.html
+++ b/frontend/src/app/core/profile/profile-dialog.html
@@ -1,0 +1,259 @@
+<div class="profile-dialog" (click)="onBackdropClick()">
+  <div class="profile-dialog__backdrop" aria-hidden="true"></div>
+  <article
+    #panel
+    class="profile-dialog__panel focus-ring"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="profile-dialog-title"
+    (click)="$event.stopPropagation()"
+    tabindex="-1"
+  >
+    <header class="profile-dialog__header">
+      <div>
+        <p class="profile-dialog__eyebrow">アカウント設定</p>
+        <h2 class="profile-dialog__title" id="profile-dialog-title">プロフィールを編集</h2>
+        <p class="profile-dialog__description">
+          表示名やアイコン、担当領域などのプロフィール情報を更新できます。
+        </p>
+      </div>
+      <button
+        type="button"
+        class="profile-dialog__close focus-ring"
+        (click)="onCancelClick()"
+        aria-label="プロフィール設定を閉じる"
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="1.8">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M18 6l-12 12" />
+        </svg>
+      </button>
+    </header>
+
+    @if (loading()) {
+      <div class="profile-dialog__loading" role="status" aria-live="polite">
+        プロフィールを読み込んでいます…
+      </div>
+    } @else {
+      <form class="profile-dialog__form" (submit)="onSubmit($event)" novalidate>
+        @if (error(); as errorMessage) {
+          <div class="profile-dialog__alert" role="alert" aria-live="assertive">
+            {{ errorMessage }}
+          </div>
+        }
+
+        <section class="profile-dialog__section" aria-labelledby="profile-avatar-section">
+          <div class="profile-dialog__section-header">
+            <h3 id="profile-avatar-section">アイコン画像</h3>
+            <p class="profile-dialog__section-description">
+              正方形の画像をアップロードすると、中央を円形にトリミングして表示します。
+            </p>
+          </div>
+          <div class="profile-dialog__avatar">
+            <div
+              class="profile-dialog__avatar-preview"
+              [class.profile-dialog__avatar-preview--empty]="!avatarPreview()"
+            >
+              @if (avatarPreview(); as preview) {
+                <img [src]="preview" alt="選択中のアイコン" />
+              } @else {
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.6"
+                    fill="none"
+                    d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm-7 9a7 7 0 0 1 14 0"
+                  />
+                </svg>
+              }
+            </div>
+            <div class="profile-dialog__avatar-actions">
+              <input
+                #fileInput
+                type="file"
+                class="profile-dialog__file-input"
+                accept="image/png,image/jpeg,image/webp"
+                (change)="onAvatarChange($event)"
+              />
+              <button type="button" class="profile-dialog__button focus-ring" (click)="triggerAvatarPicker()">
+                画像を選択
+              </button>
+              @if (avatarSelected()) {
+                <button type="button" class="profile-dialog__link-button focus-ring" (click)="onAvatarRemove()">
+                  画像を削除
+                </button>
+              }
+            </div>
+            <p class="profile-dialog__hint">PNG / JPEG / WebP 形式、5MB 以内のファイルが利用できます。</p>
+          </div>
+        </section>
+
+        <section class="profile-dialog__section" aria-labelledby="profile-basic-section">
+          <div class="profile-dialog__section-header">
+            <h3 id="profile-basic-section">基本情報</h3>
+            <p class="profile-dialog__section-description">チームに表示される名前や経験年数を設定します。</p>
+          </div>
+          <div class="profile-dialog__grid">
+            <label class="profile-dialog__field" for="profile-nickname">
+              <span class="profile-dialog__label">ニックネーム <span class="profile-dialog__required">必須</span></span>
+              <input
+                id="profile-nickname"
+                type="text"
+                maxlength="60"
+                [value]="form.controls.nickname.value()"
+                (input)="onNicknameInput($event)"
+                class="profile-dialog__input"
+                [class.profile-dialog__input--invalid]="nicknameError()"
+                aria-required="true"
+                [attr.aria-invalid]="nicknameError() ? 'true' : null"
+                [attr.aria-describedby]="nicknameError() ? 'profile-nickname-error' : null"
+                autocomplete="name"
+              />
+              @if (nicknameError(); as nicknameMessage) {
+                <p id="profile-nickname-error" class="profile-dialog__error" aria-live="polite">
+                  {{ nicknameMessage }}
+                </p>
+              }
+            </label>
+
+            <label class="profile-dialog__field" for="profile-experience">
+              <span class="profile-dialog__label">経験年数</span>
+              <input
+                id="profile-experience"
+                type="number"
+                inputmode="numeric"
+                min="0"
+                max="50"
+                [value]="experienceDisplay()"
+                (input)="onExperienceInput($event)"
+                class="profile-dialog__input"
+                [class.profile-dialog__input--invalid]="experienceError()"
+                [attr.aria-invalid]="experienceError() ? 'true' : null"
+                [attr.aria-describedby]="experienceError() ? 'profile-experience-error' : null"
+              />
+              @if (experienceError(); as experienceMessage) {
+                <p id="profile-experience-error" class="profile-dialog__error" aria-live="polite">
+                  {{ experienceMessage }}
+                </p>
+              }
+            </label>
+          </div>
+        </section>
+
+        <section class="profile-dialog__section" aria-labelledby="profile-role-section">
+          <div class="profile-dialog__section-header">
+            <h3 id="profile-role-section">担当領域</h3>
+            <p class="profile-dialog__section-description">現在担当している業務内容を選択してください（最大5件）。</p>
+          </div>
+          <div class="profile-dialog__role-grid" role="group" aria-labelledby="profile-role-section">
+            @for (role of roleOptions; track role) {
+              <label class="profile-dialog__role-option">
+                <input
+                  type="checkbox"
+                  [checked]="form.controls.roles.value().includes(role)"
+                  (change)="onRoleToggle(role)"
+                />
+                <span>{{ role }}</span>
+              </label>
+            }
+          </div>
+          @if (rolesError(); as rolesMessage) {
+            <p class="profile-dialog__error" aria-live="assertive">{{ rolesMessage }}</p>
+          }
+        </section>
+
+        <section class="profile-dialog__section" aria-labelledby="profile-bio-section">
+          <div class="profile-dialog__section-header">
+            <h3 id="profile-bio-section">自己紹介</h3>
+            <p class="profile-dialog__section-description">得意分野や担当プロジェクトなどを自由に記載できます。</p>
+          </div>
+          <label class="profile-dialog__field" for="profile-bio">
+            <span class="profile-dialog__label">自己紹介（任意）</span>
+            <textarea
+              id="profile-bio"
+              rows="4"
+              maxlength="500"
+              [value]="form.controls.bio.value()"
+              (input)="onBioInput($event)"
+              class="profile-dialog__textarea"
+              [class.profile-dialog__textarea--invalid]="bioError()"
+              [attr.aria-invalid]="bioError() ? 'true' : null"
+              [attr.aria-describedby]="bioError() ? 'profile-bio-error' : null"
+            ></textarea>
+            <div class="profile-dialog__counter" aria-hidden="true">
+              {{ bioLength() }} / {{ maxBioLength }}
+            </div>
+            @if (bioError(); as bioMessage) {
+              <p id="profile-bio-error" class="profile-dialog__error" aria-live="polite">{{ bioMessage }}</p>
+            }
+          </label>
+        </section>
+
+        <section class="profile-dialog__section" aria-labelledby="profile-additional-section">
+          <div class="profile-dialog__section-header">
+            <h3 id="profile-additional-section">追加情報</h3>
+            <p class="profile-dialog__section-description">
+              拠点やポートフォリオURLを設定すると、メンバーが連絡を取りやすくなります。
+            </p>
+          </div>
+          <div class="profile-dialog__grid">
+            <label class="profile-dialog__field" for="profile-location">
+              <span class="profile-dialog__label">拠点（任意）</span>
+              <select
+                id="profile-location"
+                class="profile-dialog__select"
+                [value]="form.controls.location.value() || '未設定'"
+                (change)="onLocationChange($event)"
+              >
+                @for (location of locationOptions; track location) {
+                  <option [value]="location">{{ location }}</option>
+                }
+              </select>
+            </label>
+
+            <label class="profile-dialog__field" for="profile-portfolio">
+              <span class="profile-dialog__label">ポートフォリオURL（任意）</span>
+              <input
+                id="profile-portfolio"
+                type="url"
+                inputmode="url"
+                [value]="form.controls.portfolioUrl.value()"
+                (input)="onPortfolioInput($event)"
+                class="profile-dialog__input"
+                [class.profile-dialog__input--invalid]="portfolioError()"
+                [attr.aria-invalid]="portfolioError() ? 'true' : null"
+                [attr.aria-describedby]="portfolioError() ? 'profile-portfolio-error' : null"
+                placeholder="https://example.com"
+              />
+              @if (portfolioError(); as portfolioMessage) {
+                <p id="profile-portfolio-error" class="profile-dialog__error" aria-live="polite">
+                  {{ portfolioMessage }}
+                </p>
+              }
+            </label>
+          </div>
+        </section>
+
+        <footer class="profile-dialog__footer">
+          <button type="button" class="profile-dialog__button-secondary focus-ring" (click)="onCancelClick()">
+            キャンセル
+          </button>
+          <button
+            type="submit"
+            class="profile-dialog__button-primary focus-ring"
+            [disabled]="!canSubmit()"
+            [attr.aria-disabled]="!canSubmit() ? 'true' : null"
+          >
+            @if (saving()) {
+              <span class="profile-dialog__spinner" aria-hidden="true"></span>
+              保存中…
+            } @else {
+              保存する
+            }
+          </button>
+        </footer>
+      </form>
+    }
+  </article>
+</div>

--- a/frontend/src/app/core/profile/profile-dialog.scss
+++ b/frontend/src/app/core/profile/profile-dialog.scss
@@ -1,0 +1,448 @@
+.profile-dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.profile-dialog__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(6px);
+}
+
+.profile-dialog__panel {
+  position: relative;
+  z-index: 1;
+  width: min(48rem, 100%);
+  max-height: calc(100vh - 3rem);
+  overflow-y: auto;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.94));
+  box-shadow:
+    0 24px 60px -35px rgba(37, 99, 235, 0.45),
+    0 18px 36px -28px rgba(15, 23, 42, 0.38);
+  padding: 2.25rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+:host-context(.dark) .profile-dialog__panel {
+  border-color: rgba(148, 163, 184, 0.28);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.86));
+  box-shadow:
+    0 24px 60px -32px rgba(15, 23, 42, 0.8),
+    0 18px 36px -28px rgba(37, 99, 235, 0.45);
+}
+
+.profile-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.profile-dialog__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(71, 85, 105, 0.85);
+  margin-bottom: 0.35rem;
+}
+
+.profile-dialog__title {
+  font-size: 1.65rem;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.92);
+  margin: 0;
+}
+
+.profile-dialog__description {
+  margin-top: 0.35rem;
+  color: rgba(71, 85, 105, 0.92);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+:host-context(.dark) .profile-dialog__eyebrow {
+  color: rgba(203, 213, 225, 0.72);
+}
+
+:host-context(.dark) .profile-dialog__title {
+  color: rgba(241, 245, 249, 0.96);
+}
+
+:host-context(.dark) .profile-dialog__description {
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.profile-dialog__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.5rem;
+  width: 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(255, 255, 255, 0.85);
+  color: rgba(30, 41, 59, 0.8);
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.profile-dialog__close:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px -28px rgba(37, 99, 235, 0.35);
+}
+
+:host-context(.dark) .profile-dialog__close {
+  border-color: rgba(148, 163, 184, 0.32);
+  background: rgba(30, 41, 59, 0.9);
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.profile-dialog__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 0;
+  font-size: 1rem;
+  color: rgba(71, 85, 105, 0.9);
+}
+
+.profile-dialog__form {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.profile-dialog__alert {
+  border-radius: 1rem;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  background: rgba(254, 242, 242, 0.85);
+  padding: 0.9rem 1rem;
+  color: rgba(153, 27, 27, 0.88);
+  font-size: 0.9rem;
+}
+
+:host-context(.dark) .profile-dialog__alert {
+  border-color: rgba(248, 113, 113, 0.45);
+  background: rgba(69, 10, 10, 0.65);
+  color: rgba(252, 231, 243, 0.92);
+}
+
+.profile-dialog__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-dialog__section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.profile-dialog__section-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(30, 41, 59, 0.92);
+}
+
+.profile-dialog__section-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(71, 85, 105, 0.85);
+  line-height: 1.5;
+}
+
+:host-context(.dark) .profile-dialog__section-header h3 {
+  color: rgba(226, 232, 240, 0.95);
+}
+
+:host-context(.dark) .profile-dialog__section-description {
+  color: rgba(203, 213, 225, 0.75);
+}
+
+.profile-dialog__avatar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.profile-dialog__avatar-preview {
+  width: 6rem;
+  height: 6rem;
+  border-radius: 9999px;
+  overflow: hidden;
+  border: 3px solid rgba(37, 99, 235, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.3), rgba(129, 140, 248, 0.35));
+  color: rgba(30, 41, 59, 0.65);
+}
+
+.profile-dialog__avatar-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-dialog__avatar-preview svg {
+  width: 2.4rem;
+  height: 2.4rem;
+}
+
+.profile-dialog__avatar-preview--empty {
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.profile-dialog__avatar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.profile-dialog__file-input {
+  display: none;
+}
+
+.profile-dialog__button,
+.profile-dialog__button-secondary,
+.profile-dialog__button-primary,
+.profile-dialog__link-button {
+  font-size: 0.9rem;
+  font-weight: 600;
+  border-radius: 0.9rem;
+  padding: 0.6rem 1.1rem;
+  transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease,
+    color 150ms ease;
+}
+
+.profile-dialog__button {
+  border: 1px solid rgba(59, 130, 246, 0.5);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(59, 130, 246, 0.35));
+  color: rgba(37, 99, 235, 0.95);
+}
+
+.profile-dialog__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px -24px rgba(37, 99, 235, 0.4);
+}
+
+.profile-dialog__link-button {
+  border: none;
+  background: none;
+  color: rgba(37, 99, 235, 0.9);
+  padding-inline: 0;
+}
+
+.profile-dialog__link-button:hover {
+  text-decoration: underline;
+}
+
+.profile-dialog__hint {
+  font-size: 0.78rem;
+  color: rgba(100, 116, 139, 0.85);
+}
+
+:host-context(.dark) .profile-dialog__hint {
+  color: rgba(203, 213, 225, 0.7);
+}
+
+.profile-dialog__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 1.25rem;
+}
+
+.profile-dialog__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.profile-dialog__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(30, 41, 59, 0.85);
+}
+
+.profile-dialog__required {
+  margin-left: 0.35rem;
+  font-size: 0.75rem;
+  color: rgba(239, 68, 68, 0.9);
+  font-weight: 600;
+}
+
+.profile-dialog__input,
+.profile-dialog__select,
+.profile-dialog__textarea {
+  width: 100%;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.95);
+  padding: 0.7rem 0.9rem;
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.9);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+:host-context(.dark) .profile-dialog__input,
+:host-context(.dark) .profile-dialog__select,
+:host-context(.dark) .profile-dialog__textarea {
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(148, 163, 184, 0.38);
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.profile-dialog__input:focus,
+.profile-dialog__select:focus,
+.profile-dialog__textarea:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+
+.profile-dialog__textarea {
+  resize: vertical;
+  min-height: 7rem;
+}
+
+.profile-dialog__input--invalid,
+.profile-dialog__textarea--invalid {
+  border-color: rgba(239, 68, 68, 0.6);
+}
+
+.profile-dialog__error {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(220, 38, 38, 0.85);
+}
+
+.profile-dialog__role-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: 0.8rem;
+}
+
+.profile-dialog__role-option {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(255, 255, 255, 0.85);
+  color: rgba(30, 41, 59, 0.85);
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.profile-dialog__role-option input {
+  accent-color: var(--accent, #2563eb);
+}
+
+.profile-dialog__role-option:hover {
+  border-color: rgba(37, 99, 235, 0.45);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.profile-dialog__counter {
+  font-size: 0.78rem;
+  text-align: right;
+  color: rgba(100, 116, 139, 0.75);
+}
+
+.profile-dialog__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.9rem;
+  padding-top: 0.5rem;
+}
+
+.profile-dialog__button-secondary {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.9);
+  color: rgba(30, 41, 59, 0.85);
+}
+
+.profile-dialog__button-secondary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px -24px rgba(15, 23, 42, 0.35);
+}
+
+.profile-dialog__button-primary {
+  border: none;
+  background: linear-gradient(135deg, var(--accent, #2563eb), var(--accent-strong, #1d4ed8));
+  color: var(--on-surface-inverse, #fff);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.profile-dialog__button-primary:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.profile-dialog__spinner {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-top-color: rgba(255, 255, 255, 0.1);
+  animation: profile-dialog-spin 900ms linear infinite;
+}
+
+@keyframes profile-dialog-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 768px) {
+  .profile-dialog {
+    padding: 1rem;
+  }
+
+  .profile-dialog__panel {
+    width: 100%;
+    padding: 1.75rem;
+    border-radius: 1.25rem;
+  }
+
+  .profile-dialog__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .profile-dialog__avatar {
+    align-items: center;
+  }
+
+  .profile-dialog__footer {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .profile-dialog__button-secondary,
+  .profile-dialog__button-primary {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/frontend/src/app/core/profile/profile-dialog.ts
+++ b/frontend/src/app/core/profile/profile-dialog.ts
@@ -1,0 +1,529 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Output,
+  ViewChild,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { firstValueFrom } from 'rxjs';
+
+import { createSignalForm } from '@lib/forms/signal-forms';
+
+import { ProfileFormState, ProfileUpdatePayload, UserProfile } from './profile.models';
+import { ProfileService } from './profile.service';
+
+const ROLE_OPTIONS: readonly string[] = [
+  'Java',
+  'フロント',
+  'バックエンド',
+  'PMO',
+  'インフラ',
+  'QA',
+  'データ分析',
+  'その他',
+];
+
+const LOCATION_OPTIONS: readonly string[] = [
+  '未設定',
+  '北海道',
+  '青森県',
+  '岩手県',
+  '宮城県',
+  '秋田県',
+  '山形県',
+  '福島県',
+  '茨城県',
+  '栃木県',
+  '群馬県',
+  '埼玉県',
+  '千葉県',
+  '東京都',
+  '神奈川県',
+  '新潟県',
+  '富山県',
+  '石川県',
+  '福井県',
+  '山梨県',
+  '長野県',
+  '岐阜県',
+  '静岡県',
+  '愛知県',
+  '三重県',
+  '滋賀県',
+  '京都府',
+  '大阪府',
+  '兵庫県',
+  '奈良県',
+  '和歌山県',
+  '鳥取県',
+  '島根県',
+  '岡山県',
+  '広島県',
+  '山口県',
+  '徳島県',
+  '香川県',
+  '愛媛県',
+  '高知県',
+  '福岡県',
+  '佐賀県',
+  '長崎県',
+  '熊本県',
+  '大分県',
+  '宮崎県',
+  '鹿児島県',
+  '沖縄県',
+  '海外',
+];
+
+const MAX_NICKNAME_LENGTH = 30;
+const MAX_BIO_LENGTH = 500;
+const MAX_PORTFOLIO_LENGTH = 255;
+const MAX_EXPERIENCE_YEARS = 50;
+const MAX_ROLES = 5;
+const ALLOWED_AVATAR_TYPES = ['image/png', 'image/jpeg', 'image/webp'] as const;
+const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
+
+@Component({
+  selector: 'app-profile-dialog',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './profile-dialog.html',
+  styleUrl: './profile-dialog.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProfileDialogComponent implements AfterViewInit {
+  @Output() public readonly dismiss = new EventEmitter<void>();
+  @Output() public readonly profileSaved = new EventEmitter<UserProfile>();
+
+  @ViewChild('panel', { static: true }) private readonly panel?: ElementRef<HTMLDivElement>;
+  @ViewChild('fileInput') private readonly fileInput?: ElementRef<HTMLInputElement>;
+
+  private readonly profileService = inject(ProfileService);
+
+  public readonly roleOptions = ROLE_OPTIONS;
+  public readonly locationOptions = LOCATION_OPTIONS;
+  public readonly maxBioLength = MAX_BIO_LENGTH;
+
+  public readonly form = createSignalForm<ProfileFormState>({
+    nickname: '',
+    experienceYears: null,
+    roles: [],
+    bio: '',
+    location: '',
+    portfolioUrl: '',
+  });
+
+  private readonly loadingStore = signal(true);
+  private readonly savingStore = signal(false);
+  private readonly errorStore = signal<string | null>(null);
+  private readonly roleErrorStore = signal<string | null>(null);
+  private readonly nicknameTouched = signal(false);
+  private readonly experienceTouched = signal(false);
+  private readonly bioTouched = signal(false);
+  private readonly portfolioTouched = signal(false);
+  private readonly initialValueStore = signal<ProfileFormState | null>(null);
+  private readonly avatarPreviewStore = signal<string | null>(null);
+  private readonly avatarFileStore = signal<File | null>(null);
+  private readonly removeAvatarStore = signal(false);
+
+  public readonly loading = computed(() => this.loadingStore());
+  public readonly saving = computed(() => this.savingStore());
+  public readonly error = computed(() => this.errorStore());
+  public readonly rolesError = computed(() => this.roleErrorStore());
+  public readonly avatarPreview = computed(() => this.avatarPreviewStore());
+  public readonly avatarSelected = computed(
+    () => this.avatarFileStore() !== null || this.avatarPreviewStore() !== null,
+  );
+
+  public readonly nicknameError = computed(() => {
+    if (!this.nicknameTouched()) {
+      return null;
+    }
+
+    const value = this.form.controls.nickname.value().trim();
+    if (!value) {
+      return 'ニックネームを入力してください。';
+    }
+    if (value.length > MAX_NICKNAME_LENGTH) {
+      return `ニックネームは${MAX_NICKNAME_LENGTH}文字以内で入力してください。`;
+    }
+    return null;
+  });
+
+  public readonly experienceError = computed(() => {
+    if (!this.experienceTouched()) {
+      return null;
+    }
+
+    const value = this.form.controls.experienceYears.value();
+    if (value === null) {
+      return null;
+    }
+
+    if (!Number.isInteger(value) || value < 0 || value > MAX_EXPERIENCE_YEARS) {
+      return `経験年数は0から${MAX_EXPERIENCE_YEARS}の整数で入力してください。`;
+    }
+
+    return null;
+  });
+
+  public readonly bioError = computed(() => {
+    if (!this.bioTouched()) {
+      return null;
+    }
+
+    const length = this.form.controls.bio.value().trim().length;
+    if (length > MAX_BIO_LENGTH) {
+      return `自己紹介は${MAX_BIO_LENGTH}文字以内で入力してください。`;
+    }
+    return null;
+  });
+
+  public readonly portfolioError = computed(() => {
+    if (!this.portfolioTouched()) {
+      return null;
+    }
+
+    const value = this.form.controls.portfolioUrl.value().trim();
+    if (!value) {
+      return null;
+    }
+
+    if (value.length > MAX_PORTFOLIO_LENGTH) {
+      return `ポートフォリオURLは${MAX_PORTFOLIO_LENGTH}文字以内で入力してください。`;
+    }
+
+    try {
+      const url = new URL(value);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return 'ポートフォリオURLは http または https で始まる必要があります。';
+      }
+    } catch {
+      return '有効なURLを入力してください。';
+    }
+
+    return null;
+  });
+
+  public readonly hasValidationErrors = computed(
+    () =>
+      Boolean(
+        this.nicknameError() ||
+          this.experienceError() ||
+          this.bioError() ||
+          this.portfolioError() ||
+          this.rolesError(),
+      ),
+  );
+
+  public readonly experienceDisplay = computed(() => {
+    const value = this.form.controls.experienceYears.value();
+    return value === null ? '' : String(value);
+  });
+
+  public readonly bioLength = computed(() => this.form.controls.bio.value().trim().length);
+
+  public readonly isDirty = computed(() => {
+    const initial = this.initialValueStore();
+    if (!initial) {
+      return false;
+    }
+
+    const current = this.form.value();
+    if (initial.nickname !== current.nickname) {
+      return true;
+    }
+    if (initial.experienceYears !== current.experienceYears) {
+      return true;
+    }
+    if (initial.bio !== current.bio) {
+      return true;
+    }
+    if (initial.location !== current.location) {
+      return true;
+    }
+    if (initial.portfolioUrl !== current.portfolioUrl) {
+      return true;
+    }
+    if (!this.areRolesEqual(initial.roles, current.roles)) {
+      return true;
+    }
+    if (this.avatarFileStore() !== null) {
+      return true;
+    }
+    if (this.removeAvatarStore()) {
+      return true;
+    }
+    return false;
+  });
+
+  public readonly canSubmit = computed(
+    () => !this.loading() && !this.saving() && this.isDirty() && !this.hasValidationErrors(),
+  );
+
+  public constructor() {
+    void this.loadProfile();
+  }
+
+  public ngAfterViewInit(): void {
+    queueMicrotask(() => {
+      this.panel?.nativeElement.focus();
+    });
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  public onKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Escape') {
+      return;
+    }
+
+    event.preventDefault();
+    this.handleDismissRequest();
+  }
+
+  public onBackdropClick(): void {
+    this.handleDismissRequest();
+  }
+
+  public onCancelClick(): void {
+    this.handleDismissRequest();
+  }
+
+  public async onSubmit(event: Event): Promise<void> {
+    event.preventDefault();
+    this.nicknameTouched.set(true);
+    this.experienceTouched.set(true);
+    this.bioTouched.set(true);
+    this.portfolioTouched.set(true);
+    this.errorStore.set(null);
+
+    if (!this.canSubmit()) {
+      if (this.hasValidationErrors()) {
+        this.errorStore.set('入力内容に誤りがあります。赤字の項目を修正してください。');
+      }
+      return;
+    }
+
+    const value = this.form.value();
+    const payload: ProfileUpdatePayload = {
+      nickname: value.nickname.trim(),
+      experienceYears: value.experienceYears,
+      roles: [...value.roles],
+      bio: value.bio,
+      location: value.location,
+      portfolioUrl: value.portfolioUrl,
+      removeAvatar: this.removeAvatarStore(),
+      avatarFile: this.avatarFileStore(),
+    };
+
+    this.savingStore.set(true);
+
+    try {
+      const profile = await firstValueFrom(this.profileService.update(payload));
+      this.applyProfile(profile);
+      this.profileSaved.emit(profile);
+      this.dismiss.emit();
+    } catch (error) {
+      console.error(error);
+      this.errorStore.set('プロフィールの更新に失敗しました。時間をおいて再度お試しください。');
+    } finally {
+      this.savingStore.set(false);
+    }
+  }
+
+  public onNicknameInput(event: Event): void {
+    this.nicknameTouched.set(true);
+    this.errorStore.set(null);
+    const target = event.target as HTMLInputElement | null;
+    const value = target?.value ?? '';
+    this.form.controls.nickname.setValue(value);
+  }
+
+  public onExperienceInput(event: Event): void {
+    this.experienceTouched.set(true);
+    const target = event.target as HTMLInputElement | null;
+    const raw = target?.value ?? '';
+    if (raw === '') {
+      this.form.controls.experienceYears.setValue(null);
+      return;
+    }
+
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed)) {
+      this.form.controls.experienceYears.setValue(null);
+      return;
+    }
+
+    this.form.controls.experienceYears.setValue(parsed);
+  }
+
+  public onBioInput(event: Event): void {
+    this.bioTouched.set(true);
+    const target = event.target as HTMLTextAreaElement | null;
+    const value = target?.value ?? '';
+    this.form.controls.bio.setValue(value);
+  }
+
+  public onLocationChange(event: Event): void {
+    const target = event.target as HTMLSelectElement | null;
+    const value = target?.value ?? '';
+    this.form.controls.location.setValue(value === '未設定' ? '' : value);
+  }
+
+  public onPortfolioInput(event: Event): void {
+    this.portfolioTouched.set(true);
+    const target = event.target as HTMLInputElement | null;
+    const value = target?.value ?? '';
+    this.form.controls.portfolioUrl.setValue(value);
+  }
+
+  public onRoleToggle(role: string): void {
+    const roles = this.form.controls.roles.value();
+    if (roles.includes(role)) {
+      const filtered = roles.filter((item) => item !== role);
+      this.form.controls.roles.setValue(filtered);
+      this.roleErrorStore.set(null);
+      return;
+    }
+
+    if (roles.length >= MAX_ROLES) {
+      this.roleErrorStore.set(`業務内容は最大${MAX_ROLES}件まで選択できます。`);
+      return;
+    }
+
+    this.roleErrorStore.set(null);
+    this.form.controls.roles.setValue([...roles, role]);
+  }
+
+  public triggerAvatarPicker(): void {
+    this.errorStore.set(null);
+    this.fileInput?.nativeElement.click();
+  }
+
+  public async onAvatarChange(event: Event): Promise<void> {
+    const target = event.target as HTMLInputElement | null;
+    const file = target?.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (!ALLOWED_AVATAR_TYPES.includes(file.type as (typeof ALLOWED_AVATAR_TYPES)[number])) {
+      this.errorStore.set('アイコン画像は PNG / JPEG / WebP 形式のファイルを選択してください。');
+      this.resetFileInput();
+      return;
+    }
+
+    if (file.size > MAX_AVATAR_BYTES) {
+      this.errorStore.set('アイコン画像は5MB以内のファイルを選択してください。');
+      this.resetFileInput();
+      return;
+    }
+
+    try {
+      const preview = await this.readFile(file);
+      this.avatarFileStore.set(file);
+      this.removeAvatarStore.set(false);
+      this.avatarPreviewStore.set(preview);
+      this.resetFileInput();
+    } catch {
+      this.errorStore.set('画像の読み込みに失敗しました。別のファイルをお試しください。');
+    }
+  }
+
+  public onAvatarRemove(): void {
+    this.avatarFileStore.set(null);
+    this.avatarPreviewStore.set(null);
+    this.removeAvatarStore.set(true);
+    this.resetFileInput();
+  }
+
+  private async loadProfile(): Promise<void> {
+    this.loadingStore.set(true);
+    this.errorStore.set(null);
+    try {
+      const profile = await firstValueFrom(this.profileService.fetch());
+      this.applyProfile(profile);
+    } catch (error) {
+      console.error(error);
+      this.errorStore.set('プロフィール情報の取得に失敗しました。時間をおいて再度お試しください。');
+    } finally {
+      this.loadingStore.set(false);
+    }
+  }
+
+  private applyProfile(profile: UserProfile): void {
+    const state: ProfileFormState = {
+      nickname: profile.nickname ?? '',
+      experienceYears: profile.experience_years ?? null,
+      roles: [...profile.roles],
+      bio: profile.bio ?? '',
+      location: profile.location ?? '',
+      portfolioUrl: profile.portfolio_url ?? '',
+    };
+
+    this.form.reset({ ...state, roles: [...state.roles] });
+    this.initialValueStore.set({ ...state, roles: [...state.roles] });
+    this.avatarPreviewStore.set(profile.avatar_url);
+    this.avatarFileStore.set(null);
+    this.removeAvatarStore.set(false);
+    this.nicknameTouched.set(false);
+    this.experienceTouched.set(false);
+    this.bioTouched.set(false);
+    this.portfolioTouched.set(false);
+    this.roleErrorStore.set(null);
+  }
+
+  private handleDismissRequest(): void {
+    if (this.saving()) {
+      return;
+    }
+
+    if (this.isDirty()) {
+      if (typeof window !== 'undefined') {
+        const confirmed = window.confirm('保存されていない変更があります。破棄して閉じますか？');
+        if (!confirmed) {
+          return;
+        }
+      }
+    }
+
+    this.dismiss.emit();
+  }
+
+  private areRolesEqual(first: readonly string[], second: readonly string[]): boolean {
+    if (first.length !== second.length) {
+      return false;
+    }
+
+    return first.every((role, index) => role === second[index]);
+  }
+
+  private resetFileInput(): void {
+    if (!this.fileInput) {
+      return;
+    }
+
+    this.fileInput.nativeElement.value = '';
+  }
+
+  private async readFile(file: File): Promise<string> {
+    return await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        resolve(typeof reader.result === 'string' ? reader.result : '');
+      };
+      reader.onerror = (event) => {
+        console.error(event);
+        reject(event);
+      };
+      reader.readAsDataURL(file);
+    });
+  }
+}

--- a/frontend/src/app/core/profile/profile.models.ts
+++ b/frontend/src/app/core/profile/profile.models.ts
@@ -2,7 +2,7 @@ import { AuthenticatedUser } from '@core/models/auth';
 
 export type UserProfile = AuthenticatedUser;
 
-export interface ProfileFormState {
+export interface ProfileFormState extends Record<string, unknown> {
   readonly nickname: string;
   readonly experienceYears: number | null;
   readonly roles: readonly string[];

--- a/frontend/src/app/core/profile/profile.models.ts
+++ b/frontend/src/app/core/profile/profile.models.ts
@@ -1,0 +1,17 @@
+import { AuthenticatedUser } from '@core/models/auth';
+
+export type UserProfile = AuthenticatedUser;
+
+export interface ProfileFormState {
+  readonly nickname: string;
+  readonly experienceYears: number | null;
+  readonly roles: readonly string[];
+  readonly bio: string;
+  readonly location: string;
+  readonly portfolioUrl: string;
+}
+
+export interface ProfileUpdatePayload extends ProfileFormState {
+  readonly removeAvatar: boolean;
+  readonly avatarFile: File | null;
+}

--- a/frontend/src/app/core/profile/profile.service.ts
+++ b/frontend/src/app/core/profile/profile.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { buildApiUrl } from '@core/api/api.config';
+
+import { ProfileUpdatePayload, UserProfile } from './profile.models';
+
+@Injectable({ providedIn: 'root' })
+export class ProfileService {
+  private readonly http = inject(HttpClient);
+
+  public fetch(): Observable<UserProfile> {
+    return this.http.get<UserProfile>(buildApiUrl('/profile/me'));
+  }
+
+  public update(payload: ProfileUpdatePayload): Observable<UserProfile> {
+    const formData = new FormData();
+
+    formData.append('nickname', payload.nickname.trim());
+
+    if (payload.experienceYears !== null) {
+      formData.append('experience_years', String(payload.experienceYears));
+    }
+
+    if (payload.roles.length > 0) {
+      formData.append('roles', JSON.stringify(payload.roles));
+    }
+
+    const bio = payload.bio.trim();
+    if (bio) {
+      formData.append('bio', bio);
+    }
+
+    const location = payload.location.trim();
+    if (location) {
+      formData.append('location', location);
+    }
+
+    const portfolioUrl = payload.portfolioUrl.trim();
+    if (portfolioUrl) {
+      formData.append('portfolio_url', portfolioUrl);
+    }
+
+    if (payload.removeAvatar) {
+      formData.append('remove_avatar', 'true');
+    }
+
+    if (payload.avatarFile) {
+      formData.append('avatar', payload.avatarFile, payload.avatarFile.name);
+    }
+
+    return this.http.put<UserProfile>(buildApiUrl('/profile/me'), formData);
+  }
+}


### PR DESCRIPTION
## Summary
- add backend profile endpoints that validate updates, store avatars, and expose profile data via `/profile/me`
- extend migrations, models, and auth flows so avatar binaries and profile metadata persist in the database
- implement Angular profile dialog launched from the header with avatar preview, validation, and toast feedback

## Testing
- pytest
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d33b4327608320b15c72aa73e0c61f