### PR TITLE
Emphasize recent completions in competency evaluations

### DIFF
--- a/backend/app/migrations.py
+++ b/backend/app/migrations.py
@@ -159,12 +159,46 @@ def _ensure_user_profile_columns(engine: Engine) -> None:
             )
 
 
+def _datetime_column_type(dialect_name: str) -> str:
+    if dialect_name == "postgresql":
+        return "TIMESTAMP WITH TIME ZONE"
+    if dialect_name == "mysql":
+        return "DATETIME(6)"
+    return "DATETIME"
+
+
+def _ensure_completion_timestamps(engine: Engine) -> None:
+    column_type = _datetime_column_type(engine.dialect.name)
+
+    with engine.connect() as connection:
+        inspector = inspect(connection)
+        tables = {
+            table: _column_names(inspector, table)
+            for table in ("cards", "subtasks")
+            if _table_exists(inspector, table)
+        }
+
+    for table_name, columns in tables.items():
+        if "completed_at" in columns:
+            continue
+
+        try:
+            with engine.begin() as connection:
+                connection.execute(
+                    text(f"ALTER TABLE {table_name} ADD COLUMN completed_at {column_type}")
+                )
+        except SQLAlchemyError as exc:
+            if not _is_duplicate_column_error(exc):
+                raise
+
+
 def run_startup_migrations(engine: Engine) -> None:
     """Ensure database upgrades that rely on application startup are applied."""
 
     _ensure_users_is_admin_column(engine)
     _ensure_user_profile_columns(engine)
     _promote_first_user_to_admin(engine)
+    _ensure_completion_timestamps(engine)
 
 
 __all__: Iterable[str] = ["run_startup_migrations"]

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -141,6 +141,7 @@ class Card(Base, TimestampMixin):
     )
     ai_similarity_vector_id: Mapped[str | None] = mapped_column(String)
     analytics_notes: Mapped[str | None] = mapped_column(Text)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     owner_id: Mapped[str] = mapped_column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
 
     labels: Mapped[list[Label]] = relationship(
@@ -204,6 +205,7 @@ class Subtask(Base, TimestampMixin):
     root_cause_node_id: Mapped[str | None] = mapped_column(
         String, ForeignKey("root_cause_nodes.id", ondelete="SET NULL"), nullable=True
     )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     card: Mapped[Card] = relationship("Card", back_populates="subtasks")
     root_cause_node: Mapped[Optional["RootCauseNode"]] = relationship("RootCauseNode", back_populates="subtasks")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -196,6 +196,7 @@ class SubtaskRead(SubtaskBase):
     id: str
     created_at: datetime
     updated_at: datetime
+    completed_at: Optional[datetime] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -251,6 +252,7 @@ class CardRead(CardBase):
     owner_id: str
     created_at: datetime
     updated_at: datetime
+    completed_at: Optional[datetime] = None
     labels: List[LabelRead] = Field(default_factory=list)
     subtasks: List[SubtaskRead] = Field(default_factory=list)
     status: Optional[StatusRead] = None

--- a/backend/app/services/competency_evaluator.py
+++ b/backend/app/services/competency_evaluator.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, time, timezone
+from datetime import date, datetime, time, timezone, timedelta
 from typing import Iterable
 
 from sqlalchemy.orm import Session
 
 from .. import models
+
+
+RECENT_COMPLETION_WINDOW_DAYS = 30
+RECENT_COMPLETION_WEIGHT = 2.0
 
 
 class CompetencyEvaluator:
@@ -98,9 +102,30 @@ class CompetencyEvaluator:
             .all()
         )
 
+        recent_cutoff = max(start, end - timedelta(days=RECENT_COMPLETION_WINDOW_DAYS))
+
         completed_cards = sum(1 for card in cards if self._is_done(card.status_id, card.status))
         completed_subtasks = sum(
             1 for subtask in subtasks if self._is_status_done(subtask.status)
+        )
+
+        recent_cards_completed = sum(
+            1
+            for card in cards
+            if self._is_done(card.status_id, card.status)
+            and (
+                (completion_ts := self._completion_timestamp(card)) is not None
+                and recent_cutoff <= completion_ts <= end
+            )
+        )
+        recent_subtasks_completed = sum(
+            1
+            for subtask in subtasks
+            if self._is_status_done(subtask.status)
+            and (
+                (completion_ts := self._completion_timestamp(subtask)) is not None
+                and recent_cutoff <= completion_ts <= end
+            )
         )
 
         return {
@@ -108,6 +133,9 @@ class CompetencyEvaluator:
             "cards_completed": completed_cards,
             "subtasks_created": len(subtasks),
             "subtasks_completed": completed_subtasks,
+            "recent_cards_completed": recent_cards_completed,
+            "recent_subtasks_completed": recent_subtasks_completed,
+            "recent_completion_window_days": RECENT_COMPLETION_WINDOW_DAYS,
         }
 
     def _determine_score(
@@ -116,23 +144,39 @@ class CompetencyEvaluator:
         scale: int,
         metrics: dict[str, int],
     ) -> tuple[int, str]:
