### PR TITLE
Remove additional profile info section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ continuous-improvement tooling in one cohesive experience.
   coaching guidance.
 - **Admin controls & secure secrets** – Admin endpoints rotate external API credentials, configure
   default quotas, and override per-user limits so teams can tune automation safely.
-- **Profile management & avatars** – Users can update nicknames, biographies, locations, portfolio
+- **Profile management & avatars** – Users can update nicknames, biographies, and avatars
   URLs, and upload validated avatars directly from the UI, keeping the workspace personable.
 
 ## Repository Layout

--- a/backend/app/migrations.py
+++ b/backend/app/migrations.py
@@ -114,8 +114,6 @@ def _profile_column_types(dialect_name: str) -> dict[str, str]:
         "experience_years": "INTEGER",
         "roles": "JSON",
         "bio": "TEXT",
-        "location": "VARCHAR(120)",
-        "portfolio_url": "VARCHAR(255)",
         "avatar_image": "BLOB",
         "avatar_mime_type": "VARCHAR(64)",
     }

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 from datetime import date, datetime, timezone
 from typing import Optional
 from uuid import uuid4
@@ -53,8 +52,6 @@ class User(Base, TimestampMixin):
     experience_years: Mapped[int | None] = mapped_column(Integer, nullable=True)
     roles: Mapped[list[str]] = mapped_column(JSON, default=list)
     bio: Mapped[str | None] = mapped_column(Text, nullable=True)
-    location: Mapped[str | None] = mapped_column(String(120), nullable=True)
-    portfolio_url: Mapped[str | None] = mapped_column(String(255), nullable=True)
     avatar_image: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     avatar_mime_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
 

--- a/backend/app/routers/profile.py
+++ b/backend/app/routers/profile.py
@@ -13,8 +13,6 @@ from ..services.profile import (
     parse_roles,
     process_avatar_upload,
     sanitize_bio,
-    sanitize_location,
-    sanitize_portfolio_url,
     should_remove_avatar,
 )
 
