### PR TITLE
style: tighten shell header spacing

### DIFF
--- a/frontend/src/app/core/layout/shell/shell.scss
+++ b/frontend/src/app/core/layout/shell/shell.scss
@@ -13,7 +13,7 @@
 
 .shell-header {
   position: relative;
-  padding-block: clamp(1.8rem, 5vw, 4.2rem);
+  padding-block: clamp(1.1rem, 3.5vw, 2.8rem);
   background:
     radial-gradient(circle at 8% 12%, rgba(59, 130, 246, 0.16), transparent 62%),
     radial-gradient(circle at 92% 0%, rgba(129, 140, 248, 0.16), transparent 58%),
@@ -46,7 +46,7 @@
 .shell-header__surface {
   position: relative;
   display: block;
-  padding: clamp(1.4rem, 3vw, 2.4rem);
+  padding: clamp(1rem, 2.4vw, 1.9rem);
   border-radius: 1.75rem;
   border: 1px solid rgba(148, 163, 184, 0.22);
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 240, 0.6));
@@ -83,7 +83,7 @@
   position: relative;
   z-index: 1;
   display: grid;
-  gap: clamp(1.1rem, 3vw, 1.8rem);
+  gap: clamp(0.8rem, 2.4vw, 1.4rem);
   grid-template-areas:
     'brand'
     'nav'


### PR DESCRIPTION
## Summary
- reduce the shell header padding to remove excess vertical whitespace
- decrease the internal surface padding and grid gap so the layout stays compact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d36d8b80348320b9c07a735e217b9b