### PR TITLE
Align status and label settings widths

### DIFF
--- a/frontend/src/app/features/settings/page.html
+++ b/frontend/src/app/features/settings/page.html
@@ -7,7 +7,7 @@
     </p>
   </header>
 
-  <div class="grid gap-6 lg:grid-cols-[2fr_1fr]">
+  <div class="grid gap-6 lg:grid-cols-2">
     <section class="surface-panel space-y-6 px-8 py-8">
       <h3 class="text-lg font-semibold text-on-surface">ステータス設定</h3>
       <ul class="space-y-3">


### PR DESCRIPTION
## Summary
- ensure the status and label configuration panels use equal column widths on large screens

## Testing
- npm run format:check *(fails: existing formatting issues reported in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3986b62f883208e2e4a4685be2b7b