### PR TITLE
Fix competency evaluation model duplication and update quotas

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -65,6 +65,9 @@ class User(Base, TimestampMixin):
     daily_card_quotas: Mapped[list["DailyCardQuota"]] = relationship(
         "DailyCardQuota", back_populates="owner", cascade="all, delete-orphan"
     )
+    daily_evaluation_quotas: Mapped[list["DailyEvaluationQuota"]] = relationship(
+        "DailyEvaluationQuota", back_populates="owner", cascade="all, delete-orphan"
+    )
     labels: Mapped[list["Label"]] = relationship(
         "Label", back_populates="owner", cascade="all, delete-orphan"
     )
@@ -85,6 +88,12 @@ class User(Base, TimestampMixin):
     )
     competency_evaluations: Mapped[list["CompetencyEvaluation"]] = relationship(
         "CompetencyEvaluation", back_populates="user", cascade="all, delete-orphan"
+    )
+    quota_override: Mapped[Optional["UserQuotaOverride"]] = relationship(
+        "UserQuotaOverride", back_populates="user", cascade="all, delete-orphan", uselist=False
+    )
+    api_credentials: Mapped[list["ApiCredential"]] = relationship(
+        "ApiCredential", back_populates="created_by_user", cascade="all, delete-orphan"
     )
 
 
@@ -149,21 +158,6 @@ class Card(Base, TimestampMixin):
     daily_report_links: Mapped[list["DailyReportCardLink"]] = relationship(
         "DailyReportCardLink", back_populates="card", cascade="all, delete-orphan"
     )
-
-
-class CompetencyEvaluation(Base, TimestampMixin):
-    __tablename__ = "competency_evaluations"
-
-    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
-    user_id: Mapped[str] = mapped_column(
-        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
-    competency_area: Mapped[str | None] = mapped_column(String)
-    evaluation_date: Mapped[date | None] = mapped_column(Date)
-    score: Mapped[float | None] = mapped_column(Float)
-    notes: Mapped[str | None] = mapped_column(Text)
-
-    user: Mapped[User] = relationship("User", back_populates="competency_evaluations")
 
 
 class DailyCardQuota(Base):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -93,7 +93,7 @@ class User(Base, TimestampMixin):
         "UserQuotaOverride", back_populates="user", cascade="all, delete-orphan", uselist=False
     )
     api_credentials: Mapped[list["ApiCredential"]] = relationship(
-        "ApiCredential", back_populates="created_by_user", cascade="all, delete-orphan"
+        "ApiCredential", back_populates="created_by_user"
     )
 
 

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -12,6 +12,7 @@ from .. import models, schemas
 from ..auth import get_current_user
 from ..database import get_db
 from ..services.card_limits import DAILY_CARD_CREATION_LIMIT, reserve_daily_card_quota
+from ..utils.quotas import get_card_daily_limit
 from ..utils.activity import record_activity
 
 _DAILY_CARD_LIMIT_MESSAGE = (

--- a/backend/app/services/profile.py
+++ b/backend/app/services/profile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import io
 import json
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -35,7 +36,15 @@ _MISSING_PILLOW_MESSAGE = "画像処理ライブラリ(Pillow)がインストー
 
 
 def build_user_profile(user: models.User) -> schemas.UserProfile:
-    return schemas.UserProfile.model_validate(user)
+    profile = schemas.UserProfile.model_validate(user)
+    avatar_bytes = getattr(user, "avatar_image", None)
+    avatar_mime = getattr(user, "avatar_mime_type", None)
+    if avatar_bytes and avatar_mime:
+        encoded = base64.b64encode(avatar_bytes).decode("ascii")
+        profile.avatar_url = f"data:{avatar_mime};base64,{encoded}"
+    else:
+        profile.avatar_url = None
+    return profile
 
 
 def _import_pillow() -> _PillowModules:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.110.0
-uvicorn[standard]==0.27.1
+uvicorn[standard]==0.31.1
 SQLAlchemy==2.0.43
 pydantic>=2.11.0,<3.0.0
 pydantic-settings>=2.10.1,<3.0.0


### PR DESCRIPTION
## Summary
- remove the redundant CompetencyEvaluation model definition and wire User relationships to the new quota tables
- pull in the card quota helper where it is used and emit data-URI avatar URLs from the profile builder
- bump uvicorn to 0.31.1 to satisfy mcp's minimum requirement

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d35ae0cd5883209d032c782dc42773