### PR TITLE
Add competency evaluation history page for general users

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -35,6 +35,11 @@ export const appRoutes: Routes = [
         loadComponent: () => import('@features/analytics/page').then((mod) => mod.AnalyticsPage),
       },
       {
+        path: 'profile/evaluations',
+        loadComponent: () =>
+          import('@features/profile/evaluations/page').then((mod) => mod.ProfileEvaluationsPage),
+      },
+      {
         path: 'settings',
         loadComponent: () => import('@features/settings/page').then((mod) => mod.SettingsPage),
       },

--- a/frontend/src/app/core/api/competency-api.service.ts
+++ b/frontend/src/app/core/api/competency-api.service.ts
@@ -1,0 +1,27 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { CompetencyEvaluation } from '@core/models';
+
+import { buildApiUrl } from './api.config';
+
+/**
+ * API client for competency evaluation resources available to authenticated users.
+ */
+@Injectable({ providedIn: 'root' })
+export class CompetencyApiService {
+  private readonly http = inject(HttpClient);
+
+  /**
+   * Retrieves the competency evaluation history for the current user.
+   *
+   * @param limit Maximum number of evaluations to return. Defaults to 20, capped at the API layer.
+   */
+  public getMyEvaluations(limit?: number): Observable<CompetencyEvaluation[]> {
+    const params = limit ? { limit: limit.toString() } : undefined;
+    return this.http.get<CompetencyEvaluation[]>(buildApiUrl('/users/me/evaluations'), {
+      params,
+    });
+  }
+}

--- a/frontend/src/app/core/layout/shell/shell.ts
+++ b/frontend/src/app/core/layout/shell/shell.ts
@@ -96,6 +96,7 @@ export class Shell {
       { path: '/board', label: 'ボード' },
       { path: '/input', label: 'タスク起票' },
       { path: '/analytics', label: '分析' },
+      { path: '/profile/evaluations', label: 'コンピテンシー評価' },
       { path: '/settings', label: 'ワークスペース設定' },
     ];
 

--- a/frontend/src/app/features/analytics/page.html
+++ b/frontend/src/app/features/analytics/page.html
@@ -7,6 +7,30 @@
     </p>
   </header>
 
