### PR TITLE
feat: enable self-service competency evaluations

### DIFF
--- a/backend/app/routers/competency_evaluations.py
+++ b/backend/app/routers/competency_evaluations.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from .. import models, schemas
 from ..auth import get_current_user
 from ..database import get_db
+from ..services.competency_evaluator import CompetencyEvaluator
+from ..utils.quotas import (
+    get_daily_usage,
+    get_evaluation_daily_limit,
+    reserve_daily_quota,
+)
 from ..utils.dependencies import require_admin
 
 router = APIRouter(tags=["competencies"])
@@ -25,6 +31,31 @@ def _evaluation_query(db: Session):
         )
         .order_by(models.CompetencyEvaluation.created_at.desc())
     )
+
+
+def _resolve_competency(db: Session, competency_id: str | None) -> models.Competency:
+    query = db.query(models.Competency).filter(models.Competency.is_active.is_(True))
+
+    if competency_id:
+        competency = query.filter(models.Competency.id == competency_id).one_or_none()
+    else:
+        competency = query.order_by(models.Competency.sort_order.asc(), models.Competency.created_at.asc()).first()
+
+    if not competency:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Competency not found")
+
+    return competency
+
+
+def _normalize_period(period_start: date | None, period_end: date | None) -> tuple[date, date]:
+    today = date.today()
+    resolved_end = period_end or today
+    resolved_start = period_start or resolved_end.replace(day=1)
+
+    if resolved_start > resolved_end:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid period range")
+
+    return resolved_start, resolved_end
 
 
 @router.get("/admin/evaluations", response_model=list[schemas.CompetencyEvaluationRead])