-        completed = metrics.get("cards_completed", 0) + metrics.get("subtasks_completed", 0)
+        total_completed = metrics.get("cards_completed", 0) + metrics.get(
+            "subtasks_completed",
+            0,
+        )
+        recent_completed = metrics.get("recent_cards_completed", 0) + metrics.get(
+            "recent_subtasks_completed",
+            0,
+        )
+        older_completed = max(total_completed - recent_completed, 0)
+        effective_completed = int(
+            recent_completed * RECENT_COMPLETION_WEIGHT + older_completed
+        )
+
+        metrics["recent_completed_total"] = recent_completed
+        metrics["older_completed_total"] = older_completed
+        metrics["effective_completed"] = effective_completed
+        metrics["recent_completion_weight"] = RECENT_COMPLETION_WEIGHT
 
         if scale == 3:
-            if completed >= 12:
+            if effective_completed >= 12:
                 return 3, "達成"
-            if completed >= 5:
+            if effective_completed >= 5:
                 return 2, "部分達成"
             return 1, "未達"
 
         # Five-point scale for intermediate level
-        if completed >= 20:
+        if effective_completed >= 20:
             return 5, "卓越"
-        if completed >= 12:
+        if effective_completed >= 12:
             return 4, "良好"
-        if completed >= 6:
+        if effective_completed >= 6:
             return 3, "標準"
-        if completed >= 3:
+        if effective_completed >= 3:
             return 2, "要改善"
         return 1, "未達"
 
@@ -146,6 +190,9 @@ class CompetencyEvaluator:
             f"{competency.name}に対する今月の評価は『{score_label}』です。"
             f"カード完了数は{metrics.get('cards_completed', 0)}件、"
             f"サブタスク完了数は{metrics.get('subtasks_completed', 0)}件でした。"
+            f"直近{metrics.get('recent_completion_window_days', RECENT_COMPLETION_WINDOW_DAYS)}日では"
+            f"カード{metrics.get('recent_cards_completed', 0)}件、"
+            f"サブタスク{metrics.get('recent_subtasks_completed', 0)}件を完了しています。"
         )
 
     def _build_criterion_rationale(
@@ -159,6 +206,9 @@ class CompetencyEvaluator:
                 f"全体評価は『{score_label}』です。"
                 f"カード{metrics.get('cards_completed', 0)}件、"
                 f"サブタスク{metrics.get('subtasks_completed', 0)}件を完了しました。"
+                f"直近{metrics.get('recent_completion_window_days', RECENT_COMPLETION_WINDOW_DAYS)}日では"
+                f"カード{metrics.get('recent_cards_completed', 0)}件、"
+                f"サブタスク{metrics.get('recent_subtasks_completed', 0)}件の完了が確認できています。"
             )
 
         base = f"評価項目『{criterion.title}』では『{score_label}』と判定しました。"
@@ -166,6 +216,9 @@ class CompetencyEvaluator:
             base
             + f"対象期間中の成果はカード完了{metrics.get('cards_completed', 0)}件、"
             f"サブタスク完了{metrics.get('subtasks_completed', 0)}件です。"