+  <div
+    class="flex flex-col gap-2 rounded-3xl border border-dashed border-subtle bg-white/70 px-4 py-4 text-sm text-slate-600 shadow-soft dark:bg-slate-900/60 dark:text-slate-300 lg:flex-row lg:items-center lg:justify-between"
+  >
+    <p class="leading-relaxed">
+      最新のコンピテンシー判定とあわせてボード分析を見ると、改善の優先度が整理しやすくなります。
+    </p>
+    <a
+      routerLink="/profile/evaluations"
+      class="focus-ring inline-flex items-center gap-2 self-start rounded-full bg-accent px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-on-surface-inverse transition hover:bg-accent-strong"
+    >
+      最新の評価を確認
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        class="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.8"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+      </svg>
+    </a>
+  </div>
+
   @if (summarySignal(); as summary) {
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <article class="surface-panel px-6 py-6">

--- a/frontend/src/app/features/analytics/page.ts
+++ b/frontend/src/app/features/analytics/page.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
 
 import { FeedbackSeverity } from '@core/models';
 import { ContinuousImprovementStore } from '@core/state/continuous-improvement-store';
@@ -11,7 +12,7 @@ import { WorkspaceStore } from '@core/state/workspace-store';
 @Component({
   selector: 'app-analytics-page',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterLink],
   templateUrl: './page.html',
   styleUrl: './page.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -28,6 +28,22 @@
             [style.width.%]="summary.progressRatio"
           ></div>
         </div>
+        <a
+          routerLink="/profile/evaluations"
+          class="focus-ring inline-flex items-center justify-center gap-2 self-start rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-accent shadow-soft transition hover:bg-accent-muted hover:text-accent-strong dark:bg-slate-900/60"
+        >
+          最新のコンピテンシー判定を確認
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            class="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </a>
       </section>
     }
     <div class="flex h-full min-w-0 flex-col gap-4">

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
+import { RouterLink } from '@angular/router';
 
 import { WorkspaceStore } from '@core/state/workspace-store';
 import {
@@ -99,7 +100,7 @@ const RESOLVED_SUBTASK_STATUSES = new Set<SubtaskStatus>(['done', 'non-issue']);
 @Component({
   selector: 'app-board-page',
   standalone: true,
-  imports: [CommonModule, DragDropModule],
+  imports: [CommonModule, DragDropModule, RouterLink],
   templateUrl: './page.html',
   styleUrl: './page.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/features/profile/evaluations/page.html
+++ b/frontend/src/app/features/profile/evaluations/page.html
@@ -1,0 +1,250 @@
+<section class="evaluations-page shell-container">
+  <header class="page-header">
+    <div class="page-header__content">
+      <p class="page-eyebrow">Competency Insights</p>
+      <h1 class="page-title">コンピテンシー評価の履歴</h1>
+      <p class="page-description">
+        直近のコンピテンシー判定とアクションプランを確認できます。姿勢面と行動面それぞれの推奨事項を振り返り、
+        次のスプリント計画に活用しましょう。
+      </p>
+    </div>
+    <div class="page-header__actions">
+      <button
+        type="button"
+        class="refresh-button focus-ring"
+        (click)="refresh()"
+        [disabled]="loading()"
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.8">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M4 4v5h5M20 20v-5h-5M5 14a7 7 0 0 1 12-4.9l2 1.9M19 10a7 7 0 0 1-12 4.9l-2-1.9"
+          />
+        </svg>
+        最新情報に更新
+      </button>
+      <a routerLink="/board" class="back-link focus-ring">ボードに戻る</a>
+    </div>
+  </header>
+
+  @if (loading()) {
+    <div class="state state--loading">
+      <span class="state__spinner" aria-hidden="true"></span>
+      <p>評価履歴を読み込んでいます…</p>
+    </div>
+  } @else {
+    @if (error(); as message) {
+      <div class="state state--error" role="alert">
+        <h2>取得に失敗しました</h2>
+        <p>{{ message }}</p>
+        <button type="button" class="retry-button focus-ring" (click)="refresh()">再試行する</button>
+      </div>
+    } @else {
+      @if (!hasEvaluations()) {
+        <div class="state state--empty">
+          <svg aria-hidden="true" viewBox="0 0 24 24" class="h-12 w-12 text-slate-400">
+            <path
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M12 3c3.866 0 7 3.134 7 7 0 2.93-1.877 5.42-4.5 6.4L12 21l-2.5-4.6C6.877 15.42 5 12.93 5 10c0-3.866 3.134-7 7-7Z"
+            />
+          </svg>
+          <h2>まだ評価はありません</h2>
+          <p>コンピテンシー評価が実行されると、ここに結果が表示されます。</p>
+        </div>
+      } @else {
+        @if (latestEvaluation(); as evaluation) {
+          <section class="latest surface-panel">
+            <header class="latest__header">
+              <div class="latest__summary">
+                <p class="latest__eyebrow">最新の評価</p>
+                <h2 class="latest__title">{{ evaluation.competency?.name || 'コンピテンシー評価' }}</h2>
+                <p class="latest__meta">
+                  評価期間
+                  <span>{{ evaluation.period_start | date: 'yyyy/MM/dd' }}</span>
+                  〜
+                  <span>{{ evaluation.period_end | date: 'yyyy/MM/dd' }}</span>
+                </p>
+                <p class="latest__meta">
+                  判定種別: {{ triggeredLabel(evaluation.triggered_by) }} / モデル: {{ evaluation.ai_model || '未設定' }}
+                </p>
+              </div>
+              <div class="latest__score" aria-label="評価スコア">
+                <div class="latest__score-value">
+                  <span aria-hidden="true">{{ evaluation.score_value }}</span>
+                  <span class="latest__score-scale" aria-hidden="true">/ {{ evaluation.scale }}</span>
+                </div>
+                <p class="latest__score-label">{{ evaluation.score_label }}</p>
+                <p class="latest__score-percent">達成率 {{ scorePercent(evaluation) }}%</p>
+              </div>
+            </header>
+
+            <div class="latest__progress" role="presentation">
+              <div class="latest__progress-bar" [style.width.%]="scorePercent(evaluation)"></div>
+            </div>
+
+            <div class="latest__body">
+              @if (evaluation.rationale) {
+                <section class="latest__section">
+                  <h3>総合所見</h3>
+                  <p class="latest__text">{{ evaluation.rationale }}</p>
+                </section>
+              }
+
+              <section class="latest__actions-grid">
+                <article class="latest__action">
+                  <header>
+                    <h3>姿勢・意識面でのアクション</h3>
+                    <p>モチベーションやコミュニケーションの観点で意識したいポイントです。</p>
+                  </header>
+                  @if (hasActions(evaluation.attitude_actions)) {
+                    <ul>
+                      @for (action of evaluation.attitude_actions; track action) {
+                        <li>{{ action }}</li>
+                      }
+                    </ul>
+                  } @else {
+                    <p class="latest__empty">推奨事項は特にありません。</p>
+                  }
+                </article>
+                <article class="latest__action">
+                  <header>
+                    <h3>具体的な行動プラン</h3>
+                    <p>すぐに実行できるタスクや振り返りポイントをまとめています。</p>
+                  </header>
+                  @if (hasActions(evaluation.behavior_actions)) {
+                    <ul>
+                      @for (action of evaluation.behavior_actions; track action) {
+                        <li>{{ action }}</li>
+                      }
+                    </ul>
+                  } @else {
+                    <p class="latest__empty">特筆すべきアクションはありません。</p>
+                  }
+                </article>
+              </section>
+
+              @if (evaluation.items.length > 0) {
+                <section class="latest__details">
+                  <h3>評価項目の内訳</h3>
+                  <div class="latest__items">
+                    @for (item of evaluation.items; track item.id; let index = $index) {
+                      <article class="latest__item surface-card">
+                        <header>
+                          <p class="latest__item-title">{{ '評価項目 ' + (index + 1) }}</p>
+                          <p class="latest__item-score">{{ item.score_label }} ({{ item.score_value }} 点)</p>
+                        </header>
+                        <div class="latest__item-body">
+                          <p class="latest__item-text">{{ item.rationale || '根拠メモは記録されていません。' }}</p>
+
+                          @if (hasActions(item.attitude_actions)) {
+                            <div class="latest__item-actions">
+                              <h4>姿勢・意識</h4>
+                              <ul>
+                                @for (action of item.attitude_actions; track action) {
+                                  <li>{{ action }}</li>
+                                }
+                              </ul>
+                            </div>
+                          }
+
+                          @if (hasActions(item.behavior_actions)) {
+                            <div class="latest__item-actions">
+                              <h4>行動プラン</h4>
+                              <ul>
+                                @for (action of item.behavior_actions; track action) {
+                                  <li>{{ action }}</li>
+                                }
+                              </ul>
+                            </div>
+                          }
+                        </div>
+                      </article>
+                    }
+                  </div>
+                </section>
+              }
+            </div>
+          </section>
+        }
+
+        <section class="history surface-panel">
+          <header class="history__header">
+            <div>
+              <h2>過去の評価履歴</h2>
+              <p>最大 12 件まで表示します。詳細を開いて改善ポイントを再確認できます。</p>
+            </div>
+            <span class="history__count">{{ evaluations().length }} 件表示中</span>
+          </header>
+
+          @if (history().length === 0) {
+            <p class="history__empty">最新の判定のみが登録されています。</p>
+          } @else {
+            <ul class="history__list">
+              @for (item of history(); track item.id) {
+                <li class="history__entry">
+                  <details>
+                    <summary>
+                      <div class="history__summary">
+                        <div class="history__summary-text">
+                          <span class="history__period"
+                            >{{ item.period_start | date: 'yyyy/MM/dd' }} 〜
+                            {{ item.period_end | date: 'yyyy/MM/dd' }}</span
+                          >
+                          <span class="history__label">{{ item.competency?.name || 'コンピテンシー評価' }}</span>
+                        </div>
+                        <div class="history__score">
+                          <span class="history__score-value">{{ item.score_value }}</span>
+                          <span class="history__score-scale">/ {{ item.scale }}</span>
+                          <span class="history__score-label">{{ item.score_label }}</span>
+                        </div>
+                      </div>
+                    </summary>
+                    <div class="history__content">
+                      @if (item.rationale) {
+                        <p class="history__text">{{ item.rationale }}</p>
+                      }
+                      <div class="history__meta">
+                        <span>判定種別: {{ triggeredLabel(item.triggered_by) }}</span>
+                        <span>モデル: {{ item.ai_model || '未設定' }}</span>
+                        <span>記録日時: {{ item.created_at | date: 'yyyy/MM/dd HH:mm' }}</span>
+                      </div>
+                      @if (hasActions(item.attitude_actions) || hasActions(item.behavior_actions)) {
+                        <div class="history__actions">
+                          @if (hasActions(item.attitude_actions)) {
+                            <div>
+                              <h4>姿勢・意識</h4>
+                              <ul>
+                                @for (action of item.attitude_actions; track action) {
+                                  <li>{{ action }}</li>
+                                }
+                              </ul>
+                            </div>
+                          }
+                          @if (hasActions(item.behavior_actions)) {
+                            <div>
+                              <h4>行動プラン</h4>
+                              <ul>
+                                @for (action of item.behavior_actions; track action) {
+                                  <li>{{ action }}</li>
+                                }
+                              </ul>
+                            </div>
+                          }
+                        </div>
+                      }
+                    </div>
+                  </details>
+                </li>
+              }
+            </ul>
+          }
+        </section>
+      }
+    }
+  }
+</section>

--- a/frontend/src/app/features/profile/evaluations/page.scss
+++ b/frontend/src/app/features/profile/evaluations/page.scss
@@ -1,0 +1,616 @@
+:host {
+  display: block;
+  padding: clamp(2rem, 5vw, 4rem) 0 clamp(3rem, 6vw, 5rem);
+}
+
+.evaluations-page {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.25rem, 3vw, 2rem);
+  border-radius: 2rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.05));
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  box-shadow: 0 24px 48px -32px rgba(37, 99, 235, 0.35);
+}
+
+:host-context(.dark) .page-header {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(14, 165, 233, 0.12));
+  border-color: rgba(96, 165, 250, 0.25);
+  box-shadow: 0 24px 48px -28px rgba(14, 165, 233, 0.4);
+}
+
+.page-header__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  max-width: 48rem;
+}
+
+.page-eyebrow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(37, 99, 235, 0.85);
+}
+
+:host-context(.dark) .page-eyebrow {
+  color: rgba(147, 197, 253, 0.9);
+}
+
+.page-title {
+  font-size: clamp(1.75rem, 2.5vw, 2.5rem);
+  font-weight: 700;
+  color: var(--on-surface);
+}
+
+.page-description {
+  font-size: 0.95rem;
+  line-height: 1.8;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+:host-context(.dark) .page-description {
+  color: rgba(226, 232, 240, 0.76);
+}
+
+.page-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.refresh-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.4rem;
+  border: 0;
+  border-radius: 9999px;
+  background: var(--accent);
+  color: var(--on-surface-inverse);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 160ms ease-in-out, transform 160ms ease-in-out;
+}
+
+.refresh-button:hover:not(:disabled) {
+  background: var(--accent-strong);
+  transform: translateY(-1px);
+}
+
+.refresh-button:disabled {
+  opacity: 0.65;
+  cursor: progress;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1.25rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  background: rgba(255, 255, 255, 0.85);
+  color: rgba(37, 99, 235, 0.9);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-decoration: none;
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.back-link:hover {
+  border-color: rgba(37, 99, 235, 0.55);
+  background: rgba(219, 234, 254, 0.85);
+  transform: translateY(-1px);
+}
+
+:host-context(.dark) .back-link {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(96, 165, 250, 0.35);
+  color: rgba(191, 219, 254, 0.95);
+}
+
+.state {
+  display: grid;
+  gap: 0.75rem;
+  place-items: center;
+  padding: 3rem 1.5rem;
+  border-radius: 1.75rem;
+  border: 2px dashed rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.65);
+  text-align: center;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+:host-context(.dark) .state {
+  background: rgba(15, 23, 42, 0.6);
+  border-color: rgba(148, 163, 184, 0.45);
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.state--error {
+  border-style: solid;
+  border-color: rgba(248, 113, 113, 0.6);
+  background: rgba(254, 226, 226, 0.55);
+  color: rgba(153, 27, 27, 0.9);
+}
+
+:host-context(.dark) .state--error {
+  background: rgba(127, 29, 29, 0.55);
+  border-color: rgba(254, 202, 202, 0.35);
+  color: rgba(254, 226, 226, 0.92);
+}
+
+.state__spinner {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 3px solid rgba(148, 163, 184, 0.35);
+  border-top-color: var(--accent);
+  animation: spin 1s linear infinite;
+}
+
+.retry-button {
+  padding: 0.65rem 1.4rem;
+  border-radius: 9999px;
+  border: 0;
+  background: var(--accent);
+  color: var(--on-surface-inverse);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.retry-button:hover {
+  background: var(--accent-strong);
+}
+
+.latest {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+}
+
+.latest__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .latest__header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 2rem;
+  }
+}
+
+.latest__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  color: rgba(71, 85, 105, 0.9);
+}
+
+:host-context(.dark) .latest__summary {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.latest__eyebrow {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(37, 99, 235, 0.8);
+}
+
+.latest__title {
+  font-size: clamp(1.6rem, 2.2vw, 2.2rem);
+  font-weight: 700;
+  color: var(--on-surface);
+}
+
+.latest__meta {
+  font-size: 0.85rem;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+:host-context(.dark) .latest__meta {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.latest__score {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.08));
+  color: rgba(37, 99, 235, 0.95);
+  text-align: right;
+  align-self: flex-start;
+}
+
+:host-context(.dark) .latest__score {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.18), rgba(37, 99, 235, 0.12));
+  color: rgba(191, 219, 254, 0.95);
+}
+
+.latest__score-value {
+  font-size: clamp(2.4rem, 3vw, 3rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.latest__score-scale {
+  margin-left: 0.15em;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.latest__score-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.latest__score-percent {
+  font-size: 0.8rem;
+  color: rgba(37, 99, 235, 0.8);
+}
+
+:host-context(.dark) .latest__score-percent {
+  color: rgba(191, 219, 254, 0.85);
+}
+
+.latest__progress {
+  position: relative;
+  height: 0.6rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.28);
+  overflow: hidden;
+}
+
+.latest__progress-bar {
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  background: linear-gradient(90deg, rgba(37, 99, 235, 0.9), rgba(59, 130, 246, 0.75));
+  transition: width 200ms ease-out;
+}
+
+.latest__body {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.latest__section h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.latest__text {
+  font-size: 0.95rem;
+  line-height: 1.8;
+  color: rgba(71, 85, 105, 0.9);
+}
+
+:host-context(.dark) .latest__text {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.latest__actions-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 840px) {
+  .latest__actions-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.latest__action {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  background: rgba(219, 234, 254, 0.35);
+}
+
+.latest__action h3 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.latest__action p {
+  font-size: 0.85rem;
+  color: rgba(71, 85, 105, 0.85);
+  line-height: 1.6;
+}
+
+.latest__action ul {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: 0.9rem;
+  color: var(--on-surface);
+}
+
+.latest__empty {
+  font-size: 0.85rem;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+:host-context(.dark) .latest__action {
+  background: rgba(37, 99, 235, 0.12);
+  border-color: rgba(96, 165, 250, 0.25);
+}
+
+.latest__details {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.latest__items {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .latest__items {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.latest__item {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.latest__item header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.latest__item-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--on-surface);
+}
+
+.latest__item-score {
+  font-size: 0.85rem;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.latest__item-text {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+:host-context(.dark) .latest__item-score,
+:host-context(.dark) .latest__item-text {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.latest__item-actions {
+  margin-top: 0.75rem;
+}
+
+.latest__item-actions h4 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.4rem;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.latest__item-actions ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.history {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.history__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+@media (min-width: 720px) {
+  .history__header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.history__header h2 {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.history__header p {
+  font-size: 0.9rem;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.history__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.9rem;
+  border-radius: 9999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: rgba(37, 99, 235, 0.85);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.history__empty {
+  padding: 1.25rem 1.5rem;
+  border-radius: 1.25rem;
+  border: 1px dashed rgba(148, 163, 184, 0.45);
+  background: rgba(248, 250, 252, 0.7);
+  color: rgba(71, 85, 105, 0.75);
+  font-size: 0.9rem;
+}
+
+.history__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.history__entry details {
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.85);
+  padding: 1.1rem 1.3rem;
+  box-shadow: 0 12px 36px -24px rgba(37, 99, 235, 0.25);
+}
+
+:host-context(.dark) .history__entry details {
+  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+.history__entry summary {
+  cursor: pointer;
+  display: block;
+  outline: none;
+}
+
+.history__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 720px) {
+  .history__summary {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.history__summary-text {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.history__period {
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  color: rgba(71, 85, 105, 0.75);
+  text-transform: uppercase;
+}
+
+.history__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--on-surface);
+}
+
+.history__score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  font-weight: 600;
+  color: rgba(37, 99, 235, 0.85);
+}
+
+.history__score-value {
+  font-size: 1.4rem;
+}
+
+.history__score-scale {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.history__score-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.history__content {
+  margin-top: 1rem;
+  display: grid;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: rgba(71, 85, 105, 0.8);
+}
+
+:host-context(.dark) .history__content {
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.history__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: rgba(71, 85, 105, 0.65);
+}
+
+.history__actions {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.history__actions h4 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.4rem;
+}
+
+.history__actions ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/app/features/profile/evaluations/page.ts
+++ b/frontend/src/app/features/profile/evaluations/page.ts
@@ -1,0 +1,103 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { RouterLink } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import { CompetencyApiService } from '@core/api/competency-api.service';
+import { CompetencyEvaluation } from '@core/models';
+
+const DEFAULT_HISTORY_LIMIT = 12;
+
+/**
+ * Page allowing end users to review their competency evaluation results.
+ */
+@Component({
+  selector: 'app-profile-evaluations-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './page.html',
+  styleUrl: './page.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProfileEvaluationsPage {
+  private readonly api = inject(CompetencyApiService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  public readonly evaluations = signal<CompetencyEvaluation[]>([]);
+  public readonly loading = signal<boolean>(false);
+  public readonly error = signal<string | null>(null);
+
+  public readonly latestEvaluation = computed<CompetencyEvaluation | null>(() => {
+    const [latest] = this.evaluations();
+    return latest ?? null;
+  });
+
+  public readonly history = computed<CompetencyEvaluation[]>(() => {
+    const [, ...history] = this.evaluations();
+    return history;
+  });
+
+  public readonly hasEvaluations = computed(() => this.evaluations().length > 0);
+
+  public constructor() {
+    this.loadEvaluations();
+  }
+
+  public refresh(): void {
+    this.loadEvaluations();
+  }
+
+  public scorePercent(evaluation: CompetencyEvaluation | null): number {
+    if (!evaluation || evaluation.scale <= 0) {
+      return 0;
+    }
+
+    return Math.round((evaluation.score_value / evaluation.scale) * 100);
+  }
+
+  public triggeredLabel(triggeredBy: string): string {
+    switch (triggeredBy) {
+      case 'auto':
+        return '自動判定';
+      case 'manual':
+        return '手動実行';
+      default:
+        return '不明な実行方法';
+    }
+  }
+
+  public hasActions(actions: readonly string[] | undefined | null): boolean {
+    return Array.isArray(actions) && actions.length > 0;
+  }
+
+  private loadEvaluations(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.api
+      .getMyEvaluations(DEFAULT_HISTORY_LIMIT)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (evaluations) => {
+          this.evaluations.set(evaluations);
+          this.loading.set(false);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.loading.set(false);
+          const message =
+            typeof error.error === 'object' && error.error?.detail
+              ? String(error.error.detail)
+              : 'コンピテンシー評価の取得に失敗しました。時間をおいて再度お試しください。';
+          this.error.set(message);
+        },
+      });
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared competency API client and lazy route for the user-facing evaluation history
- create the profile evaluations page with rationale, action items, and history styling for general users
- expose navigation and cross-links from the board and analytics views so users can open the new page quickly

## Testing
- npm run lint
- npm run format:check *(fails: repository contains existing Prettier issues in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d34f6c59b883208afaac1cb8cda025