@@ -60,6 +91,98 @@ def my_evaluations(
     query = _evaluation_query(db).filter(models.CompetencyEvaluation.user_id == current_user.id)
     evaluations = query.limit(limit).all()
     return evaluations
+
+
+@router.get("/users/me/evaluations/quota", response_model=schemas.EvaluationQuotaStatus)
+def my_evaluation_quota(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.EvaluationQuotaStatus:
+    today = date.today()
+    limit = get_evaluation_daily_limit(db, current_user.id)
+    used = get_daily_usage(
+        db,
+        quota_model=models.DailyEvaluationQuota,
+        owner_id=current_user.id,
+        quota_day=today,
+    )
+    remaining: int | None
+    if limit > 0:
+        remaining = max(limit - used, 0)
+    else:
+        remaining = None
+
+    return schemas.EvaluationQuotaStatus(daily_limit=limit, used=used, remaining=remaining)
+
+
+@router.post("/users/me/evaluations", response_model=schemas.CompetencyEvaluationRead)
+def create_my_evaluation(
+    payload: schemas.SelfEvaluationRequest,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> models.CompetencyEvaluation:
+    competency = _resolve_competency(db, payload.competency_id)
+    period_start, period_end = _normalize_period(payload.period_start, payload.period_end)
+
+    today = date.today()
+    limit = get_evaluation_daily_limit(db, current_user.id)
+    quota_reserved = reserve_daily_quota(
+        db,
+        owner_id=current_user.id,
+        quota_day=today,
+        limit=limit,
+        quota_model=models.DailyEvaluationQuota,
+        counter_field="executed_count",
+    )
+    if not quota_reserved:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Daily competency evaluation limit of {limit} reached.",
+        )
+
+    job = models.CompetencyEvaluationJob(
+        competency=competency,
+        user_id=current_user.id,
+        status="running",
+        scope="user",
+        target_period_start=period_start,
+        target_period_end=period_end,
+        triggered_by="manual",
+        triggered_by_user=current_user,
+        started_at=datetime.now(timezone.utc),
+    )
+    db.add(job)
+    db.flush()
+
+    evaluator = CompetencyEvaluator(db)
+
+    try:
+        evaluation = evaluator.evaluate(
+            user=current_user,
+            competency=competency,
+            period_start=period_start,
+            period_end=period_end,
+            triggered_by="manual",
+            job=job,
+        )
+    except Exception as exc:  # pragma: no cover - defensive handling
+        job.status = "failed"
+        job.completed_at = datetime.now(timezone.utc)
+        job.error_message = str(exc)
+        db.add(job)
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        ) from exc
+
+    job.status = "succeeded"
+    job.completed_at = datetime.now(timezone.utc)
+    job.summary_stats = {"evaluations": 1}
+    db.add(job)
+    db.commit()
+    db.refresh(evaluation)
+    return evaluation
 
 
 __all__ = ["router"]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -893,6 +893,25 @@ class EvaluationTriggerRequest(BaseModel):
         return values
 
 
+class SelfEvaluationRequest(BaseModel):
+    competency_id: Optional[str] = None
+    period_start: Optional[date] = None
+    period_end: Optional[date] = None
+
+    @model_validator(mode="after")
+    def ensure_period(cls, values: "SelfEvaluationRequest") -> "SelfEvaluationRequest":
+        if values.period_start and values.period_end:
+            if values.period_start > values.period_end:
+                raise ValueError("period_start must be on or before period_end")
+        return values
+
+
+class EvaluationQuotaStatus(BaseModel):
+    daily_limit: int
+    used: int
+    remaining: Optional[int] = None
+
+
 class AdminUserRead(BaseModel):
     id: str
     email: EmailStr

--- a/backend/tests/test_competency_evaluations.py
+++ b/backend/tests/test_competency_evaluations.py
@@ -1,0 +1,93 @@
+from fastapi.testclient import TestClient
+
+from app.utils.quotas import DEFAULT_EVALUATION_DAILY_LIMIT
+
+
+def _register(client: TestClient, email: str) -> dict[str, str]:
+    response = client.post(
+        "/auth/register",
+        json={"email": email, "password": "Password123!"},
+    )
+    assert response.status_code == 201, response.text
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_competency(client: TestClient, headers: dict[str, str]) -> str:
+    response = client.post(
+        "/admin/competencies",
+        json={
+            "name": "チームワーク基礎",
+            "level": "junior",
+            "description": "テスト用コンピテンシー",
+            "rubric": {},
+            "sort_order": 1,
+            "is_active": True,
+            "criteria": [],
+        },
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def test_user_can_trigger_evaluation_and_view_quota(client: TestClient) -> None:
+    admin_headers = _register(client, "admin@example.com")
+    competency_id = _create_competency(client, admin_headers)
+
+    user_headers = _register(client, "member@example.com")
+
+    quota_response = client.get("/users/me/evaluations/quota", headers=user_headers)
+    assert quota_response.status_code == 200
+    quota_payload = quota_response.json()
+
+    assert quota_payload["daily_limit"] == DEFAULT_EVALUATION_DAILY_LIMIT
+    assert quota_payload["used"] == 0
+    if quota_payload["daily_limit"] > 0:
+        assert quota_payload["remaining"] == DEFAULT_EVALUATION_DAILY_LIMIT
+    else:
+        assert quota_payload["remaining"] is None
+
+    evaluation_response = client.post(
+        "/users/me/evaluations",
+        json={"competency_id": competency_id},
+        headers=user_headers,
+    )
+    assert evaluation_response.status_code == 200, evaluation_response.text
+    evaluation_data = evaluation_response.json()
+
+    assert evaluation_data["competency_id"] == competency_id
+    assert evaluation_data["user_id"] != ""
+    assert evaluation_data["items"] != []
+
+    history_response = client.get("/users/me/evaluations", headers=user_headers)
+    assert history_response.status_code == 200
+    history = history_response.json()
+    assert any(item["id"] == evaluation_data["id"] for item in history)
+
+    updated_quota = client.get("/users/me/evaluations/quota", headers=user_headers)
+    assert updated_quota.status_code == 200
+    updated_payload = updated_quota.json()
+    assert updated_payload["used"] == 1
+    if updated_payload["daily_limit"] > 0:
+        assert updated_payload["remaining"] == DEFAULT_EVALUATION_DAILY_LIMIT - 1
+    else:
+        assert updated_payload["remaining"] is None
+
+    if DEFAULT_EVALUATION_DAILY_LIMIT > 0:
+        for _ in range(DEFAULT_EVALUATION_DAILY_LIMIT - 1):
+            response = client.post(
+                "/users/me/evaluations",
+                json={"competency_id": competency_id},
+                headers=user_headers,
+            )
+            assert response.status_code == 200, response.text
+
+        final_attempt = client.post(
+            "/users/me/evaluations",
+            json={"competency_id": competency_id},
+            headers=user_headers,
+        )
+        assert final_attempt.status_code == 429
+        assert "limit" in final_attempt.json()["detail"]
+

--- a/frontend/src/app/core/api/competency-api.service.ts
+++ b/frontend/src/app/core/api/competency-api.service.ts
@@ -2,7 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { CompetencyEvaluation } from '@core/models';
+import { CompetencyEvaluation, EvaluationQuotaStatus, SelfEvaluationRequest } from '@core/models';
 
 import { buildApiUrl } from './api.config';
 
@@ -23,5 +23,13 @@ export class CompetencyApiService {
     return this.http.get<CompetencyEvaluation[]>(buildApiUrl('/users/me/evaluations'), {
       params,
     });
+  }
+
+  public getMyEvaluationQuota(): Observable<EvaluationQuotaStatus> {
+    return this.http.get<EvaluationQuotaStatus>(buildApiUrl('/users/me/evaluations/quota'));
+  }
+
+  public runMyEvaluation(payload: SelfEvaluationRequest): Observable<CompetencyEvaluation> {
+    return this.http.post<CompetencyEvaluation>(buildApiUrl('/users/me/evaluations'), payload);
   }
 }

--- a/frontend/src/app/core/models/admin.ts
+++ b/frontend/src/app/core/models/admin.ts
@@ -94,6 +94,18 @@ export interface EvaluationTriggerRequest {
   triggered_by?: 'manual' | 'auto';
 }
 
+export interface SelfEvaluationRequest {
+  competency_id?: string;
+  period_start?: IsoDateString | null;
+  period_end?: IsoDateString | null;
+}
+
+export interface EvaluationQuotaStatus {
+  daily_limit: number;
+  used: number;
+  remaining?: number | null;
+}
+
 export interface AdminUser {
   id: string;
   email: string;

--- a/frontend/src/app/features/profile/evaluations/page.html
+++ b/frontend/src/app/features/profile/evaluations/page.html
@@ -9,24 +9,72 @@
       </p>
     </div>
     <div class="page-header__actions">
-      <button
-        type="button"
-        class="refresh-button focus-ring"
-        (click)="refresh()"
-        [disabled]="loading()"
-      >
-        <svg aria-hidden="true" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.8">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M4 4v5h5M20 20v-5h-5M5 14a7 7 0 0 1 12-4.9l2 1.9M19 10a7 7 0 0 1-12 4.9l-2-1.9"
-          />
-        </svg>
-        最新情報に更新
-      </button>
-      <a routerLink="/board" class="back-link focus-ring">ボードに戻る</a>
+      <section class="quota-card" aria-live="polite">
+        <p class="quota-card__label">本日の評価判定可能回数</p>
+
+        @if (quotaLoading()) {
+          <p class="quota-card__loading">計算中…</p>
+        } @else if (quotaError(); as message) {
+          <p class="quota-card__warning">{{ message }}</p>
+        } @else {
+          <div class="quota-card__values">
+            <span class="quota-card__value">{{ limitLabel(quota()) }}</span>
+            <span class="quota-card__separator">／</span>
+            <span class="quota-card__value quota-card__value--remaining">
+              {{ remainingLabel(quota()) }}
+            </span>
+          </div>
+          <p class="quota-card__meta">実行済み {{ quota()?.used ?? 0 }} 回</p>
+
+          @if (limitReached()) {
+            <p class="quota-card__warning">本日の上限に達しました。</p>
+          }
+        }
+      </section>
+
+      <div class="page-header__buttons">
+        <button
+          type="button"
+          class="refresh-button focus-ring"
+          (click)="runEvaluation()"
+          [disabled]="runningEvaluation() || loading() || !canRunEvaluation()"
+        >
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            class="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M12 3v2m0 14v2m9-9h-2M5 12H3m12.364-5.364-1.414 1.414M6.05 17.95l-1.414 1.414m12.728 0-1.414-1.414M6.05 6.05 4.636 4.636M9 12a3 3 0 1 0 6 0 3 3 0 0 0-6 0Z"
+            />
+          </svg>
+          評価を実行
+        </button>
+
+        <button
+          type="button"
+          class="secondary-button focus-ring"
+          (click)="exportLatestAsJson()"
+          [disabled]="!latestEvaluation()"
+        >
+          JSON で出力
+        </button>
+      </div>
     </div>
   </header>
+
+  @if (actionError(); as message) {
+    <p class="page-alert page-alert--error" role="alert">{{ message }}</p>
+  }
+
+  @if (feedback(); as message) {
+    <p class="page-alert page-alert--success" role="status">{{ message }}</p>
+  }
 
   @if (loading()) {
     <div class="state state--loading">
@@ -38,7 +86,9 @@
       <div class="state state--error" role="alert">
         <h2>取得に失敗しました</h2>
         <p>{{ message }}</p>
-        <button type="button" class="retry-button focus-ring" (click)="refresh()">再試行する</button>
+        <button type="button" class="retry-button focus-ring" (click)="refresh()">
+          再試行する
+        </button>
       </div>
     } @else {
       @if (!hasEvaluations()) {
@@ -62,7 +112,9 @@
             <header class="latest__header">
               <div class="latest__summary">
                 <p class="latest__eyebrow">最新の評価</p>
-                <h2 class="latest__title">{{ evaluation.competency?.name || 'コンピテンシー評価' }}</h2>
+                <h2 class="latest__title">
+                  {{ evaluation.competency?.name || 'コンピテンシー評価' }}
+                </h2>
                 <p class="latest__meta">
                   評価期間
                   <span>{{ evaluation.period_start | date: 'yyyy/MM/dd' }}</span>
@@ -70,13 +122,16 @@
                   <span>{{ evaluation.period_end | date: 'yyyy/MM/dd' }}</span>
                 </p>
                 <p class="latest__meta">
-                  判定種別: {{ triggeredLabel(evaluation.triggered_by) }} / モデル: {{ evaluation.ai_model || '未設定' }}
+                  判定種別: {{ triggeredLabel(evaluation.triggered_by) }} / モデル:
+                  {{ evaluation.ai_model || '未設定' }}
                 </p>
               </div>
               <div class="latest__score" aria-label="評価スコア">
                 <div class="latest__score-value">
                   <span aria-hidden="true">{{ evaluation.score_value }}</span>
-                  <span class="latest__score-scale" aria-hidden="true">/ {{ evaluation.scale }}</span>
+                  <span class="latest__score-scale" aria-hidden="true"
+                    >/ {{ evaluation.scale }}</span
+                  >
                 </div>
                 <p class="latest__score-label">{{ evaluation.score_label }}</p>
                 <p class="latest__score-percent">達成率 {{ scorePercent(evaluation) }}%</p>
@@ -136,10 +191,14 @@
                       <article class="latest__item surface-card">
                         <header>
                           <p class="latest__item-title">{{ '評価項目 ' + (index + 1) }}</p>
-                          <p class="latest__item-score">{{ item.score_label }} ({{ item.score_value }} 点)</p>
+                          <p class="latest__item-score">
+                            {{ item.score_label }} ({{ item.score_value }} 点)
+                          </p>
                         </header>
                         <div class="latest__item-body">
-                          <p class="latest__item-text">{{ item.rationale || '根拠メモは記録されていません。' }}</p>
+                          <p class="latest__item-text">
+                            {{ item.rationale || '根拠メモは記録されていません。' }}
+                          </p>
 
                           @if (hasActions(item.attitude_actions)) {
                             <div class="latest__item-actions">
@@ -195,7 +254,9 @@
                             >{{ item.period_start | date: 'yyyy/MM/dd' }} 〜
                             {{ item.period_end | date: 'yyyy/MM/dd' }}</span
                           >
-                          <span class="history__label">{{ item.competency?.name || 'コンピテンシー評価' }}</span>
+                          <span class="history__label">{{
+                            item.competency?.name || 'コンピテンシー評価'
+                          }}</span>
                         </div>
                         <div class="history__score">
                           <span class="history__score-value">{{ item.score_value }}</span>

--- a/frontend/src/app/features/profile/evaluations/page.scss
+++ b/frontend/src/app/features/profile/evaluations/page.scss
@@ -63,9 +63,31 @@
 
 .page-header__actions {
   display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .page-header__actions {
+    flex-direction: row;
+    align-items: stretch;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+}
+
+.page-header__buttons {
+  display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
   align-items: center;
+  justify-content: flex-start;
+}
+
+@media (min-width: 768px) {
+  .page-header__buttons {
+    justify-content: flex-end;
+  }
 }
 
 .refresh-button {
@@ -80,7 +102,9 @@
   font-size: 0.9rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 160ms ease-in-out, transform 160ms ease-in-out;
+  transition:
+    background 160ms ease-in-out,
+    transform 160ms ease-in-out;
 }
 
 .refresh-button:hover:not(:disabled) {
@@ -90,10 +114,10 @@
 
 .refresh-button:disabled {
   opacity: 0.65;
-  cursor: progress;
+  cursor: not-allowed;
 }
 
-.back-link {
+.secondary-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -104,20 +128,144 @@
   color: rgba(37, 99, 235, 0.9);
   font-weight: 600;
   font-size: 0.85rem;
-  text-decoration: none;
-  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    transform 160ms ease;
 }
 
-.back-link:hover {
+.secondary-button:hover:not(:disabled) {
   border-color: rgba(37, 99, 235, 0.55);
   background: rgba(219, 234, 254, 0.85);
   transform: translateY(-1px);
 }
 
-:host-context(.dark) .back-link {
+:host-context(.dark) .secondary-button {
   background: rgba(30, 41, 59, 0.85);
   border-color: rgba(96, 165, 250, 0.35);
   color: rgba(191, 219, 254, 0.95);
+}
+
+.secondary-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.quota-card {
+  flex: 1 1 16rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(37, 99, 235, 0.25);
+  background: rgba(255, 255, 255, 0.82);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+:host-context(.dark) .quota-card {
+  background: rgba(15, 23, 42, 0.65);
+  border-color: rgba(147, 197, 253, 0.35);
+}
+
+.quota-card__label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(37, 99, 235, 0.85);
+}
+
+:host-context(.dark) .quota-card__label {
+  color: rgba(191, 219, 254, 0.9);
+}
+
+.quota-card__values {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--on-surface);
+}
+
+:host-context(.dark) .quota-card__values {
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.quota-card__separator {
+  font-size: 1rem;
+  color: rgba(59, 130, 246, 0.8);
+}
+
+.quota-card__value--remaining {
+  color: rgba(22, 163, 74, 0.9);
+}
+
+:host-context(.dark) .quota-card__value--remaining {
+  color: rgba(134, 239, 172, 0.85);
+}
+
+.quota-card__meta {
+  font-size: 0.85rem;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+:host-context(.dark) .quota-card__meta {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.quota-card__warning {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: rgba(220, 38, 38, 0.9);
+}
+
+:host-context(.dark) .quota-card__warning {
+  color: rgba(248, 113, 113, 0.85);
+}
+
+.quota-card__loading {
+  font-size: 0.9rem;
+  color: rgba(71, 85, 105, 0.8);
+}
+
+:host-context(.dark) .quota-card__loading {
+  color: rgba(226, 232, 240, 0.76);
+}
+
+.page-alert {
+  margin-top: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.page-alert--error {
+  background: rgba(254, 226, 226, 0.85);
+  color: rgba(153, 27, 27, 0.95);
+  border-color: rgba(248, 113, 113, 0.6);
+}
+
+:host-context(.dark) .page-alert--error {
+  background: rgba(127, 29, 29, 0.55);
+  color: rgba(254, 226, 226, 0.95);
+  border-color: rgba(254, 202, 202, 0.4);
+}
+
+.page-alert--success {
+  background: rgba(187, 247, 208, 0.85);
+  color: rgba(22, 101, 52, 0.95);
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+:host-context(.dark) .page-alert--success {
+  background: rgba(21, 128, 61, 0.55);
+  color: rgba(220, 252, 231, 0.9);
+  border-color: rgba(134, 239, 172, 0.4);
 }
 
 .state {

--- a/frontend/src/app/features/profile/evaluations/page.ts
+++ b/frontend/src/app/features/profile/evaluations/page.ts
@@ -8,11 +8,10 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { CompetencyApiService } from '@core/api/competency-api.service';
-import { CompetencyEvaluation } from '@core/models';
+import { CompetencyEvaluation, EvaluationQuotaStatus, SelfEvaluationRequest } from '@core/models';
 
 const DEFAULT_HISTORY_LIMIT = 12;
 
@@ -22,7 +21,7 @@ const DEFAULT_HISTORY_LIMIT = 12;
 @Component({
   selector: 'app-profile-evaluations-page',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule],
   templateUrl: './page.html',
   styleUrl: './page.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -30,10 +29,17 @@ const DEFAULT_HISTORY_LIMIT = 12;
 export class ProfileEvaluationsPage {
   private readonly api = inject(CompetencyApiService);
   private readonly destroyRef = inject(DestroyRef);
+  private feedbackTimeoutId: number | null = null;
 
   public readonly evaluations = signal<CompetencyEvaluation[]>([]);
   public readonly loading = signal<boolean>(false);
   public readonly error = signal<string | null>(null);
+  public readonly quota = signal<EvaluationQuotaStatus | null>(null);
+  public readonly quotaLoading = signal<boolean>(false);
+  public readonly quotaError = signal<string | null>(null);
+  public readonly runningEvaluation = signal<boolean>(false);
+  public readonly actionError = signal<string | null>(null);
+  public readonly feedback = signal<string | null>(null);
 
   public readonly latestEvaluation = computed<CompetencyEvaluation | null>(() => {
     const [latest] = this.evaluations();
@@ -46,13 +52,32 @@ export class ProfileEvaluationsPage {
   });
 
   public readonly hasEvaluations = computed(() => this.evaluations().length > 0);
+  public readonly limitReached = computed<boolean>(() => {
+    const quota = this.quota();
+    if (!quota || quota.daily_limit <= 0) {
+      return false;
+    }
+
+    const remaining = quota.remaining ?? Math.max(quota.daily_limit - quota.used, 0);
+    return remaining <= 0;
+  });
+
+  public readonly canRunEvaluation = computed<boolean>(() => {
+    if (this.quotaLoading()) {
+      return false;
+    }
+
+    return !this.limitReached();
+  });
 
   public constructor() {
     this.loadEvaluations();
+    this.loadQuota();
   }
 
   public refresh(): void {
     this.loadEvaluations();
+    this.loadQuota();
   }
 
   public scorePercent(evaluation: CompetencyEvaluation | null): number {
@@ -78,6 +103,97 @@ export class ProfileEvaluationsPage {
     return Array.isArray(actions) && actions.length > 0;
   }
 
+  public limitLabel(quota: EvaluationQuotaStatus | null): string {
+    if (!quota) {
+      return '-';
+    }
+
+    return quota.daily_limit <= 0 ? '無制限' : `${quota.daily_limit} 回`;
+  }
+
+  public remainingLabel(quota: EvaluationQuotaStatus | null): string {
+    if (!quota) {
+      return '-';
+    }
+
+    if (quota.daily_limit <= 0 || quota.remaining === null || quota.remaining === undefined) {
+      return '無制限';
+    }
+
+    return `${quota.remaining} 回`;
+  }
+
+  public runEvaluation(): void {
+    if (this.runningEvaluation() || !this.canRunEvaluation()) {
+      return;
+    }
+
+    this.runningEvaluation.set(true);
+    this.actionError.set(null);
+    this.feedback.set(null);
+
+    const payload: SelfEvaluationRequest = {};
+    const latest = this.latestEvaluation();
+    if (latest?.competency_id) {
+      payload.competency_id = latest.competency_id;
+    }
+
+    this.api
+      .runMyEvaluation(payload)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (evaluation) => {
+          this.runningEvaluation.set(false);
+          this.error.set(null);
+          this.evaluations.update((list) => {
+            const filtered = list.filter((item) => item.id !== evaluation.id);
+            return [evaluation, ...filtered].slice(0, DEFAULT_HISTORY_LIMIT);
+          });
+          this.showFeedback('評価を実行しました。最新の結果が反映されています。');
+          this.loadQuota();
+        },
+        error: (error: HttpErrorResponse) => {
+          this.runningEvaluation.set(false);
+          const message =
+            typeof error.error === 'object' && error.error?.detail
+              ? String(error.error.detail)
+              : '評価の実行に失敗しました。時間をおいて再度お試しください。';
+          this.actionError.set(message);
+          if (error.status === 429 || error.status === 401) {
+            this.loadQuota();
+          }
+        },
+      });
+  }
+
+  public exportLatestAsJson(): void {
+    const evaluation = this.latestEvaluation();
+    if (!evaluation || typeof document === 'undefined') {
+      return;
+    }
+
+    const sanitizedName = this.sanitizeFileName(
+      evaluation.competency?.name || 'competency-evaluation',
+    );
+    const period = (evaluation.period_end || evaluation.period_start || 'latest')
+      .toString()
+      .replaceAll('/', '-')
+      .replaceAll('.', '-')
+      .replaceAll(' ', '_');
+    const fileName = `competency-evaluation-${sanitizedName}-${period}.json`;
+    const json = JSON.stringify(evaluation, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = fileName;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+    this.showFeedback('評価結果を JSON 形式で出力しました。');
+  }
+
   private loadEvaluations(): void {
     this.loading.set(true);
     this.error.set(null);
@@ -99,5 +215,51 @@ export class ProfileEvaluationsPage {
           this.error.set(message);
         },
       });
+  }
+
+  private loadQuota(): void {
+    this.quotaLoading.set(true);
+    this.quotaError.set(null);
+
+    this.api
+      .getMyEvaluationQuota()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (quota) => {
+          this.quota.set(quota);
+          this.quotaLoading.set(false);
+        },
+        error: (error: HttpErrorResponse) => {
+          this.quotaLoading.set(false);
+          this.quota.set(null);
+          const message =
+            typeof error.error === 'object' && error.error?.detail
+              ? String(error.error.detail)
+              : '評価上限の情報を取得できませんでした。';
+          this.quotaError.set(message);
+        },
+      });
+  }
+
+  private showFeedback(message: string): void {
+    this.feedback.set(message);
+    if (typeof window !== 'undefined') {
+      if (this.feedbackTimeoutId !== null) {
+        window.clearTimeout(this.feedbackTimeoutId);
+      }
+
+      this.feedbackTimeoutId = window.setTimeout(() => {
+        this.feedback.set(null);
+        this.feedbackTimeoutId = null;
+      }, 4000);
+    }
+  }
+
+  private sanitizeFileName(input: string): string {
+    return input
+      .trim()
+      .toLowerCase()
+      .replace(/[\\/:*?"<>|]/g, '-')
+      .replace(/\s+/g, '-');
   }
 }


### PR DESCRIPTION
## Summary
- allow authenticated users to trigger their own competency evaluations and retrieve daily quota status via new backend endpoints
- surface quota usage, manual execution controls, and JSON export on the competency evaluation page with refreshed styling
- add API models and automated tests covering the self-service evaluation flow and quota enforcement

## Testing
- pytest backend/tests
- npm run lint
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d368b5a22483208cdf0c3b3ed83dc9