### PR TITLE
Refresh admin console styling for improved contrast

### DIFF
--- a/frontend/src/app/features/admin/page.scss
+++ b/frontend/src/app/features/admin/page.scss
@@ -1,108 +1,274 @@
+:host {
+  display: block;
+  padding: clamp(1.5rem, 2vw, 2.5rem) 0 4rem;
+  color: var(--on-surface);
+  --admin-muted: rgba(15, 23, 42, 0.65);
+  --admin-muted-strong: rgba(15, 23, 42, 0.78);
+  --admin-card-shadow: 0 18px 44px -32px rgba(37, 99, 235, 0.35);
+  --admin-panel-bg: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(14, 165, 233, 0.08));
+  --admin-subtle-bg: rgba(148, 163, 184, 0.12);
+  --admin-tabs-bg: rgba(255, 255, 255, 0.82);
+  --admin-tabs-shadow: 0 18px 40px -30px rgba(37, 99, 235, 0.28);
+}
+
+:host-context(.dark) {
+  --admin-muted: rgba(226, 232, 240, 0.68);
+  --admin-muted-strong: rgba(226, 232, 240, 0.82);
+  --admin-card-shadow: 0 24px 48px -28px rgba(15, 23, 42, 0.72);
+  --admin-panel-bg: linear-gradient(135deg, rgba(30, 41, 59, 0.94), rgba(15, 23, 42, 0.82));
+  --admin-subtle-bg: rgba(148, 163, 184, 0.14);
+  --admin-tabs-bg: rgba(15, 23, 42, 0.78);
+  --admin-tabs-shadow: 0 24px 48px -28px rgba(15, 23, 42, 0.75);
+}
+
 .admin-page {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(1.75rem, 2vw, 2.75rem);
+  isolation: isolate;
 }
 
 .admin-header {
+  position: relative;
+  z-index: 0;
+  overflow: hidden;
+  padding: clamp(2rem, 4vw, 2.75rem);
+  border-radius: 1.75rem;
+  border: 1px solid var(--border-subtle);
+  background: var(--admin-panel-bg);
+  box-shadow: var(--admin-card-shadow);
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.75rem;
+}
+
+.admin-header::before,
+.admin-header::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0.8;
+}
+
+.admin-header::before {
+  inset: auto auto -35% -12%;
+  width: clamp(16rem, 22vw, 24rem);
+  aspect-ratio: 1;
+  background: radial-gradient(circle at center, rgba(37, 99, 235, 0.18), transparent 65%);
+}
+
+.admin-header::after {
+  inset: -45% -18% auto auto;
+  width: clamp(14rem, 20vw, 22rem);
+  aspect-ratio: 1;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.18), transparent 70%);
+}
+
+:host-context(.dark) .admin-header::before {
+  background: radial-gradient(circle at center, rgba(96, 165, 250, 0.32), transparent 68%);
+}
+
+:host-context(.dark) .admin-header::after {
+  background: radial-gradient(circle at center, rgba(168, 85, 247, 0.28), transparent 70%);
+}
+
+.admin-header > * {
+  position: relative;
+  z-index: 1;
 }
 
 .admin-title {
   margin: 0;
-  font-size: clamp(1.5rem, 1.2rem + 1vw, 2rem);
-  font-weight: 600;
+  font-size: clamp(2rem, 1.6rem + 1.2vw, 2.75rem);
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  color: var(--on-surface);
 }
 
 .admin-description {
   margin: 0;
-  color: var(--color-muted, #64748b);
+  max-width: 42rem;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--admin-muted);
 }
 
 .admin-alert {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 1rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
+  padding: 0.85rem 1.2rem;
+  border-radius: 1rem;
+  border: 1px solid transparent;
   font-size: 0.95rem;
+  font-weight: 500;
+  box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.45);
+}
+
+:host-context(.dark) .admin-alert {
+  box-shadow: 0 18px 40px -28px rgba(15, 23, 42, 0.8);
 }
 
 .admin-alert--error {
-  background: rgba(248, 113, 113, 0.14);
-  color: #991b1b;
+  background: rgba(248, 113, 113, 0.16);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: rgba(127, 29, 29, 0.95);
 }
 
 .admin-alert--success {
-  background: rgba(34, 197, 94, 0.16);
-  color: #065f46;
+  background: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.32);
+  color: rgba(22, 101, 52, 0.95);
+}
+
+:host-context(.dark) .admin-alert--error {
+  background: rgba(239, 68, 68, 0.22);
+  border-color: rgba(239, 68, 68, 0.45);
+  color: rgba(254, 226, 226, 0.92);
+}
+
+:host-context(.dark) .admin-alert--success {
+  background: rgba(34, 197, 94, 0.22);
+  border-color: rgba(34, 197, 94, 0.45);
+  color: rgba(187, 247, 208, 0.92);
 }
 
 .admin-alert__close {
   appearance: none;
   border: none;
-  background: transparent;
+  border-radius: 9999px;
+  padding: 0.4rem 0.9rem;
   font-size: 0.85rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.7);
   color: inherit;
   cursor: pointer;
