### PR TITLE
Include engineer profile metadata in analysis prompts

### DIFF
--- a/backend/app/routers/analysis.py
+++ b/backend/app/routers/analysis.py
@@ -1,17 +1,25 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 
+from .. import models
+from ..auth import get_current_user
 from ..schemas import AnalysisRequest, AnalysisResponse
 from ..services.chatgpt import ChatGPTClient, ChatGPTError, get_chatgpt_client
+from ..services.profile import build_user_profile
 
 router = APIRouter(prefix="/analysis", tags=["analysis"])
 
 
 @router.post("", response_model=AnalysisResponse)
-def analyze(payload: AnalysisRequest, chatgpt: ChatGPTClient = Depends(get_chatgpt_client)) -> AnalysisResponse:
+def analyze(
+    payload: AnalysisRequest,
+    chatgpt: ChatGPTClient = Depends(get_chatgpt_client),
+    current_user: models.User = Depends(get_current_user),
+) -> AnalysisResponse:
     """Analyze free-form text and return structured card proposals."""
 
+    profile = build_user_profile(current_user)
     try:
-        return chatgpt.analyze(payload)
+        return chatgpt.analyze(payload, user_profile=profile)
     except ChatGPTError as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/backend/tests/test_analysis.py
+++ b/backend/tests/test_analysis.py
@@ -6,14 +6,33 @@ from fastapi.testclient import TestClient
 from app.config import settings
 
 
+def _register_and_login(client: TestClient, email: str) -> dict[str, str]:
+    password = "Analysis123!"  # noqa: S105 - test credential
+    register = client.post(
+        "/auth/register",
+        json={"email": email, "password": password},
+    )
+    assert register.status_code == 201, register.text
+
+    login = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert login.status_code == 200, login.text
+    token = login.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
 @pytest.mark.skipif(
     bool(settings.chatgpt_api_key),
     reason="requires analysis endpoint to be disabled",
 )
 def test_analysis_requires_api_key(client: TestClient) -> None:
+    headers = _register_and_login(client, "analysis-user@example.com")
     response = client.post(
         "/analysis",
         json={"text": "Implement login flow", "max_cards": 1},
+        headers=headers,
     )
 
     assert response.status_code == 503

--- a/backend/tests/test_cards.py
+++ b/backend/tests/test_cards.py
@@ -137,12 +137,14 @@ def test_subtask_crud_flow(client: TestClient) -> None:
 
 
 def test_analysis_endpoint(client: TestClient) -> None:
+    headers = register_and_login(client, "analysis@example.com")
     response = client.post(
         "/analysis",
         json={
             "text": "Fix login bug by adding tests. Also plan feature launch roadmap.",
             "max_cards": 2,
         },
+        headers=headers,
     )
 
     if settings.chatgpt_api_key:
@@ -175,10 +177,7 @@ def test_card_creation_daily_limit(client: TestClient) -> None:
     )
 
     assert extra_response.status_code == 429
-    assert (
-        extra_response.json()["detail"]
-        == f"Daily card creation limit of {DEFAULT_CARD_DAILY_LIMIT} reached."
-    )
+    assert extra_response.json()["detail"] == f"Daily card creation limit of {DEFAULT_CARD_DAILY_LIMIT} reached."
 
 
 def test_cards_are_scoped_to_current_user(client: TestClient) -> None:
@@ -226,10 +225,7 @@ def test_card_creation_daily_limit(client: TestClient) -> None:
         headers=headers,
     )
     assert limit_response.status_code == 429
-    assert (
-        limit_response.json()["detail"]
-        == f"Daily card creation limit of {DEFAULT_CARD_DAILY_LIMIT} reached."
-    )
+    assert limit_response.json()["detail"] == f"Daily card creation limit of {DEFAULT_CARD_DAILY_LIMIT} reached."
 
 
 def test_status_and_label_scoping(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- include the engineer profile metadata in the ChatGPT analysis prompt so card proposals can be tailored to the requester
- require the analysis endpoint to authenticate and pass the current user profile through to the ChatGPT client
- extend the unit tests to cover the enriched prompt content and to authenticate before hitting the analysis API

## Testing
- ruff check backend/app/services/chatgpt.py backend/app/routers/analysis.py backend/tests/test_chatgpt_service.py backend/tests/test_analysis.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d34d64c72c8320b38a6bc8340d0221