@@ -34,8 +32,6 @@ async def update_profile(
     experience_years: str | None = Form(default=None),
     roles: str | None = Form(default=None),
     bio: str | None = Form(default=None),
-    location: str | None = Form(default=None),
-    portfolio_url: str | None = Form(default=None),
     remove_avatar: str | None = Form(default=None),
     avatar: UploadFile | None = File(default=None),
     current_user: models.User = Depends(get_current_user),
@@ -45,8 +41,6 @@ async def update_profile(
     sanitized_experience = parse_experience_years(experience_years)
     sanitized_roles = parse_roles(roles)
     sanitized_bio = sanitize_bio(bio)
-    sanitized_location = sanitize_location(location)
-    sanitized_portfolio = sanitize_portfolio_url(portfolio_url)
     remove_current_avatar = should_remove_avatar(remove_avatar)
 
     avatar_bytes: bytes | None = None
@@ -61,8 +55,6 @@ async def update_profile(
     current_user.experience_years = sanitized_experience
     current_user.roles = sanitized_roles
     current_user.bio = sanitized_bio
-    current_user.location = sanitized_location
-    current_user.portfolio_url = sanitized_portfolio
 
     if avatar is not None or remove_current_avatar:
         current_user.avatar_image = avatar_bytes

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -31,8 +31,6 @@ class UserProfile(UserRead):
     experience_years: Optional[int] = Field(default=None, ge=0, le=50)
     roles: List[str] = Field(default_factory=list)
     bio: Optional[str] = None
-    location: Optional[str] = None
-    portfolio_url: Optional[str] = None
     avatar_url: Optional[str] = None
 
     @model_validator(mode="before")

--- a/backend/app/services/chatgpt.py
+++ b/backend/app/services/chatgpt.py
@@ -228,10 +228,6 @@ class ChatGPTClient:
             metadata["roles"] = profile.roles
         if profile.bio:
             metadata["bio"] = profile.bio
-        if profile.location:
-            metadata["location"] = profile.location
-        if profile.portfolio_url:
-            metadata["portfolio_url"] = profile.portfolio_url
 
         if getattr(profile, "updated_at", None):
             metadata["profile_last_updated"] = profile.updated_at.isoformat()

--- a/backend/app/services/profile.py
+++ b/backend/app/services/profile.py
@@ -4,7 +4,6 @@ import base64
 import io
 import json
 from typing import TYPE_CHECKING, Any, NamedTuple
-from urllib.parse import urlparse
 
 from fastapi import HTTPException, UploadFile, status
 
@@ -12,8 +11,6 @@ from .. import models, schemas
 
 _MAX_NICKNAME_LENGTH = 30
 _MAX_BIO_LENGTH = 500
-_MAX_LOCATION_LENGTH = 120
-_MAX_PORTFOLIO_LENGTH = 255
 _MAX_ROLES = 5
 _MAX_ROLE_LENGTH = 32
 _MAX_EXPERIENCE_YEARS = 50
@@ -122,25 +119,6 @@ def _sanitize_optional_text(value: str | None, max_length: int) -> str | None:
 
 def sanitize_bio(value: str | None) -> str | None:
     return _sanitize_optional_text(value, _MAX_BIO_LENGTH)
-
-
-def sanitize_location(value: str | None) -> str | None:
-    return _sanitize_optional_text(value, _MAX_LOCATION_LENGTH)
-
-
-def sanitize_portfolio_url(value: str | None) -> str | None:
-    url = _sanitize_optional_text(value, _MAX_PORTFOLIO_LENGTH)
-    if url is None:
-        return None
-
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="ポートフォリオURLは http または https で始まる有効なURLを入力してください。",
-        )
-
-    return url
 
 
 def parse_roles(value: str | None) -> list[str]:
@@ -273,7 +251,5 @@ __all__ = [
     "parse_roles",
     "process_avatar_upload",
     "sanitize_bio",
-    "sanitize_location",
-    "sanitize_portfolio_url",
     "should_remove_avatar",
 ]

--- a/backend/tests/test_chatgpt_service.py
+++ b/backend/tests/test_chatgpt_service.py
@@ -107,8 +107,6 @@ def test_build_user_prompt_includes_profile_metadata() -> None:
         experience_years=6,
         roles=["backend", "ml"],
         bio="Builds resilient APIs.",
-        location="Tokyo",
-        portfolio_url="https://dev.example.com",
     )
 
     prompt = ChatGPTClient._build_user_prompt(

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -50,8 +50,6 @@ def test_profile_update_round_trip(client: TestClient, email: str) -> None:
         "experience_years": "7",
         "roles": json.dumps(["Java", "フロント"]),
         "bio": "Javaとフロントエンドの開発が得意です。",
-        "location": "東京都",
-        "portfolio_url": "https://example.com/portfolio",
     }
     files = {"avatar": ("avatar.png", avatar_bytes, "image/png")}
 
@@ -63,8 +61,6 @@ def test_profile_update_round_trip(client: TestClient, email: str) -> None:
     assert data["experience_years"] == 7
     assert data["roles"] == ["Java", "フロント"]
     assert data["bio"].startswith("Javaとフロントエンド")
-    assert data["location"] == "東京都"
-    assert data["portfolio_url"] == "https://example.com/portfolio"
     assert data["avatar_url"].startswith("data:image/webp;base64,")
 
     follow_up = client.get("/profile/me", headers=headers)

--- a/frontend/src/app/core/models/auth.ts
+++ b/frontend/src/app/core/models/auth.ts
@@ -8,8 +8,6 @@ export interface AuthenticatedUser {
   readonly experience_years: number | null;
   readonly roles: readonly string[];
   readonly bio: string | null;
-  readonly location: string | null;
-  readonly portfolio_url: string | null;
   readonly avatar_url: string | null;
 }
 

--- a/frontend/src/app/core/profile/profile-dialog.html
+++ b/frontend/src/app/core/profile/profile-dialog.html
@@ -190,51 +190,6 @@
           </label>
         </section>
 
-        <section class="profile-dialog__section" aria-labelledby="profile-additional-section">
-          <div class="profile-dialog__section-header">
-            <h3 id="profile-additional-section">追加情報</h3>
-            <p class="profile-dialog__section-description">
-              拠点やポートフォリオURLを設定すると、メンバーが連絡を取りやすくなります。
-            </p>
-          </div>
-          <div class="profile-dialog__grid">
-            <label class="profile-dialog__field" for="profile-location">
-              <span class="profile-dialog__label">拠点（任意）</span>
-              <select
-                id="profile-location"
-                class="profile-dialog__select"
-                [value]="form.controls.location.value() || '未設定'"
-                (change)="onLocationChange($event)"
-              >
-                @for (location of locationOptions; track location) {
-                  <option [value]="location">{{ location }}</option>
-                }
-              </select>
-            </label>
-
-            <label class="profile-dialog__field" for="profile-portfolio">
-              <span class="profile-dialog__label">ポートフォリオURL（任意）</span>
-              <input
-                id="profile-portfolio"
-                type="url"
-                inputmode="url"
-                [value]="form.controls.portfolioUrl.value()"
-                (input)="onPortfolioInput($event)"
-                class="profile-dialog__input"
-                [class.profile-dialog__input--invalid]="portfolioError()"
-                [attr.aria-invalid]="portfolioError() ? 'true' : null"
-                [attr.aria-describedby]="portfolioError() ? 'profile-portfolio-error' : null"
-                placeholder="https://example.com"
-              />
-              @if (portfolioError(); as portfolioMessage) {
-                <p id="profile-portfolio-error" class="profile-dialog__error" aria-live="polite">
-                  {{ portfolioMessage }}
-                </p>
-              }
-            </label>
-          </div>
-        </section>
-
         <footer class="profile-dialog__footer">
           <button type="button" class="profile-dialog__button-secondary focus-ring" (click)="onCancelClick()">
             キャンセル

--- a/frontend/src/app/core/profile/profile-dialog.ts
+++ b/frontend/src/app/core/profile/profile-dialog.ts
@@ -30,61 +30,8 @@ const ROLE_OPTIONS: readonly string[] = [
   'その他',
 ];
 
-const LOCATION_OPTIONS: readonly string[] = [
-  '未設定',
-  '北海道',
-  '青森県',
-  '岩手県',
-  '宮城県',
-  '秋田県',
-  '山形県',
-  '福島県',
-  '茨城県',
-  '栃木県',
-  '群馬県',
-  '埼玉県',
-  '千葉県',
-  '東京都',
-  '神奈川県',
-  '新潟県',
-  '富山県',
-  '石川県',
-  '福井県',
-  '山梨県',
-  '長野県',
-  '岐阜県',
-  '静岡県',
-  '愛知県',
-  '三重県',
-  '滋賀県',
-  '京都府',
-  '大阪府',
-  '兵庫県',
-  '奈良県',
-  '和歌山県',
-  '鳥取県',
-  '島根県',
-  '岡山県',
-  '広島県',
-  '山口県',
-  '徳島県',
-  '香川県',
-  '愛媛県',
-  '高知県',
-  '福岡県',
-  '佐賀県',
-  '長崎県',
-  '熊本県',
-  '大分県',
-  '宮崎県',
-  '鹿児島県',
-  '沖縄県',
-  '海外',
-];
-
 const MAX_NICKNAME_LENGTH = 30;
 const MAX_BIO_LENGTH = 500;
-const MAX_PORTFOLIO_LENGTH = 255;
 const MAX_EXPERIENCE_YEARS = 50;
 const MAX_ROLES = 5;
 const ALLOWED_AVATAR_TYPES = ['image/png', 'image/jpeg', 'image/webp'] as const;
@@ -108,7 +55,6 @@ export class ProfileDialogComponent implements AfterViewInit {
   private readonly profileService = inject(ProfileService);
 
   public readonly roleOptions = ROLE_OPTIONS;
-  public readonly locationOptions = LOCATION_OPTIONS;
   public readonly maxBioLength = MAX_BIO_LENGTH;
 
   public readonly form = createSignalForm<ProfileFormState>({
@@ -116,8 +62,6 @@ export class ProfileDialogComponent implements AfterViewInit {
     experienceYears: null,
     roles: [],
     bio: '',
-    location: '',
-    portfolioUrl: '',
   });
 
   private readonly loadingStore = signal(true);
@@ -127,7 +71,6 @@ export class ProfileDialogComponent implements AfterViewInit {
   private readonly nicknameTouched = signal(false);
   private readonly experienceTouched = signal(false);
   private readonly bioTouched = signal(false);
-  private readonly portfolioTouched = signal(false);
   private readonly initialValueStore = signal<ProfileFormState | null>(null);
   private readonly avatarPreviewStore = signal<string | null>(null);
   private readonly avatarFileStore = signal<File | null>(null);
@@ -186,39 +129,12 @@ export class ProfileDialogComponent implements AfterViewInit {
     return null;
   });
 
-  public readonly portfolioError = computed(() => {
-    if (!this.portfolioTouched()) {
-      return null;
-    }
-
-    const value = this.form.controls.portfolioUrl.value().trim();
-    if (!value) {
-      return null;
-    }
-
-    if (value.length > MAX_PORTFOLIO_LENGTH) {
-      return `ポートフォリオURLは${MAX_PORTFOLIO_LENGTH}文字以内で入力してください。`;
-    }
-
-    try {
-      const url = new URL(value);
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-        return 'ポートフォリオURLは http または https で始まる必要があります。';
-      }
-    } catch {
-      return '有効なURLを入力してください。';
-    }
-
-    return null;
-  });
-
   public readonly hasValidationErrors = computed(
     () =>
       Boolean(
         this.nicknameError() ||
           this.experienceError() ||
           this.bioError() ||
-          this.portfolioError() ||
           this.rolesError(),
       ),
   );
@@ -244,12 +160,6 @@ export class ProfileDialogComponent implements AfterViewInit {
       return true;
     }
     if (initial.bio !== current.bio) {
-      return true;
-    }
-    if (initial.location !== current.location) {
-      return true;
-    }
-    if (initial.portfolioUrl !== current.portfolioUrl) {
       return true;
     }
     if (!this.areRolesEqual(initial.roles, current.roles)) {
@@ -301,7 +211,6 @@ export class ProfileDialogComponent implements AfterViewInit {
     this.nicknameTouched.set(true);
     this.experienceTouched.set(true);
     this.bioTouched.set(true);
-    this.portfolioTouched.set(true);
     this.errorStore.set(null);
 
     if (!this.canSubmit()) {
@@ -317,8 +226,6 @@ export class ProfileDialogComponent implements AfterViewInit {
       experienceYears: value.experienceYears,
       roles: [...value.roles],
       bio: value.bio,
-      location: value.location,
-      portfolioUrl: value.portfolioUrl,
       removeAvatar: this.removeAvatarStore(),
       avatarFile: this.avatarFileStore(),
     };
@@ -369,19 +276,6 @@ export class ProfileDialogComponent implements AfterViewInit {
     const target = event.target as HTMLTextAreaElement | null;
     const value = target?.value ?? '';
     this.form.controls.bio.setValue(value);
-  }
-
-  public onLocationChange(event: Event): void {
-    const target = event.target as HTMLSelectElement | null;
-    const value = target?.value ?? '';
-    this.form.controls.location.setValue(value === '未設定' ? '' : value);
-  }
-
-  public onPortfolioInput(event: Event): void {
-    this.portfolioTouched.set(true);
-    const target = event.target as HTMLInputElement | null;
-    const value = target?.value ?? '';
-    this.form.controls.portfolioUrl.setValue(value);
   }
 
   public onRoleToggle(role: string): void {
@@ -464,8 +358,6 @@ export class ProfileDialogComponent implements AfterViewInit {
       experienceYears: profile.experience_years ?? null,
       roles: [...profile.roles],
       bio: profile.bio ?? '',
-      location: profile.location ?? '',
-      portfolioUrl: profile.portfolio_url ?? '',
     };
 
     this.form.reset({ ...state, roles: [...state.roles] });
@@ -476,7 +368,6 @@ export class ProfileDialogComponent implements AfterViewInit {
     this.nicknameTouched.set(false);
     this.experienceTouched.set(false);
     this.bioTouched.set(false);
-    this.portfolioTouched.set(false);
     this.roleErrorStore.set(null);
   }
 

--- a/frontend/src/app/core/profile/profile.models.ts
+++ b/frontend/src/app/core/profile/profile.models.ts
@@ -7,8 +7,6 @@ export interface ProfileFormState extends Record<string, unknown> {
   readonly experienceYears: number | null;
   readonly roles: readonly string[];
   readonly bio: string;
-  readonly location: string;
-  readonly portfolioUrl: string;
 }
 
 export interface ProfileUpdatePayload extends ProfileFormState {

--- a/frontend/src/app/core/profile/profile.service.ts
+++ b/frontend/src/app/core/profile/profile.service.ts
@@ -32,16 +32,6 @@ export class ProfileService {
       formData.append('bio', bio);
     }
 
-    const location = payload.location.trim();
-    if (location) {
-      formData.append('location', location);
-    }
-
-    const portfolioUrl = payload.portfolioUrl.trim();
-    if (portfolioUrl) {
-      formData.append('portfolio_url', portfolioUrl);
-    }
-
     if (payload.removeAvatar) {
       formData.append('remove_avatar', 'true');
     }


### PR DESCRIPTION
## Summary
- remove the additional information section from the profile dialog UI
- drop the location and portfolio fields from the profile form state and service payload handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d369e259888320b1cfe0eec0e5b39e