+            f"直近{metrics.get('recent_completion_window_days', RECENT_COMPLETION_WINDOW_DAYS)}日で"
+            f"カード{metrics.get('recent_cards_completed', 0)}件、"
+            f"サブタスク{metrics.get('recent_subtasks_completed', 0)}件を完了しています。"
         )
 
     def _build_actions(
@@ -205,6 +258,19 @@ class CompetencyEvaluator:
         start_dt = datetime.combine(start, time.min).replace(tzinfo=timezone.utc)
         end_dt = datetime.combine(end, time.max).replace(tzinfo=timezone.utc)
         return start_dt, end_dt
+
+    def _completion_timestamp(self, obj: models.Card | models.Subtask) -> datetime | None:
+        updated = self._normalize_datetime(getattr(obj, "updated_at", None))
+        created = self._normalize_datetime(getattr(obj, "created_at", None))
+        return updated or created
+
+    @staticmethod
+    def _normalize_datetime(value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
 
 __all__: Iterable[str] = ["CompetencyEvaluator"]

--- a/backend/app/services/competency_evaluator.py
+++ b/backend/app/services/competency_evaluator.py
@@ -260,9 +260,11 @@ class CompetencyEvaluator:
         return start_dt, end_dt
 
     def _completion_timestamp(self, obj: models.Card | models.Subtask) -> datetime | None:
-        updated = self._normalize_datetime(getattr(obj, "updated_at", None))
-        created = self._normalize_datetime(getattr(obj, "created_at", None))
-        return updated or created
+        completed = self._normalize_datetime(getattr(obj, "completed_at", None))
+        if completed:
+            return completed
+
+        return self._normalize_datetime(getattr(obj, "created_at", None))
 
     @staticmethod
     def _normalize_datetime(value: datetime | None) -> datetime | None:

--- a/backend/tests/test_competency_evaluator.py
+++ b/backend/tests/test_competency_evaluator.py
@@ -33,25 +33,30 @@ def test_recent_completions_are_emphasized(db_session):
 
     old_card = models.Card(title="過去カード", owner_id=user.id, status=status)
     old_card.created_at = now - timedelta(days=80)
-    old_card.updated_at = now - timedelta(days=35)
+    old_card.updated_at = now - timedelta(days=2)
+    old_card.completed_at = now - timedelta(days=35)
 
     recent_card = models.Card(title="最近カード", owner_id=user.id, status=status)
     recent_card.created_at = now - timedelta(days=20)
-    recent_card.updated_at = now - timedelta(days=5)
+    recent_card.updated_at = now - timedelta(days=1)
+    recent_card.completed_at = now - timedelta(days=5)
 
     db_session.add_all([old_card, recent_card])
 
     old_subtask = models.Subtask(card=old_card, title="過去サブタスク", status="done")
     old_subtask.created_at = now - timedelta(days=80)
-    old_subtask.updated_at = now - timedelta(days=35)
+    old_subtask.updated_at = now - timedelta(days=2)
+    old_subtask.completed_at = now - timedelta(days=35)
 
     recent_subtask_one = models.Subtask(card=recent_card, title="最近サブタスク1", status="done")
     recent_subtask_one.created_at = now - timedelta(days=20)
-    recent_subtask_one.updated_at = now - timedelta(days=5)
+    recent_subtask_one.updated_at = now - timedelta(days=1)
+    recent_subtask_one.completed_at = now - timedelta(days=5)
 
     recent_subtask_two = models.Subtask(card=recent_card, title="最近サブタスク2", status="done")
     recent_subtask_two.created_at = now - timedelta(days=18)
-    recent_subtask_two.updated_at = now - timedelta(days=3)
+    recent_subtask_two.updated_at = now - timedelta(days=1)
+    recent_subtask_two.completed_at = now - timedelta(days=3)
 
     db_session.add_all([old_subtask, recent_subtask_one, recent_subtask_two])
     db_session.flush()
@@ -79,3 +84,48 @@ def test_recent_completions_are_emphasized(db_session):
     assert evaluation.score_label == "標準"
     assert "直近30日" in evaluation.rationale
     assert evaluation.items[0].rationale.count("直近30日") == 1
+
+
+def test_editing_completed_work_does_not_count_as_recent(db_session):
+    now = datetime.now(timezone.utc)
+    today = now.date()
+    period_start = today - timedelta(days=200)
+
+    user = models.User(email="member@example.com", password_hash="hashed")
+    competency = models.Competency(name="完了済みテスト", level="intermediate")
+    db_session.add_all([user, competency])
+    db_session.flush()
+
+    status = models.Status(name="完了", category="done", owner_id=user.id)
+    db_session.add(status)
+    db_session.flush()
+
+    card = models.Card(title="完了済みカード", owner_id=user.id, status=status)
+    card.created_at = now - timedelta(days=150)
+    card.updated_at = now - timedelta(days=2)
+    card.completed_at = now - timedelta(days=90)
+
+    subtask = models.Subtask(card=card, title="完了済みサブタスク", status="done")
+    subtask.created_at = now - timedelta(days=150)
+    subtask.updated_at = now - timedelta(days=1)
+    subtask.completed_at = now - timedelta(days=90)
+
+    db_session.add_all([card, subtask])
+    db_session.flush()
+
+    evaluator = CompetencyEvaluator(db_session)
+    evaluation = evaluator.evaluate(
+        user=user,
+        competency=competency,
+        period_start=period_start,
+        period_end=today,
+        triggered_by="test",
+    )
+
+    metrics = evaluation.context["metrics"]
+    assert metrics["cards_completed"] == 1
+    assert metrics["subtasks_completed"] == 1
+    assert metrics["recent_cards_completed"] == 0
+    assert metrics["recent_subtasks_completed"] == 0
+    assert metrics["recent_completed_total"] == 0
+    assert metrics["older_completed_total"] == 2

--- a/backend/tests/test_competency_evaluator.py
+++ b/backend/tests/test_competency_evaluator.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app import models
+from app.services.competency_evaluator import CompetencyEvaluator
+
+from .conftest import TestingSessionLocal
+
+
+@pytest.fixture()
+def db_session(client):
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_recent_completions_are_emphasized(db_session):
+    now = datetime.now(timezone.utc)
+    today = now.date()
+    period_start = today - timedelta(days=120)
+
+    user = models.User(email="member@example.com", password_hash="hashed")
+    competency = models.Competency(name="成長テスト", level="intermediate")
+    db_session.add_all([user, competency])
+    db_session.flush()
+
+    status = models.Status(name="完了", category="done", owner_id=user.id)
+    db_session.add(status)
+    db_session.flush()
+
+    old_card = models.Card(title="過去カード", owner_id=user.id, status=status)
+    old_card.created_at = now - timedelta(days=80)
+    old_card.updated_at = now - timedelta(days=35)
+
+    recent_card = models.Card(title="最近カード", owner_id=user.id, status=status)
+    recent_card.created_at = now - timedelta(days=20)
+    recent_card.updated_at = now - timedelta(days=5)
+
+    db_session.add_all([old_card, recent_card])
+
+    old_subtask = models.Subtask(card=old_card, title="過去サブタスク", status="done")
+    old_subtask.created_at = now - timedelta(days=80)
+    old_subtask.updated_at = now - timedelta(days=35)
+
+    recent_subtask_one = models.Subtask(card=recent_card, title="最近サブタスク1", status="done")
+    recent_subtask_one.created_at = now - timedelta(days=20)
+    recent_subtask_one.updated_at = now - timedelta(days=5)
+
+    recent_subtask_two = models.Subtask(card=recent_card, title="最近サブタスク2", status="done")
+    recent_subtask_two.created_at = now - timedelta(days=18)
+    recent_subtask_two.updated_at = now - timedelta(days=3)
+
+    db_session.add_all([old_subtask, recent_subtask_one, recent_subtask_two])
+    db_session.flush()
+
+    evaluator = CompetencyEvaluator(db_session)
+    evaluation = evaluator.evaluate(
+        user=user,
+        competency=competency,
+        period_start=period_start,
+        period_end=today,
+        triggered_by="test",
+    )
+
+    metrics = evaluation.context["metrics"]
+    assert metrics["cards_completed"] == 2
+    assert metrics["subtasks_completed"] == 3
+    assert metrics["recent_cards_completed"] == 1
+    assert metrics["recent_subtasks_completed"] == 2
+    assert metrics["effective_completed"] == 8
+    assert metrics["recent_completed_total"] == 3
+    assert metrics["older_completed_total"] == 2
+    assert metrics["recent_completion_window_days"] == 30
+
+    assert evaluation.score_value == 3
+    assert evaluation.score_label == "標準"
+    assert "直近30日" in evaluation.rationale
+    assert evaluation.items[0].rationale.count("直近30日") == 1


### PR DESCRIPTION
## Summary
- add weighting for cards and subtasks completed within the last 30 days when calculating competency scores
- surface recent completion metrics in rationales so growth is acknowledged in evaluation narratives
- cover the new behavior with a dedicated test that ensures weighted scoring and messaging behave as expected

## Testing
- pytest backend/tests


------
https://chatgpt.com/codex/tasks/task_e_68d370a7a8e48320aa255ff97e9a851d