+  transition:
+    background 150ms ease,
+    transform 150ms ease;
+}
+
+.admin-alert__close:hover {
+  background: rgba(255, 255, 255, 0.9);
+  transform: translateY(-1px);
+}
+
+:host-context(.dark) .admin-alert__close {
+  background: rgba(15, 23, 42, 0.6);
+}
+
+:host-context(.dark) .admin-alert__close:hover {
+  background: rgba(30, 41, 59, 0.72);
 }
 
 .admin-tabs {
-  display: flex;
+  display: inline-flex;
+  align-items: center;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.35rem;
+  padding: 0.4rem;
+  border-radius: 9999px;
+  border: 1px solid var(--border-subtle);
+  background: var(--admin-tabs-bg);
+  box-shadow: var(--admin-tabs-shadow);
+  backdrop-filter: blur(18px);
+  max-width: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;
+  align-self: flex-start;
+}
+
+.admin-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .admin-tabs__button {
-  padding: 0.5rem 1rem;
+  position: relative;
+  padding: 0.6rem 1.35rem;
   border-radius: 9999px;
   border: 1px solid transparent;
-  background: var(--surface-subtle, #f1f5f9);
-  color: inherit;
+  background: transparent;
+  color: var(--admin-muted-strong);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  white-space: nowrap;
+  transition:
+    color 150ms ease,
+    background-color 150ms ease,
+    transform 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.admin-tabs__button:hover {
+  color: var(--accent-strong);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.admin-tabs__button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .admin-tabs__button--active {
-  background: var(--accent, #0ea5e9);
-  color: #fff;
+  color: var(--on-surface-inverse);
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  box-shadow: 0 16px 40px -28px rgba(37, 99, 235, 0.55);
+  transform: translateY(-1px);
+}
+
+:host-context(.dark) .admin-tabs__button:hover {
+  background: rgba(148, 163, 184, 0.16);
 }
 
 .admin-section {
-  background: var(--surface, #ffffff);
-  border-radius: 1rem;
-  padding: 1.25rem;
-  box-shadow: var(--shadow-sm, 0 4px 10px rgba(15, 23, 42, 0.06));
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
+  padding: clamp(1.5rem, 2vw, 2rem);
+  border-radius: 1.75rem;
+  border: 1px solid var(--border-card);
+  background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
+  box-shadow: var(--admin-card-shadow);
+}
+
+:host-context(.dark) .admin-section {
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.92));
 }
 
 .admin-section__header {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.4rem;
+}
+
+.admin-section__header h2,
+.admin-section__header h3 {
+  margin: 0;
+  font-weight: 600;
+  color: var(--on-surface);
 }
 
 .admin-section__subtitle {
   margin: 0;
-  color: var(--color-muted, #64748b);
-  font-size: 0.9rem;
+  font-size: 0.92rem;
+  color: var(--admin-muted);
 }
 
 .admin-empty {
   margin: 0;
-  color: var(--color-muted, #64748b);
   font-size: 0.95rem;
+  color: var(--admin-muted);
 }
 
 .admin-hint {
   margin: 0;
   font-size: 0.85rem;
-  color: var(--color-muted, #64748b);
+  color: var(--admin-muted);
 }
 
 .admin-list {
@@ -110,94 +276,157 @@
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .admin-list__item {
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 0.9rem;
-  padding: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.65rem;
+  padding: 1.1rem 1.25rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--border-card);
+  background: linear-gradient(180deg, var(--surface-card), rgba(255, 255, 255, 0.9));
+  box-shadow: var(--admin-card-shadow);
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.admin-list__item:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
+}
+
+:host-context(.dark) .admin-list__item {
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.82), rgba(15, 23, 42, 0.88));
 }
 
 .admin-list__heading {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .admin-list__title {
-  font-size: 1rem;
+  font-size: 1.05rem;
   font-weight: 600;
+  color: var(--on-surface);
 }
 
 .admin-list__description {
   margin: 0;
-  color: var(--color-muted, #64748b);
   font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--admin-muted);
 }
 
 .admin-list__meta {
   display: flex;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.85rem;
   font-size: 0.85rem;
-  color: var(--color-muted, #64748b);
+  color: var(--admin-muted);
 }
 
 .admin-badge {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.2rem 0.6rem;
+  padding: 0.3rem 0.75rem;
   border-radius: 9999px;
-  background: rgba(14, 165, 233, 0.15);
-  color: #0369a1;
+  background: var(--admin-subtle-bg);
+  color: var(--accent-strong);
   font-size: 0.75rem;
   font-weight: 600;
-  margin-left: 0.5rem;
+  letter-spacing: 0.02em;
 }
 
 .admin-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.45rem;
   font-size: 0.9rem;
+  color: var(--admin-muted-strong);
+}
+
+.admin-toggle input {
+  accent-color: var(--accent);
 }
 
 .admin-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .admin-form__grid {
   display: grid;
-  gap: 1rem;
+  gap: 1.1rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .admin-field {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.45rem;
   font-size: 0.9rem;
+  color: var(--admin-muted-strong);
+}
+
+.admin-field span {
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
 .admin-field input,
 .admin-field select,
 .admin-field textarea {
   width: 100%;
-  border-radius: 0.6rem;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  padding: 0.5rem 0.75rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface);
+  color: var(--on-surface);
+  padding: 0.65rem 0.85rem;
   font-size: 0.95rem;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    background-color 150ms ease;
 }
 
 .admin-field textarea {
   resize: vertical;
+  min-height: 3rem;
+}
+
+.admin-field input::placeholder,
+.admin-field textarea::placeholder {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.admin-field input:focus-visible,
+.admin-field select:focus-visible,
+.admin-field textarea:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  background: var(--surface-card);
+}
+
+:host-context(.dark) .admin-field input,
+:host-context(.dark) .admin-field select,
+:host-context(.dark) .admin-field textarea {
+  background: rgba(15, 23, 42, 0.72);
+  color: var(--on-surface);
+  border-color: rgba(148, 163, 184, 0.28);
+}
+
+:host-context(.dark) .admin-field input::placeholder,
+:host-context(.dark) .admin-field textarea::placeholder {
+  color: rgba(148, 163, 184, 0.65);
 }
 
 .admin-field--full {
@@ -208,42 +437,87 @@
   align-self: flex-start;
   border: none;
   border-radius: 9999px;
-  padding: 0.55rem 1.2rem;
+  padding: 0.65rem 1.5rem;
   font-size: 0.95rem;
+  font-weight: 600;
   cursor: pointer;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease,
+    background-color 150ms ease,
+    color 150ms ease;
+}
+
+.admin-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .admin-button--primary {
-  background: var(--accent, #0ea5e9);
-  color: #fff;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: var(--on-surface-inverse);
+  box-shadow: 0 18px 44px -28px rgba(37, 99, 235, 0.55);
+}
+
+.admin-button--primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 48px -26px rgba(37, 99, 235, 0.65);
+}
+
+.admin-button--primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+  transform: none;
 }
 
 .admin-button--ghost {
-  background: rgba(148, 163, 184, 0.15);
-  color: inherit;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--admin-muted-strong);
+}
+
+.admin-button--ghost:hover {
+  background: rgba(148, 163, 184, 0.24);
+  transform: translateY(-1px);
+}
+
+:host-context(.dark) .admin-button--ghost {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--admin-muted-strong);
+}
+
+:host-context(.dark) .admin-button--ghost:hover {
+  background: rgba(148, 163, 184, 0.24);
 }
 
 .admin-criteria {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.9rem;
 }
 
 .admin-criteria__header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .admin-criteria__row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.75rem;
-  align-items: flex-end;
-  padding: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 0.8rem;
-  background: var(--surface-subtle, #f8fafc);
+  gap: 0.85rem;
+  align-items: flex-start;
+  padding: 1rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-card);
+  background: rgba(148, 163, 184, 0.08);
+  box-shadow: var(--admin-card-shadow);
+}
+
+:host-context(.dark) .admin-criteria__row {
+  background: rgba(30, 41, 59, 0.72);
 }
 
 .admin-criteria__row .admin-button {
@@ -251,61 +525,122 @@
 }
 
 .admin-evaluations {
-  list-style: none;
   margin: 0;
   padding: 0;
+  list-style: none;
   display: grid;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .admin-evaluations__item {
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 0.9rem;
-  padding: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.75rem;
+  padding: 1.2rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--border-card);
+  background: linear-gradient(180deg, var(--surface-card), rgba(255, 255, 255, 0.92));
+  box-shadow: var(--admin-card-shadow);
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.admin-evaluations__item:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
+}
+
+:host-context(.dark) .admin-evaluations__item {
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.86), rgba(15, 23, 42, 0.9));
 }
 
 .admin-evaluations__header {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.35rem;
 }
 
 .admin-evaluations__meta {
   font-size: 0.85rem;
-  color: var(--color-muted, #64748b);
+  color: var(--admin-muted);
 }
 
 .admin-evaluations__rationale {
   margin: 0;
   font-size: 0.95rem;
-  color: var(--color-muted, #475569);
+  line-height: 1.6;
+  color: var(--admin-muted-strong);
 }
 
 .admin-evaluations__items {
   margin: 0;
   padding-left: 1.2rem;
-  color: var(--color-muted, #64748b);
   font-size: 0.9rem;
+  color: var(--admin-muted);
+  list-style: disc;
 }
 
 .admin-table__wrapper {
   overflow-x: auto;
+  border-radius: 1.5rem;
+  border: 1px solid var(--border-card);
+  background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
+  box-shadow: var(--admin-card-shadow);
+}
+
+:host-context(.dark) .admin-table__wrapper {
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.92));
 }
 
 .admin-table {
   width: 100%;
   border-collapse: collapse;
+  min-width: 600px;
   font-size: 0.95rem;
+}
+
+.admin-table thead {
+  background: rgba(148, 163, 184, 0.14);
+}
+
+:host-context(.dark) .admin-table thead {
+  background: rgba(148, 163, 184, 0.12);
 }
 
 .admin-table th,
 .admin-table td {
-  padding: 0.6rem 0.75rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-card);
   text-align: left;
+  color: var(--on-surface);
+}
+
+.admin-table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--admin-muted-strong);
+}
+
+.admin-table tbody tr:nth-child(even) {
+  background: rgba(148, 163, 184, 0.06);
+}
+
+:host-context(.dark) .admin-table tbody tr:nth-child(even) {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.admin-table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.04);
+}
+
+:host-context(.dark) .admin-table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.admin-table tbody tr:last-child td {
+  border-bottom: none;
 }
 
 .admin-table__cell--center {
@@ -315,14 +650,35 @@
 .admin-table input[type='number'] {
   width: 100%;
   max-width: 8rem;
-  border-radius: 0.6rem;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  padding: 0.4rem 0.5rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-subtle);
+  padding: 0.45rem 0.6rem;
+  background: var(--surface);
+  color: var(--on-surface);
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.admin-table input[type='number']:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+
+:host-context(.dark) .admin-table input[type='number'] {
+  background: rgba(15, 23, 42, 0.72);
+  border-color: rgba(148, 163, 184, 0.28);
+  color: var(--on-surface);
 }
 
 @media (max-width: 768px) {
+  .admin-header {
+    padding: 1.75rem;
+  }
+
   .admin-section {
-    padding: 1rem;
+    padding: 1.25rem;
   }
 
   .admin-criteria__row {
@@ -331,5 +687,16 @@
 
   .admin-form__grid {
     grid-template-columns: 1fr;
+  }
+
+  .admin-table {
+    min-width: 520px;
+  }
+}
+
+@media (max-width: 640px) {
+  .admin-tabs {
+    width: 100%;
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- refresh the admin console hero, tabs, and sections to reuse shared theme tokens and deliver higher contrast backgrounds
- modernize list, form, evaluation, and table treatments for clearer hierarchy and improved dark mode support
- tune interactive states and responsive spacing so the console matches the rest of the product’s polished feel

## Testing
- npm run format:check *(fails: existing Prettier violations in unrelated files)*
- npx prettier --check src/app/features/admin/page.scss


------
https://chatgpt.com/codex/tasks/task_e_68d3692994d483209b92836cb0337ab6