### PR TITLE
refactor: normalize css theme tokens

### DIFF
--- a/frontend/src/app/core/layout/shell/help-dialog.scss
+++ b/frontend/src/app/core/layout/shell/help-dialog.scss
@@ -17,7 +17,7 @@
 .help-dialog__backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(15, 23, 42, 0.62);
+  background: color-mix(in srgb, var(--surface-inverse) 62%, transparent);
   backdrop-filter: blur(14px);
 }
 
@@ -60,7 +60,7 @@
   font-weight: 700;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: rgba(37, 99, 235, 0.8);
+  color: color-mix(in srgb, var(--accent) 80%, transparent);
 }
 
 .help-dialog__title {
@@ -85,7 +85,7 @@
   border: 1px solid var(--border-overlay);
   background: var(--surface-overlay);
   color: var(--text-secondary);
-  box-shadow: 0 16px 44px -30px rgba(37, 99, 235, 0.5);
+  box-shadow: 0 16px 44px -30px color-mix(in srgb, var(--accent) 50%, transparent);
   transition:
     transform 150ms ease,
     box-shadow 150ms ease,
@@ -97,7 +97,7 @@
   transform: translateY(-1px);
   border-color: var(--border-overlay-strong);
   background: var(--surface-overlay-strong);
-  box-shadow: 0 22px 50px -28px rgba(37, 99, 235, 0.55);
+  box-shadow: 0 22px 50px -28px color-mix(in srgb, var(--accent) 55%, transparent);
   color: var(--text-primary);
 }
 
@@ -132,8 +132,8 @@
   border: 1px solid var(--border-overlay);
   background: var(--surface-overlay);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.45),
-    0 20px 40px -32px rgba(15, 23, 42, 0.45);
+    inset 0 1px 0 color-mix(in srgb, var(--on-surface-inverse) 45%, transparent),
+    0 20px 40px -32px color-mix(in srgb, var(--surface-inverse) 45%, transparent);
   overflow: hidden;
 }
 
@@ -172,7 +172,7 @@
   border: 1px solid var(--border-overlay);
   background: var(--surface-overlay-muted);
   padding: 1.25rem 1.5rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--on-surface-inverse) 40%, transparent);
 }
 
 .help-dialog__faq-question {
@@ -203,7 +203,7 @@
   color: var(--on-surface-inverse);
   font-weight: 700;
   letter-spacing: 0.02em;
-  box-shadow: 0 22px 48px -28px rgba(37, 99, 235, 0.55);
+  box-shadow: 0 22px 48px -28px color-mix(in srgb, var(--accent) 55%, transparent);
   cursor: pointer;
   transition:
     transform 150ms ease,
@@ -212,11 +212,11 @@
 
 .help-dialog__primary:hover {
   transform: translateY(-1px);
-  box-shadow: 0 26px 56px -26px rgba(37, 99, 235, 0.65);
+  box-shadow: 0 26px 56px -26px color-mix(in srgb, var(--accent) 65%, transparent);
 }
 
 :host-context(.dark) .help-dialog__backdrop {
-  background: rgba(2, 6, 23, 0.7);
+  background: color-mix(in srgb, var(--surface-inverse) 70%, transparent);
 }
 
 @media (max-width: 640px) {

--- a/frontend/src/app/core/layout/shell/shell.scss
+++ b/frontend/src/app/core/layout/shell/shell.scss
@@ -325,12 +325,12 @@
   gap: 0.6rem;
   padding: 0.6rem 1.1rem;
   border-radius: 0.85rem;
-  border: 1px solid rgba(34, 197, 94, 0.42);
-  background: rgba(240, 253, 244, 0.96);
-  color: rgba(22, 101, 52, 0.92);
+  border: 1px solid color-mix(in srgb, var(--success) 42%, transparent);
+  background: color-mix(in srgb, var(--success) 20%, var(--surface-card));
+  color: color-mix(in srgb, var(--success-strong) 92%, var(--text-primary));
   font-size: 0.82rem;
   font-weight: 600;
-  box-shadow: 0 18px 40px -28px rgba(16, 185, 129, 0.3);
+  box-shadow: 0 18px 40px -28px color-mix(in srgb, var(--success) 30%, transparent);
   pointer-events: none;
 }
 

--- a/frontend/src/app/features/auth/login/page.scss
+++ b/frontend/src/app/features/auth/login/page.scss
@@ -2,9 +2,21 @@
   display: block;
   min-height: 100vh;
   background:
-    radial-gradient(circle at top left, rgba(59, 130, 246, 0.12), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(192, 38, 211, 0.12), transparent 55%),
-    linear-gradient(180deg, rgba(15, 23, 42, 0.04), rgba(15, 23, 42, 0));
+    radial-gradient(
+      circle at top left,
+      color-mix(in srgb, var(--accent) 12%, transparent),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at bottom right,
+      color-mix(in srgb, var(--accent-secondary) 12%, transparent),
+      transparent 55%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--surface-inverse) 4%, transparent),
+      transparent
+    );
 }
 
 .auth-wrapper {
@@ -39,13 +51,13 @@
   font-weight: 600;
   letter-spacing: 0.02em;
   text-transform: uppercase;
-  background: rgba(59, 130, 246, 0.15);
-  color: rgb(37, 99, 235);
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent);
 }
 
 .panel-badge.accent {
-  background: rgba(16, 185, 129, 0.18);
-  color: rgb(4, 120, 87);
+  background: color-mix(in srgb, var(--success) 18%, transparent);
+  color: var(--success-strong);
 }
 
 .panel-title {
@@ -57,14 +69,18 @@
 }
 
 .login-panel {
-  border-top: 4px solid rgba(59, 130, 246, 0.35);
+  border-top: 4px solid color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
 .register-panel {
-  border-top: 4px solid rgba(16, 185, 129, 0.45);
-  border: 1px solid rgba(16, 185, 129, 0.2);
-  background: linear-gradient(160deg, rgba(236, 253, 245, 0.65), rgba(224, 242, 254, 0.4));
-  box-shadow: 0 20px 40px rgba(16, 185, 129, 0.15);
+  border-top: 4px solid color-mix(in srgb, var(--success) 45%, transparent);
+  border: 1px solid color-mix(in srgb, var(--success) 20%, transparent);
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--success) 12%, var(--surface-card)),
+    color-mix(in srgb, var(--info) 10%, var(--surface-card))
+  );
+  box-shadow: 0 20px 40px color-mix(in srgb, var(--success) 15%, transparent);
 }
 
 .register-hints {
@@ -85,7 +101,7 @@
   width: 0.5rem;
   height: 0.5rem;
   border-radius: 50%;
-  background: rgba(16, 185, 129, 0.7);
+  background: color-mix(in srgb, var(--success) 70%, transparent);
 }
 
 .alert {
@@ -97,20 +113,20 @@
 }
 
 .alert.notice {
-  background: rgba(59, 130, 246, 0.12);
-  color: rgb(37, 99, 235);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
 }
 
 .alert.error {
-  background: rgba(248, 113, 113, 0.15);
-  color: rgb(185, 28, 28);
-  border: 1px solid rgba(248, 113, 113, 0.35);
+  background: color-mix(in srgb, var(--danger) 15%, transparent);
+  color: color-mix(in srgb, var(--danger-strong) 90%, var(--text-primary));
+  border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent);
 }
 
 .alert.success {
-  background: rgba(34, 197, 94, 0.12);
-  color: rgb(22, 101, 52);
-  border: 1px solid rgba(34, 197, 94, 0.35);
+  background: color-mix(in srgb, var(--success) 12%, transparent);
+  color: color-mix(in srgb, var(--success-strong) 90%, var(--text-primary));
+  border: 1px solid color-mix(in srgb, var(--success) 35%, transparent);
 }
 
 .field-error {
@@ -118,59 +134,75 @@
   font-size: 0.75rem;
   font-weight: 500;
   line-height: 1.4;
-  color: rgb(185, 28, 28);
+  color: color-mix(in srgb, var(--danger-strong) 90%, var(--text-primary));
 }
 
 .input-invalid {
-  border-color: rgba(248, 113, 113, 0.6);
-  box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.35);
+  border-color: color-mix(in srgb, var(--danger) 60%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--danger) 35%, transparent);
 }
 
 :host-context(.dark) {
   background:
-    radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(147, 51, 234, 0.18), transparent 55%),
-    linear-gradient(180deg, rgba(15, 23, 42, 0.4), rgba(15, 23, 42, 0.1));
+    radial-gradient(
+      circle at top left,
+      color-mix(in srgb, var(--accent) 18%, transparent),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at bottom right,
+      color-mix(in srgb, var(--accent-secondary) 18%, transparent),
+      transparent 55%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--surface-inverse) 40%, transparent),
+      color-mix(in srgb, var(--surface-inverse) 10%, transparent)
+    );
 }
 
 :host-context(.dark) .alert.notice {
-  background: rgba(59, 130, 246, 0.2);
-  color: rgba(191, 219, 254, 0.95);
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  color: color-mix(in srgb, var(--accent) 40%, var(--text-inverse-primary));
 }
 
 :host-context(.dark) .alert.error {
-  background: rgba(248, 113, 113, 0.18);
-  color: rgba(254, 226, 226, 0.92);
-  border-color: rgba(248, 113, 113, 0.35);
+  background: color-mix(in srgb, var(--danger) 18%, transparent);
+  color: color-mix(in srgb, var(--danger) 35%, var(--text-inverse-primary));
+  border-color: color-mix(in srgb, var(--danger) 35%, transparent);
 }
 
 :host-context(.dark) .panel-badge {
-  background: rgba(96, 165, 250, 0.2);
-  color: rgba(191, 219, 254, 0.9);
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  color: color-mix(in srgb, var(--accent) 45%, var(--text-inverse-primary));
 }
 
 :host-context(.dark) .panel-badge.accent {
-  background: rgba(16, 185, 129, 0.2);
-  color: rgba(167, 243, 208, 0.9);
+  background: color-mix(in srgb, var(--success) 20%, transparent);
+  color: color-mix(in srgb, var(--success) 45%, var(--text-inverse-primary));
 }
 
 :host-context(.dark) .register-panel {
-  background: linear-gradient(160deg, rgba(15, 118, 110, 0.35), rgba(14, 116, 144, 0.28));
-  border-color: rgba(20, 184, 166, 0.4);
-  box-shadow: 0 16px 36px rgba(13, 148, 136, 0.25);
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--success) 28%, transparent),
+    color-mix(in srgb, var(--info) 24%, transparent)
+  );
+  border-color: color-mix(in srgb, var(--success) 40%, transparent);
+  box-shadow: 0 16px 36px color-mix(in srgb, var(--success) 25%, transparent);
 }
 
 :host-context(.dark) .alert.success {
-  background: rgba(34, 197, 94, 0.2);
-  color: rgba(187, 247, 208, 0.95);
-  border-color: rgba(34, 197, 94, 0.35);
+  background: color-mix(in srgb, var(--success) 20%, transparent);
+  color: color-mix(in srgb, var(--success) 38%, var(--text-inverse-primary));
+  border-color: color-mix(in srgb, var(--success) 35%, transparent);
 }
 
 :host-context(.dark) .field-error {
-  color: rgba(254, 226, 226, 0.92);
+  color: color-mix(in srgb, var(--danger) 35%, var(--text-inverse-primary));
 }
 
 :host-context(.dark) .input-invalid {
-  border-color: rgba(248, 113, 113, 0.55);
-  box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.3);
+  border-color: color-mix(in srgb, var(--danger) 55%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--danger) 30%, transparent);
 }

--- a/frontend/src/app/features/board/page.scss
+++ b/frontend/src/app/features/board/page.scss
@@ -33,7 +33,7 @@
   padding: 1.5rem;
   border-radius: 1.75rem;
   border: 1px solid var(--border-subtle);
-  background: linear-gradient(180deg, rgba(148, 163, 184, 0.12), rgba(148, 163, 184, 0.24));
+  background: linear-gradient(180deg, var(--neutral-surface), var(--neutral-surface-strong));
   box-shadow: var(--shadow-soft);
   transition:
     border-color 150ms ease,
@@ -47,7 +47,11 @@
 }
 
 :host-context(.dark) .board-column {
-  background: linear-gradient(180deg, rgba(30, 41, 59, 0.88), rgba(15, 23, 42, 0.92));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-strong) 88%, transparent),
+    color-mix(in srgb, var(--surface) 92%, transparent)
+  );
 }
 
 .board-column.cdk-drop-list-dragging,
@@ -65,17 +69,17 @@
 
 .board-empty {
   border-radius: 1.5rem;
-  border: 2px dashed rgba(148, 163, 184, 0.45);
+  border: 2px dashed var(--neutral-border-strong);
   padding: 2rem 1.5rem;
   text-align: center;
-  color: #64748b;
-  background: rgba(255, 255, 255, 0.55);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+  color: color-mix(in srgb, var(--text-tertiary) 70%, transparent);
+  background: color-mix(in srgb, var(--surface-card) 55%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-tertiary) 24%, transparent);
 }
 
 :host-context(.dark) .board-empty {
-  background: rgba(30, 41, 59, 0.6);
-  color: #cbd5f5;
+  background: color-mix(in srgb, var(--surface-card) 60%, transparent);
+  color: var(--text-tertiary);
 }
 
 .board-card {
@@ -133,7 +137,7 @@
   gap: 0.5rem;
   padding: 0.75rem 1rem;
   border-radius: 1rem;
-  background: rgba(148, 163, 184, 0.16);
+  background: color-mix(in srgb, var(--text-tertiary) 16%, transparent);
 }
 
 .board-badge {
@@ -142,13 +146,13 @@
   gap: 0.25rem;
   padding: 0.35rem 0.75rem;
   border-radius: 9999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--neutral-border);
+  background: color-mix(in srgb, var(--surface-card) 60%, transparent);
 }
 
 :host-context(.dark) .board-badge {
-  background: rgba(30, 41, 59, 0.6);
-  border-color: rgba(148, 163, 184, 0.5);
+  background: color-mix(in srgb, var(--surface-card) 60%, transparent);
+  border-color: var(--neutral-border-strong);
 }
 
 .cdk-drag-preview {
@@ -189,13 +193,13 @@
   align-items: center;
   padding: 0.25rem 0.65rem;
   border-radius: 9999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid var(--neutral-border);
+  background: color-mix(in srgb, var(--surface-card) 75%, transparent);
 }
 
 :host-context(.dark) .subtask-badge {
-  background: rgba(30, 41, 59, 0.65);
-  border-color: rgba(148, 163, 184, 0.5);
+  background: color-mix(in srgb, var(--surface-card) 65%, transparent);
+  border-color: var(--neutral-border-strong);
 }
 
 .subtask-card-compact-note {

--- a/frontend/src/app/features/daily-reports/page.scss
+++ b/frontend/src/app/features/daily-reports/page.scss
@@ -123,7 +123,7 @@ form {
 .section-header .remove {
   border: none;
   background: transparent;
-  color: color-mix(in srgb, #ef4444 82%, var(--text-primary));
+  color: color-mix(in srgb, var(--danger) 82%, var(--text-primary));
   font-weight: 600;
   cursor: pointer;
   padding: 0.25rem 0.5rem;
@@ -134,7 +134,7 @@ form {
 }
 
 .section-header .remove:hover:not(:disabled) {
-  background: color-mix(in srgb, #ef4444 16%, transparent);
+  background: color-mix(in srgb, var(--danger) 16%, transparent);
 }
 
 .section-header .remove:disabled {
@@ -202,11 +202,11 @@ form {
 }
 
 .feedback.error {
-  color: color-mix(in srgb, #dc2626 90%, var(--text-primary));
+  color: color-mix(in srgb, var(--danger-strong) 90%, var(--text-primary));
 }
 
 .feedback.success {
-  color: color-mix(in srgb, #15803d 90%, var(--text-primary));
+  color: color-mix(in srgb, var(--success-strong) 90%, var(--text-primary));
 }
 
 .sidebar section {
@@ -330,8 +330,8 @@ form {
   margin: 0;
   padding: 0.35rem 0.85rem;
   border-radius: 0.85rem;
-  background: color-mix(in srgb, #ef4444 18%, transparent);
-  color: color-mix(in srgb, #b91c1c 90%, var(--text-primary));
+  background: color-mix(in srgb, var(--danger) 18%, transparent);
+  color: color-mix(in srgb, var(--danger-strong) 90%, var(--text-primary));
   font-weight: 600;
 }
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -25,17 +25,42 @@
   --text-inverse-muted: #94a3b8;
   --accent: #2563eb;
   --accent-strong: #1d4ed8;
-  --accent-muted: #dbeafe;
-  --surface-overlay-strong: rgba(255, 255, 255, 0.98);
-  --surface-overlay: rgba(255, 255, 255, 0.92);
-  --surface-overlay-muted: rgba(248, 250, 252, 0.82);
-  --surface-overlay-subtle: rgba(241, 245, 249, 0.72);
-  --border-subtle: rgba(15, 23, 42, 0.08);
-  --border-card: rgba(15, 23, 42, 0.14);
-  --border-overlay: rgba(148, 163, 184, 0.24);
-  --border-overlay-strong: rgba(148, 163, 184, 0.32);
-  --shadow-soft: 0 12px 24px rgba(15, 23, 42, 0.08);
-  --shadow-strong: 0 18px 36px rgba(15, 23, 42, 0.12);
+  --accent-muted: color-mix(in srgb, var(--accent) 16%, transparent);
+  --accent-secondary: #c026d3;
+  --accent-secondary-strong: #9333ea;
+  --accent-secondary-muted: color-mix(in srgb, var(--accent-secondary) 16%, transparent);
+  --accent-glow-soft: color-mix(in srgb, var(--accent) 12%, transparent);
+  --accent-glow-strong: color-mix(in srgb, var(--accent-strong) 8%, transparent);
+  --accent-shadow-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  --accent-shadow-strong-color: color-mix(in srgb, var(--accent-strong) 45%, transparent);
+  --info: #0ea5e9;
+  --info-strong: #0284c7;
+  --info-muted: color-mix(in srgb, var(--info) 18%, transparent);
+  --success: #22c55e;
+  --success-strong: #15803d;
+  --success-muted: color-mix(in srgb, var(--success) 18%, transparent);
+  --warning: #f59e0b;
+  --warning-strong: #b45309;
+  --warning-muted: color-mix(in srgb, var(--warning) 18%, transparent);
+  --danger: #ef4444;
+  --danger-strong: #b91c1c;
+  --danger-muted: color-mix(in srgb, var(--danger) 18%, transparent);
+  --neutral-surface: color-mix(in srgb, var(--text-tertiary) 16%, transparent);
+  --neutral-surface-strong: color-mix(in srgb, var(--text-tertiary) 24%, transparent);
+  --neutral-border: color-mix(in srgb, var(--text-tertiary) 35%, transparent);
+  --neutral-border-strong: color-mix(in srgb, var(--text-tertiary) 45%, transparent);
+  --overlay-backdrop: color-mix(in srgb, var(--surface-inverse) 55%, transparent);
+  --overlay-backdrop-strong: color-mix(in srgb, var(--surface-inverse) 65%, transparent);
+  --surface-overlay-strong: color-mix(in srgb, var(--surface-card) 98%, transparent);
+  --surface-overlay: color-mix(in srgb, var(--surface-card) 92%, transparent);
+  --surface-overlay-muted: color-mix(in srgb, var(--surface-card) 82%, transparent);
+  --surface-overlay-subtle: color-mix(in srgb, var(--surface-card) 72%, transparent);
+  --border-subtle: color-mix(in srgb, var(--surface-inverse) 8%, transparent);
+  --border-card: color-mix(in srgb, var(--surface-inverse) 14%, transparent);
+  --border-overlay: color-mix(in srgb, var(--text-tertiary) 24%, transparent);
+  --border-overlay-strong: color-mix(in srgb, var(--text-tertiary) 32%, transparent);
+  --shadow-soft: 0 12px 24px color-mix(in srgb, var(--surface-inverse) 8%, transparent);
+  --shadow-strong: 0 18px 36px color-mix(in srgb, var(--surface-inverse) 12%, transparent);
   color-scheme: light;
 }
 
@@ -58,17 +83,42 @@
   --text-inverse-muted: #475569;
   --accent: #60a5fa;
   --accent-strong: #3b82f6;
-  --accent-muted: rgba(96, 165, 250, 0.16);
-  --surface-overlay-strong: rgba(15, 23, 42, 0.95);
-  --surface-overlay: rgba(15, 23, 42, 0.88);
-  --surface-overlay-muted: rgba(30, 41, 59, 0.78);
-  --surface-overlay-subtle: rgba(30, 41, 59, 0.68);
-  --border-subtle: rgba(226, 232, 240, 0.12);
-  --border-card: rgba(226, 232, 240, 0.28);
-  --border-overlay: rgba(148, 163, 184, 0.32);
-  --border-overlay-strong: rgba(148, 163, 184, 0.42);
-  --shadow-soft: 0 12px 24px rgba(15, 23, 42, 0.32);
-  --shadow-strong: 0 18px 36px rgba(15, 23, 42, 0.36);
+  --accent-muted: color-mix(in srgb, var(--accent) 16%, transparent);
+  --accent-secondary: #a855f7;
+  --accent-secondary-strong: #7c3aed;
+  --accent-secondary-muted: color-mix(in srgb, var(--accent-secondary) 20%, transparent);
+  --accent-glow-soft: color-mix(in srgb, var(--accent) 18%, transparent);
+  --accent-glow-strong: color-mix(in srgb, var(--accent-strong) 12%, transparent);
+  --accent-shadow-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  --accent-shadow-strong-color: color-mix(in srgb, var(--accent-strong) 55%, transparent);
+  --info: #38bdf8;
+  --info-strong: #0ea5e9;
+  --info-muted: color-mix(in srgb, var(--info) 22%, transparent);
+  --success: #34d399;
+  --success-strong: #22c55e;
+  --success-muted: color-mix(in srgb, var(--success) 24%, transparent);
+  --warning: #facc15;
+  --warning-strong: #f59e0b;
+  --warning-muted: color-mix(in srgb, var(--warning) 24%, transparent);
+  --danger: #f87171;
+  --danger-strong: #ef4444;
+  --danger-muted: color-mix(in srgb, var(--danger) 24%, transparent);
+  --neutral-surface: color-mix(in srgb, var(--text-inverse-tertiary) 18%, transparent);
+  --neutral-surface-strong: color-mix(in srgb, var(--text-inverse-tertiary) 28%, transparent);
+  --neutral-border: color-mix(in srgb, var(--text-inverse-tertiary) 35%, transparent);
+  --neutral-border-strong: color-mix(in srgb, var(--text-inverse-tertiary) 45%, transparent);
+  --overlay-backdrop: color-mix(in srgb, var(--surface-inverse) 70%, transparent);
+  --overlay-backdrop-strong: color-mix(in srgb, var(--surface-inverse) 78%, transparent);
+  --surface-overlay-strong: color-mix(in srgb, var(--surface-card) 95%, transparent);
+  --surface-overlay: color-mix(in srgb, var(--surface-card) 88%, transparent);
+  --surface-overlay-muted: color-mix(in srgb, var(--surface-card) 78%, transparent);
+  --surface-overlay-subtle: color-mix(in srgb, var(--surface-card) 68%, transparent);
+  --border-subtle: color-mix(in srgb, var(--surface-inverse) 12%, transparent);
+  --border-card: color-mix(in srgb, var(--surface-inverse) 28%, transparent);
+  --border-overlay: color-mix(in srgb, var(--text-inverse-tertiary) 32%, transparent);
+  --border-overlay-strong: color-mix(in srgb, var(--text-inverse-tertiary) 42%, transparent);
+  --shadow-soft: 0 12px 24px color-mix(in srgb, var(--surface-inverse) 32%, transparent);
+  --shadow-strong: 0 18px 36px color-mix(in srgb, var(--surface-inverse) 36%, transparent);
   color-scheme: dark;
 }
 
@@ -201,10 +251,10 @@ a:hover {
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: rgba(15, 23, 42, 0.16);
+  background-color: color-mix(in srgb, var(--surface-inverse) 16%, transparent);
   border-radius: 9999px;
 }
 
 .dark ::-webkit-scrollbar-thumb {
-  background-color: rgba(226, 232, 240, 0.24);
+  background-color: color-mix(in srgb, var(--text-primary) 24%, transparent);
 }

--- a/frontend/src/styles/components/_profile-dialog.scss
+++ b/frontend/src/styles/components/_profile-dialog.scss
@@ -11,7 +11,7 @@ app-profile-dialog .profile-dialog {
 app-profile-dialog .profile-dialog__backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(15, 23, 42, 0.55);
+  background: var(--overlay-backdrop);
   backdrop-filter: blur(6px);
 }
 
@@ -88,7 +88,7 @@ app-profile-dialog .profile-dialog__close:hover {
   transform: translateY(-1px);
   border-color: var(--border-overlay-strong);
   background: var(--surface-overlay-strong);
-  box-shadow: 0 18px 40px -28px rgba(37, 99, 235, 0.3);
+  box-shadow: 0 18px 40px -28px color-mix(in srgb, var(--accent) 30%, transparent);
   color: var(--text-primary);
 }
 
@@ -109,17 +109,17 @@ app-profile-dialog .profile-dialog__form {
 
 app-profile-dialog .profile-dialog__alert {
   border-radius: 1rem;
-  border: 1px solid rgba(248, 113, 113, 0.35);
-  background: rgba(254, 242, 242, 0.85);
+  border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent);
+  background: color-mix(in srgb, var(--danger) 18%, var(--surface-overlay));
   padding: 0.9rem 1rem;
-  color: rgba(153, 27, 27, 0.88);
+  color: color-mix(in srgb, var(--danger-strong) 88%, var(--text-primary));
   font-size: 0.9rem;
 }
 
 .dark app-profile-dialog .profile-dialog__alert {
-  border-color: rgba(248, 113, 113, 0.45);
-  background: rgba(69, 10, 10, 0.65);
-  color: rgba(252, 231, 243, 0.92);
+  border-color: color-mix(in srgb, var(--danger) 45%, transparent);
+  background: color-mix(in srgb, var(--danger-strong) 30%, var(--surface-overlay-strong));
+  color: color-mix(in srgb, var(--danger) 32%, var(--text-inverse-primary));
 }
 
 app-profile-dialog .profile-dialog__section {
@@ -160,11 +160,11 @@ app-profile-dialog .profile-dialog__avatar-preview {
   height: 6rem;
   border-radius: 9999px;
   overflow: hidden;
-  border: 3px solid rgba(37, 99, 235, 0.35);
+  border: 3px solid color-mix(in srgb, var(--accent) 35%, transparent);
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.3), rgba(129, 140, 248, 0.35));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 30%, transparent), color-mix(in srgb, var(--accent-strong) 35%, transparent));
   color: var(--text-secondary);
 }
 
@@ -180,7 +180,7 @@ app-profile-dialog .profile-dialog__avatar-preview svg {
 }
 
 app-profile-dialog .profile-dialog__avatar-preview--empty {
-  border-color: rgba(148, 163, 184, 0.35);
+  border-color: color-mix(in srgb, var(--text-tertiary) 35%, transparent);
 }
 
 app-profile-dialog .profile-dialog__avatar-actions {
@@ -209,14 +209,14 @@ app-profile-dialog .profile-dialog__link-button {
 }
 
 app-profile-dialog .profile-dialog__button {
-  border: 1px solid rgba(59, 130, 246, 0.5);
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(59, 130, 246, 0.35));
+  border: 1px solid color-mix(in srgb, var(--accent-strong) 50%, transparent);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent-strong) 15%, transparent), color-mix(in srgb, var(--accent-strong) 35%, transparent));
   color: var(--accent-strong);
 }
 
 app-profile-dialog .profile-dialog__button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 36px -24px rgba(37, 99, 235, 0.4);
+  box-shadow: 0 18px 36px -24px color-mix(in srgb, var(--accent) 40%, transparent);
 }
 
 app-profile-dialog .profile-dialog__link-button {
@@ -257,7 +257,7 @@ app-profile-dialog .profile-dialog__label {
 app-profile-dialog .profile-dialog__required {
   margin-left: 0.35rem;
   font-size: 0.75rem;
-  color: rgba(239, 68, 68, 0.9);
+  color: color-mix(in srgb, var(--danger) 90%, transparent);
   font-weight: 600;
 }
 
@@ -280,8 +280,8 @@ app-profile-dialog .profile-dialog__input:focus,
 app-profile-dialog .profile-dialog__select:focus,
 app-profile-dialog .profile-dialog__textarea:focus {
   outline: none;
-  border-color: rgba(37, 99, 235, 0.6);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  border-color: color-mix(in srgb, var(--accent) 60%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 app-profile-dialog .profile-dialog__textarea {
@@ -291,13 +291,13 @@ app-profile-dialog .profile-dialog__textarea {
 
 app-profile-dialog .profile-dialog__input--invalid,
 app-profile-dialog .profile-dialog__textarea--invalid {
-  border-color: rgba(239, 68, 68, 0.6);
+  border-color: color-mix(in srgb, var(--danger) 60%, transparent);
 }
 
 app-profile-dialog .profile-dialog__error {
   margin: 0;
   font-size: 0.78rem;
-  color: rgba(220, 38, 38, 0.85);
+  color: color-mix(in srgb, var(--danger) 85%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-tree {
@@ -312,15 +312,15 @@ app-profile-dialog .profile-dialog__role-category {
   gap: 0.9rem;
   padding: 1rem 1.1rem;
   border-radius: 1.1rem;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid color-mix(in srgb, var(--text-tertiary) 24%, transparent);
+  background: color-mix(in srgb, var(--surface-card) 78%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-category-title {
   margin: 0;
   font-size: 0.98rem;
   font-weight: 600;
-  color: rgba(30, 41, 59, 0.9);
+  color: color-mix(in srgb, var(--surface-strong) 90%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-children {
@@ -339,7 +339,7 @@ app-profile-dialog .profile-dialog__role-child-title {
   margin: 0;
   font-size: 0.85rem;
   font-weight: 600;
-  color: rgba(71, 85, 105, 0.9);
+  color: color-mix(in srgb, var(--text-secondary) 90%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-options {
@@ -383,7 +383,7 @@ app-profile-dialog .profile-dialog__role-option:has(input:checked) {
   border-color: var(--accent);
   background: var(--accent-muted);
   color: var(--text-primary);
-  box-shadow: 0 10px 24px -18px rgba(37, 99, 235, 0.35);
+  box-shadow: 0 10px 24px -18px color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-option:has(input:checked) span {
@@ -425,9 +425,9 @@ app-profile-dialog .profile-dialog__custom-role-item {
   gap: 0.35rem;
   padding: 0.35rem 0.7rem;
   border-radius: 9999px;
-  border: 1px solid rgba(59, 130, 246, 0.3);
-  background: rgba(59, 130, 246, 0.15);
-  color: rgba(37, 99, 235, 0.95);
+  border: 1px solid color-mix(in srgb, var(--accent-strong) 30%, transparent);
+  background: color-mix(in srgb, var(--accent-strong) 15%, transparent);
+  color: color-mix(in srgb, var(--accent) 95%, transparent);
   font-size: 0.78rem;
   font-weight: 600;
 }
@@ -459,11 +459,11 @@ app-profile-dialog .profile-dialog__custom-role-summary-label {
   margin: 0;
   font-size: 0.78rem;
   font-weight: 600;
-  color: rgba(71, 85, 105, 0.85);
+  color: color-mix(in srgb, var(--text-secondary) 85%, transparent);
 }
 
 app-profile-dialog .profile-dialog__custom-role-remove:hover {
-  background: rgba(37, 99, 235, 0.18);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 app-profile-dialog .profile-dialog__custom-role-remove svg {
@@ -472,45 +472,45 @@ app-profile-dialog .profile-dialog__custom-role-remove svg {
 }
 
 .dark app-profile-dialog .profile-dialog__role-category {
-  border-color: rgba(148, 163, 184, 0.32);
-  background: rgba(30, 41, 59, 0.72);
+  border-color: color-mix(in srgb, var(--text-tertiary) 32%, transparent);
+  background: color-mix(in srgb, var(--surface-strong) 72%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-category-title {
-  color: rgba(226, 232, 240, 0.94);
+  color: color-mix(in srgb, var(--text-primary) 94%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-child-title {
-  color: rgba(203, 213, 225, 0.85);
+  color: color-mix(in srgb, var(--text-tertiary) 85%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-option {
-  border-color: rgba(148, 163, 184, 0.32);
-  background: rgba(15, 23, 42, 0.82);
-  color: rgba(226, 232, 240, 0.9);
+  border-color: color-mix(in srgb, var(--text-tertiary) 32%, transparent);
+  background: color-mix(in srgb, var(--surface-inverse) 82%, transparent);
+  color: color-mix(in srgb, var(--text-primary) 90%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-option:hover {
-  border-color: rgba(96, 165, 250, 0.45);
-  background: rgba(59, 130, 246, 0.22);
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  background: color-mix(in srgb, var(--accent-strong) 22%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-option input:checked + span {
-  color: rgba(191, 219, 254, 0.95);
+  color: color-mix(in srgb, var(--accent) 95%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__custom-role-item {
-  border-color: rgba(96, 165, 250, 0.45);
-  background: rgba(30, 64, 175, 0.35);
-  color: rgba(191, 219, 254, 0.95);
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  background: color-mix(in srgb, var(--accent-strong) 35%, transparent);
+  color: color-mix(in srgb, var(--accent) 95%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__custom-role-summary-label {
-  color: rgba(203, 213, 225, 0.82);
+  color: color-mix(in srgb, var(--text-tertiary) 82%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__custom-role-remove:hover {
-  background: rgba(96, 165, 250, 0.28);
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-option input:checked + span {
@@ -548,17 +548,17 @@ app-profile-dialog .profile-dialog__role-summary-item {
   gap: 0.35rem;
   padding: 0.35rem 0.7rem;
   border-radius: 9999px;
-  border: 1px solid rgba(59, 130, 246, 0.3);
-  background: rgba(59, 130, 246, 0.15);
-  color: rgba(37, 99, 235, 0.95);
+  border: 1px solid color-mix(in srgb, var(--accent-strong) 30%, transparent);
+  background: color-mix(in srgb, var(--accent-strong) 15%, transparent);
+  color: color-mix(in srgb, var(--accent) 95%, transparent);
   font-size: 0.78rem;
   font-weight: 600;
 }
 
 app-profile-dialog .profile-dialog__role-summary-item--custom {
-  border-color: rgba(45, 212, 191, 0.35);
-  background: rgba(16, 185, 129, 0.12);
-  color: rgba(5, 150, 105, 0.95);
+  border-color: color-mix(in srgb, var(--success) 35%, transparent);
+  background: color-mix(in srgb, var(--success) 12%, transparent);
+  color: color-mix(in srgb, var(--success-strong) 95%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-summary-text {
@@ -575,11 +575,11 @@ app-profile-dialog .profile-dialog__role-summary-name {
 app-profile-dialog .profile-dialog__role-summary-group {
   font-size: 0.7rem;
   font-weight: 500;
-  color: rgba(37, 99, 235, 0.7);
+  color: color-mix(in srgb, var(--accent) 70%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-summary-item--custom .profile-dialog__role-summary-group {
-  color: rgba(5, 150, 105, 0.7);
+  color: color-mix(in srgb, var(--success-strong) 70%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-summary-remove {
@@ -609,11 +609,11 @@ app-profile-dialog .profile-dialog__role-summary-label {
   margin: 0;
   font-size: 0.78rem;
   font-weight: 600;
-  color: rgba(71, 85, 105, 0.85);
+  color: color-mix(in srgb, var(--text-secondary) 85%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-summary-remove:hover {
-  background: rgba(37, 99, 235, 0.18);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 app-profile-dialog .profile-dialog__role-summary-remove svg {
@@ -633,58 +633,58 @@ app-profile-dialog
 }
 
 .dark app-profile-dialog .profile-dialog__role-category {
-  border-color: rgba(148, 163, 184, 0.32);
-  background: rgba(30, 41, 59, 0.72);
+  border-color: color-mix(in srgb, var(--text-tertiary) 32%, transparent);
+  background: color-mix(in srgb, var(--surface-strong) 72%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-category-count {
-  background: rgba(37, 99, 235, 0.32);
-  color: rgba(191, 219, 254, 0.92);
+  background: color-mix(in srgb, var(--accent) 32%, transparent);
+  color: color-mix(in srgb, var(--accent) 92%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-category-toggle {
-  border-color: rgba(148, 163, 184, 0.4);
-  background: rgba(30, 41, 59, 0.88);
-  color: rgba(226, 232, 240, 0.85);
+  border-color: color-mix(in srgb, var(--text-tertiary) 40%, transparent);
+  background: color-mix(in srgb, var(--surface-strong) 88%, transparent);
+  color: color-mix(in srgb, var(--text-primary) 85%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-category-title {
-  color: rgba(226, 232, 240, 0.94);
+  color: color-mix(in srgb, var(--text-primary) 94%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-child-title {
-  color: rgba(203, 213, 225, 0.85);
+  color: color-mix(in srgb, var(--text-tertiary) 85%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-option {
-  border-color: rgba(148, 163, 184, 0.32);
-  background: rgba(15, 23, 42, 0.82);
-  color: rgba(226, 232, 240, 0.9);
+  border-color: color-mix(in srgb, var(--text-tertiary) 32%, transparent);
+  background: color-mix(in srgb, var(--surface-inverse) 82%, transparent);
+  color: color-mix(in srgb, var(--text-primary) 90%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-option:hover {
-  border-color: rgba(96, 165, 250, 0.45);
-  background: rgba(59, 130, 246, 0.22);
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  background: color-mix(in srgb, var(--accent-strong) 22%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-option input:checked + span {
-  color: rgba(191, 219, 254, 0.95);
+  color: color-mix(in srgb, var(--accent) 95%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-summary-item {
-  border-color: rgba(96, 165, 250, 0.45);
-  background: rgba(30, 64, 175, 0.35);
-  color: rgba(191, 219, 254, 0.95);
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  background: color-mix(in srgb, var(--accent-strong) 35%, transparent);
+  color: color-mix(in srgb, var(--accent) 95%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-summary-item--custom {
-  border-color: rgba(45, 212, 191, 0.4);
-  background: rgba(6, 95, 70, 0.35);
-  color: rgba(167, 243, 208, 0.95);
+  border-color: color-mix(in srgb, var(--success) 40%, transparent);
+  background: color-mix(in srgb, var(--success-strong) 35%, transparent);
+  color: color-mix(in srgb, var(--success) 95%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-summary-group {
-  color: rgba(147, 197, 253, 0.8);
+  color: color-mix(in srgb, var(--accent) 80%, transparent);
 }
 
 .dark
@@ -693,15 +693,15 @@ app-profile-dialog
   .profile-dialog__role-summary-item--custom
   app-profile-dialog
   .profile-dialog__role-summary-group {
-  color: rgba(134, 239, 172, 0.85);
+  color: color-mix(in srgb, var(--success) 85%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-summary-label {
-  color: rgba(203, 213, 225, 0.82);
+  color: color-mix(in srgb, var(--text-tertiary) 82%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-summary-remove:hover {
-  background: rgba(96, 165, 250, 0.28);
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
 }
 
 app-profile-dialog .profile-dialog__counter {
@@ -728,7 +728,7 @@ app-profile-dialog .profile-dialog__button-secondary:hover {
   transform: translateY(-1px);
   border-color: var(--border-overlay-strong);
   background: var(--surface-overlay-strong);
-  box-shadow: 0 14px 30px -24px rgba(15, 23, 42, 0.35);
+  box-shadow: 0 14px 30px -24px color-mix(in srgb, var(--surface-inverse) 35%, transparent);
   color: var(--text-primary);
 }
 
@@ -752,8 +752,8 @@ app-profile-dialog .profile-dialog__spinner {
   width: 1rem;
   height: 1rem;
   border-radius: 9999px;
-  border: 2px solid rgba(255, 255, 255, 0.6);
-  border-top-color: rgba(255, 255, 255, 0.1);
+  border: 2px solid color-mix(in srgb, var(--on-surface-inverse) 60%, transparent);
+  border-top-color: color-mix(in srgb, var(--on-surface-inverse) 10%, transparent);
   animation: profile-dialog-spin 900ms linear infinite;
 }
 

--- a/frontend/src/styles/pages/_admin.scss
+++ b/frontend/src/styles/pages/_admin.scss
@@ -2,23 +2,23 @@ app-admin-page {
   display: block;
   padding: clamp(1.5rem, 2vw, 2.5rem) 0 4rem;
   color: var(--on-surface);
-  --admin-muted: rgba(15, 23, 42, 0.65);
-  --admin-muted-strong: rgba(15, 23, 42, 0.78);
-  --admin-card-shadow: 0 18px 44px -32px rgba(37, 99, 235, 0.35);
-  --admin-panel-bg: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(14, 165, 233, 0.08));
-  --admin-subtle-bg: rgba(148, 163, 184, 0.12);
-  --admin-tabs-bg: rgba(255, 255, 255, 0.82);
-  --admin-tabs-shadow: 0 18px 40px -30px rgba(37, 99, 235, 0.28);
+  --admin-muted: color-mix(in srgb, var(--surface-inverse) 65%, transparent);
+  --admin-muted-strong: color-mix(in srgb, var(--surface-inverse) 78%, transparent);
+  --admin-card-shadow: 0 18px 44px -32px color-mix(in srgb, var(--accent) 35%, transparent);
+  --admin-panel-bg: linear-gradient(135deg, color-mix(in srgb, var(--accent) 12%, transparent), color-mix(in srgb, var(--info) 8%, transparent));
+  --admin-subtle-bg: color-mix(in srgb, var(--text-tertiary) 12%, transparent);
+  --admin-tabs-bg: color-mix(in srgb, var(--surface-card) 82%, transparent);
+  --admin-tabs-shadow: 0 18px 40px -30px color-mix(in srgb, var(--accent) 28%, transparent);
 }
 
 .dark app-admin-page {
-  --admin-muted: rgba(226, 232, 240, 0.68);
-  --admin-muted-strong: rgba(226, 232, 240, 0.82);
-  --admin-card-shadow: 0 24px 48px -28px rgba(15, 23, 42, 0.72);
-  --admin-panel-bg: linear-gradient(135deg, rgba(30, 41, 59, 0.94), rgba(15, 23, 42, 0.82));
-  --admin-subtle-bg: rgba(148, 163, 184, 0.14);
-  --admin-tabs-bg: rgba(15, 23, 42, 0.78);
-  --admin-tabs-shadow: 0 24px 48px -28px rgba(15, 23, 42, 0.75);
+  --admin-muted: color-mix(in srgb, var(--text-primary) 68%, transparent);
+  --admin-muted-strong: color-mix(in srgb, var(--text-primary) 82%, transparent);
+  --admin-card-shadow: 0 24px 48px -28px color-mix(in srgb, var(--surface-inverse) 72%, transparent);
+  --admin-panel-bg: linear-gradient(135deg, color-mix(in srgb, var(--surface-strong) 94%, transparent), color-mix(in srgb, var(--surface-inverse) 82%, transparent));
+  --admin-subtle-bg: color-mix(in srgb, var(--text-tertiary) 14%, transparent);
+  --admin-tabs-bg: color-mix(in srgb, var(--surface-inverse) 78%, transparent);
+  --admin-tabs-shadow: 0 24px 48px -28px color-mix(in srgb, var(--surface-inverse) 75%, transparent);
 }
 
 app-admin-page .admin-page {
@@ -55,22 +55,22 @@ app-admin-page .admin-header::before {
   inset: auto auto -35% -12%;
   width: clamp(16rem, 22vw, 24rem);
   aspect-ratio: 1;
-  background: radial-gradient(circle at center, rgba(37, 99, 235, 0.18), transparent 65%);
+  background: radial-gradient(circle at center, color-mix(in srgb, var(--accent) 18%, transparent), transparent 65%);
 }
 
 app-admin-page .admin-header::after {
   inset: -45% -18% auto auto;
   width: clamp(14rem, 20vw, 22rem);
   aspect-ratio: 1;
-  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.18), transparent 70%);
+  background: radial-gradient(circle at center, color-mix(in srgb, var(--info) 18%, transparent), transparent 70%);
 }
 
 .dark app-admin-page .admin-header::before {
-  background: radial-gradient(circle at center, rgba(96, 165, 250, 0.32), transparent 68%);
+  background: radial-gradient(circle at center, color-mix(in srgb, var(--accent) 32%, transparent), transparent 68%);
 }
 
 .dark app-admin-page .admin-header::after {
-  background: radial-gradient(circle at center, rgba(168, 85, 247, 0.28), transparent 70%);
+  background: radial-gradient(circle at center, color-mix(in srgb, var(--accent-secondary) 28%, transparent), transparent 70%);
 }
 
 app-admin-page .admin-header > * {
@@ -105,35 +105,35 @@ app-admin-page .admin-alert {
   border: 1px solid transparent;
   font-size: 0.95rem;
   font-weight: 500;
-  box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 18px 40px -30px color-mix(in srgb, var(--surface-inverse) 45%, transparent);
 }
 
 .dark app-admin-page .admin-alert {
-  box-shadow: 0 18px 40px -28px rgba(15, 23, 42, 0.8);
+  box-shadow: 0 18px 40px -28px color-mix(in srgb, var(--surface-inverse) 80%, transparent);
 }
 
 app-admin-page .admin-alert--error {
-  background: rgba(248, 113, 113, 0.16);
-  border-color: rgba(239, 68, 68, 0.35);
-  color: rgba(127, 29, 29, 0.95);
+  background: color-mix(in srgb, var(--danger) 16%, transparent);
+  border-color: color-mix(in srgb, var(--danger) 35%, transparent);
+  color: color-mix(in srgb, var(--danger-strong) 95%, transparent);
 }
 
 app-admin-page .admin-alert--success {
-  background: rgba(34, 197, 94, 0.18);
-  border-color: rgba(34, 197, 94, 0.32);
-  color: rgba(22, 101, 52, 0.95);
+  background: color-mix(in srgb, var(--success) 18%, transparent);
+  border-color: color-mix(in srgb, var(--success) 32%, transparent);
+  color: color-mix(in srgb, var(--success-strong) 95%, transparent);
 }
 
 .dark app-admin-page .admin-alert--error {
-  background: rgba(239, 68, 68, 0.22);
-  border-color: rgba(239, 68, 68, 0.45);
-  color: rgba(254, 226, 226, 0.92);
+  background: color-mix(in srgb, var(--danger) 22%, transparent);
+  border-color: color-mix(in srgb, var(--danger) 45%, transparent);
+  color: color-mix(in srgb, var(--danger) 92%, transparent);
 }
 
 .dark app-admin-page .admin-alert--success {
-  background: rgba(34, 197, 94, 0.22);
-  border-color: rgba(34, 197, 94, 0.45);
-  color: rgba(187, 247, 208, 0.92);
+  background: color-mix(in srgb, var(--success) 22%, transparent);
+  border-color: color-mix(in srgb, var(--success) 45%, transparent);
+  color: color-mix(in srgb, var(--success) 92%, transparent);
 }
 
 app-admin-page .admin-alert__close {
@@ -143,7 +143,7 @@ app-admin-page .admin-alert__close {
   padding: 0.4rem 0.9rem;
   font-size: 0.85rem;
   font-weight: 600;
-  background: rgba(255, 255, 255, 0.7);
+  background: color-mix(in srgb, var(--surface-card) 70%, transparent);
   color: inherit;
   cursor: pointer;
   transition:
@@ -152,16 +152,16 @@ app-admin-page .admin-alert__close {
 }
 
 app-admin-page .admin-alert__close:hover {
-  background: rgba(255, 255, 255, 0.9);
+  background: color-mix(in srgb, var(--surface-card) 90%, transparent);
   transform: translateY(-1px);
 }
 
 .dark app-admin-page .admin-alert__close {
-  background: rgba(15, 23, 42, 0.6);
+  background: color-mix(in srgb, var(--surface-inverse) 60%, transparent);
 }
 
 .dark app-admin-page .admin-alert__close:hover {
-  background: rgba(30, 41, 59, 0.72);
+  background: color-mix(in srgb, var(--surface-strong) 72%, transparent);
 }
 
 app-admin-page .admin-tabs {
@@ -206,7 +206,7 @@ app-admin-page .admin-tabs__button {
 
 app-admin-page .admin-tabs__button:hover {
   color: var(--accent-strong);
-  background: rgba(37, 99, 235, 0.08);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 app-admin-page .admin-tabs__button:focus-visible {
@@ -217,12 +217,12 @@ app-admin-page .admin-tabs__button:focus-visible {
 app-admin-page .admin-tabs__button--active {
   color: var(--on-surface-inverse);
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  box-shadow: 0 16px 40px -28px rgba(37, 99, 235, 0.55);
+  box-shadow: 0 16px 40px -28px color-mix(in srgb, var(--accent) 55%, transparent);
   transform: translateY(-1px);
 }
 
 .dark app-admin-page .admin-tabs__button:hover {
-  background: rgba(148, 163, 184, 0.16);
+  background: color-mix(in srgb, var(--text-tertiary) 16%, transparent);
 }
 
 app-admin-page .admin-section {
@@ -237,7 +237,7 @@ app-admin-page .admin-section {
 }
 
 .dark app-admin-page .admin-section {
-  background: linear-gradient(180deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.92));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface-strong) 90%, transparent), color-mix(in srgb, var(--surface-inverse) 92%, transparent));
 }
 
 app-admin-page .admin-section__header {
@@ -286,7 +286,7 @@ app-admin-page .admin-list__item {
   padding: 1.1rem 1.25rem;
   border-radius: 1.5rem;
   border: 1px solid var(--border-card);
-  background: linear-gradient(180deg, var(--surface-card), rgba(255, 255, 255, 0.9));
+  background: linear-gradient(180deg, var(--surface-card), color-mix(in srgb, var(--surface-card) 90%, transparent));
   box-shadow: var(--admin-card-shadow);
   transition:
     transform 150ms ease,
@@ -299,7 +299,7 @@ app-admin-page .admin-list__item:hover {
 }
 
 .dark app-admin-page .admin-list__item {
-  background: linear-gradient(180deg, rgba(30, 41, 59, 0.82), rgba(15, 23, 42, 0.88));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface-strong) 82%, transparent), color-mix(in srgb, var(--surface-inverse) 88%, transparent));
 }
 
 app-admin-page .admin-list__heading {
@@ -404,7 +404,7 @@ app-admin-page .admin-field textarea {
 
 app-admin-page .admin-field input::placeholder,
 app-admin-page .admin-field textarea::placeholder {
-  color: rgba(148, 163, 184, 0.7);
+  color: color-mix(in srgb, var(--text-tertiary) 70%, transparent);
 }
 
 app-admin-page .admin-field input:focus-visible,
@@ -412,21 +412,21 @@ app-admin-page .admin-field select:focus-visible,
 app-admin-page .admin-field textarea:focus-visible {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
   background: var(--surface-card);
 }
 
 .dark app-admin-page .admin-field input,
 .dark app-admin-page .admin-field select,
 .dark app-admin-page .admin-field textarea {
-  background: rgba(15, 23, 42, 0.72);
+  background: color-mix(in srgb, var(--surface-inverse) 72%, transparent);
   color: var(--on-surface);
-  border-color: rgba(148, 163, 184, 0.28);
+  border-color: color-mix(in srgb, var(--text-tertiary) 28%, transparent);
 }
 
 .dark app-admin-page .admin-field input::placeholder,
 .dark app-admin-page .admin-field textarea::placeholder {
-  color: rgba(148, 163, 184, 0.65);
+  color: color-mix(in srgb, var(--text-tertiary) 65%, transparent);
 }
 
 app-admin-page .admin-field--full {
@@ -456,12 +456,12 @@ app-admin-page .admin-button:focus-visible {
 app-admin-page .admin-button--primary {
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
   color: var(--on-surface-inverse);
-  box-shadow: 0 18px 44px -28px rgba(37, 99, 235, 0.55);
+  box-shadow: 0 18px 44px -28px color-mix(in srgb, var(--accent) 55%, transparent);
 }
 
 app-admin-page .admin-button--primary:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 22px 48px -26px rgba(37, 99, 235, 0.65);
+  box-shadow: 0 22px 48px -26px color-mix(in srgb, var(--accent) 65%, transparent);
 }
 
 app-admin-page .admin-button--primary:disabled {
@@ -472,22 +472,22 @@ app-admin-page .admin-button--primary:disabled {
 }
 
 app-admin-page .admin-button--ghost {
-  background: rgba(148, 163, 184, 0.16);
+  background: color-mix(in srgb, var(--text-tertiary) 16%, transparent);
   color: var(--admin-muted-strong);
 }
 
 app-admin-page .admin-button--ghost:hover {
-  background: rgba(148, 163, 184, 0.24);
+  background: color-mix(in srgb, var(--text-tertiary) 24%, transparent);
   transform: translateY(-1px);
 }
 
 .dark app-admin-page .admin-button--ghost {
-  background: rgba(148, 163, 184, 0.18);
+  background: color-mix(in srgb, var(--text-tertiary) 18%, transparent);
   color: var(--admin-muted-strong);
 }
 
 .dark app-admin-page .admin-button--ghost:hover {
-  background: rgba(148, 163, 184, 0.24);
+  background: color-mix(in srgb, var(--text-tertiary) 24%, transparent);
 }
 
 app-admin-page .admin-criteria {
@@ -512,12 +512,12 @@ app-admin-page .admin-criteria__row {
   padding: 1rem;
   border-radius: 1.25rem;
   border: 1px solid var(--border-card);
-  background: rgba(148, 163, 184, 0.08);
+  background: color-mix(in srgb, var(--text-tertiary) 8%, transparent);
   box-shadow: var(--admin-card-shadow);
 }
 
 .dark app-admin-page .admin-criteria__row {
-  background: rgba(30, 41, 59, 0.72);
+  background: color-mix(in srgb, var(--surface-strong) 72%, transparent);
 }
 
 app-admin-page .admin-criteria__row .admin-button {
@@ -539,7 +539,7 @@ app-admin-page .admin-evaluations__item {
   padding: 1.2rem;
   border-radius: 1.5rem;
   border: 1px solid var(--border-card);
-  background: linear-gradient(180deg, var(--surface-card), rgba(255, 255, 255, 0.92));
+  background: linear-gradient(180deg, var(--surface-card), color-mix(in srgb, var(--surface-card) 92%, transparent));
   box-shadow: var(--admin-card-shadow);
   transition:
     transform 150ms ease,
@@ -552,7 +552,7 @@ app-admin-page .admin-evaluations__item:hover {
 }
 
 .dark app-admin-page .admin-evaluations__item {
-  background: linear-gradient(180deg, rgba(30, 41, 59, 0.86), rgba(15, 23, 42, 0.9));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface-strong) 86%, transparent), color-mix(in srgb, var(--surface-inverse) 90%, transparent));
 }
 
 app-admin-page .admin-evaluations__header {
@@ -590,7 +590,7 @@ app-admin-page .admin-table__wrapper {
 }
 
 .dark app-admin-page .admin-table__wrapper {
-  background: linear-gradient(180deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.92));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface-strong) 90%, transparent), color-mix(in srgb, var(--surface-inverse) 92%, transparent));
 }
 
 app-admin-page .admin-table {
@@ -601,11 +601,11 @@ app-admin-page .admin-table {
 }
 
 app-admin-page .admin-table thead {
-  background: rgba(148, 163, 184, 0.14);
+  background: color-mix(in srgb, var(--text-tertiary) 14%, transparent);
 }
 
 .dark app-admin-page .admin-table thead {
-  background: rgba(148, 163, 184, 0.12);
+  background: color-mix(in srgb, var(--text-tertiary) 12%, transparent);
 }
 
 app-admin-page .admin-table th,
@@ -624,19 +624,19 @@ app-admin-page .admin-table th {
 }
 
 app-admin-page .admin-table tbody tr:nth-child(even) {
-  background: rgba(148, 163, 184, 0.06);
+  background: color-mix(in srgb, var(--text-tertiary) 6%, transparent);
 }
 
 .dark app-admin-page .admin-table tbody tr:nth-child(even) {
-  background: rgba(148, 163, 184, 0.08);
+  background: color-mix(in srgb, var(--text-tertiary) 8%, transparent);
 }
 
 app-admin-page .admin-table tbody tr:hover {
-  background: rgba(37, 99, 235, 0.04);
+  background: color-mix(in srgb, var(--accent) 4%, transparent);
 }
 
 .dark app-admin-page .admin-table tbody tr:hover {
-  background: rgba(37, 99, 235, 0.12);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 app-admin-page .admin-table tbody tr:last-child td {
@@ -663,12 +663,12 @@ app-admin-page .admin-table input[type='number'] {
 app-admin-page .admin-table input[type='number']:focus-visible {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .dark app-admin-page .admin-table input[type='number'] {
-  background: rgba(15, 23, 42, 0.72);
-  border-color: rgba(148, 163, 184, 0.28);
+  background: color-mix(in srgb, var(--surface-inverse) 72%, transparent);
+  border-color: color-mix(in srgb, var(--text-tertiary) 28%, transparent);
   color: var(--on-surface);
 }
 

--- a/frontend/src/styles/pages/_profile-evaluations.scss
+++ b/frontend/src/styles/pages/_profile-evaluations.scss
@@ -15,15 +15,13 @@ app-profile-evaluations-page .page-header {
   gap: 1.5rem;
   padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.25rem, 3vw, 2rem);
   border-radius: 2rem;
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.05));
-  border: 1px solid rgba(37, 99, 235, 0.15);
-  box-shadow: 0 24px 48px -32px rgba(37, 99, 235, 0.35);
-}
-
-.dark app-profile-evaluations-page .page-header {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(14, 165, 233, 0.12));
-  border-color: rgba(96, 165, 250, 0.25);
-  box-shadow: 0 24px 48px -28px rgba(14, 165, 233, 0.4);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent) 12%, transparent),
+    color-mix(in srgb, var(--info) 8%, transparent)
+  );
+  border: 1px solid color-mix(in srgb, var(--accent) 15%, transparent);
+  box-shadow: 0 24px 48px -32px var(--accent-shadow-color);
 }
 
 app-profile-evaluations-page .page-header__content {
@@ -38,11 +36,7 @@ app-profile-evaluations-page .page-eyebrow {
   font-weight: 600;
   letter-spacing: 0.3em;
   text-transform: uppercase;
-  color: rgba(37, 99, 235, 0.85);
-}
-
-.dark app-profile-evaluations-page .page-eyebrow {
-  color: rgba(147, 197, 253, 0.9);
+  color: color-mix(in srgb, var(--accent) 85%, var(--text-primary));
 }
 
 app-profile-evaluations-page .page-title {
@@ -54,11 +48,7 @@ app-profile-evaluations-page .page-title {
 app-profile-evaluations-page .page-description {
   font-size: 0.95rem;
   line-height: 1.8;
-  color: rgba(15, 23, 42, 0.7);
-}
-
-.dark app-profile-evaluations-page .page-description {
-  color: rgba(226, 232, 240, 0.76);
+  color: color-mix(in srgb, var(--text-primary) 70%, transparent);
 }
 
 app-profile-evaluations-page .page-header__actions {
@@ -123,9 +113,9 @@ app-profile-evaluations-page .secondary-button {
   justify-content: center;
   padding: 0.6rem 1.25rem;
   border-radius: 9999px;
-  border: 1px solid rgba(37, 99, 235, 0.35);
-  background: rgba(255, 255, 255, 0.85);
-  color: rgba(37, 99, 235, 0.9);
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  background: color-mix(in srgb, var(--surface-card) 85%, transparent);
+  color: color-mix(in srgb, var(--accent) 90%, var(--text-primary));
   font-weight: 600;
   font-size: 0.85rem;
   transition:
@@ -135,15 +125,9 @@ app-profile-evaluations-page .secondary-button {
 }
 
 app-profile-evaluations-page .secondary-button:hover:not(:disabled) {
-  border-color: rgba(37, 99, 235, 0.55);
-  background: rgba(219, 234, 254, 0.85);
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  background: color-mix(in srgb, var(--accent-muted) 85%, var(--surface-card));
   transform: translateY(-1px);
-}
-
-.dark app-profile-evaluations-page .secondary-button {
-  background: rgba(30, 41, 59, 0.85);
-  border-color: rgba(96, 165, 250, 0.35);
-  color: rgba(191, 219, 254, 0.95);
 }
 
 app-profile-evaluations-page .secondary-button:disabled {
@@ -156,8 +140,8 @@ app-profile-evaluations-page .quota-card {
   flex: 1 1 16rem;
   padding: 1rem 1.25rem;
   border-radius: 1.5rem;
-  border: 1px solid rgba(37, 99, 235, 0.25);
-  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
+  background: color-mix(in srgb, var(--surface-card) 82%, transparent);
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -165,8 +149,8 @@ app-profile-evaluations-page .quota-card {
 }
 
 .dark app-profile-evaluations-page .quota-card {
-  background: rgba(15, 23, 42, 0.65);
-  border-color: rgba(147, 197, 253, 0.35);
+  background: color-mix(in srgb, var(--surface-inverse) 65%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
 app-profile-evaluations-page .quota-card__label {
@@ -174,11 +158,11 @@ app-profile-evaluations-page .quota-card__label {
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(37, 99, 235, 0.85);
+  color: color-mix(in srgb, var(--accent) 85%, transparent);
 }
 
 .dark app-profile-evaluations-page .quota-card__label {
-  color: rgba(191, 219, 254, 0.9);
+  color: color-mix(in srgb, var(--accent) 90%, transparent);
 }
 
 app-profile-evaluations-page .quota-card__values {
@@ -191,48 +175,48 @@ app-profile-evaluations-page .quota-card__values {
 }
 
 .dark app-profile-evaluations-page .quota-card__values {
-  color: rgba(226, 232, 240, 0.92);
+  color: color-mix(in srgb, var(--text-primary) 92%, transparent);
 }
 
 app-profile-evaluations-page .quota-card__separator {
   font-size: 1rem;
-  color: rgba(59, 130, 246, 0.8);
+  color: color-mix(in srgb, var(--accent-strong) 80%, transparent);
 }
 
 app-profile-evaluations-page .quota-card__value--remaining {
-  color: rgba(22, 163, 74, 0.9);
+  color: color-mix(in srgb, var(--success) 90%, transparent);
 }
 
 .dark app-profile-evaluations-page .quota-card__value--remaining {
-  color: rgba(134, 239, 172, 0.85);
+  color: color-mix(in srgb, var(--success) 85%, transparent);
 }
 
 app-profile-evaluations-page .quota-card__meta {
   font-size: 0.85rem;
-  color: rgba(71, 85, 105, 0.75);
+  color: color-mix(in srgb, var(--text-secondary) 75%, transparent);
 }
 
 .dark app-profile-evaluations-page .quota-card__meta {
-  color: rgba(148, 163, 184, 0.8);
+  color: color-mix(in srgb, var(--text-tertiary) 80%, transparent);
 }
 
 app-profile-evaluations-page .quota-card__warning {
   font-size: 0.8rem;
   font-weight: 600;
-  color: rgba(220, 38, 38, 0.9);
+  color: color-mix(in srgb, var(--danger) 90%, transparent);
 }
 
 .dark app-profile-evaluations-page .quota-card__warning {
-  color: rgba(248, 113, 113, 0.85);
+  color: color-mix(in srgb, var(--danger) 85%, transparent);
 }
 
 app-profile-evaluations-page .quota-card__loading {
   font-size: 0.9rem;
-  color: rgba(71, 85, 105, 0.8);
+  color: color-mix(in srgb, var(--text-secondary) 80%, transparent);
 }
 
 .dark app-profile-evaluations-page .quota-card__loading {
-  color: rgba(226, 232, 240, 0.76);
+  color: color-mix(in srgb, var(--text-primary) 76%, transparent);
 }
 
 app-profile-evaluations-page .page-alert {
@@ -245,27 +229,27 @@ app-profile-evaluations-page .page-alert {
 }
 
 app-profile-evaluations-page .page-alert--error {
-  background: rgba(254, 226, 226, 0.85);
-  color: rgba(153, 27, 27, 0.95);
-  border-color: rgba(248, 113, 113, 0.6);
+  background: color-mix(in srgb, var(--danger) 85%, transparent);
+  color: color-mix(in srgb, var(--danger-strong) 95%, transparent);
+  border-color: color-mix(in srgb, var(--danger) 60%, transparent);
 }
 
 .dark app-profile-evaluations-page .page-alert--error {
-  background: rgba(127, 29, 29, 0.55);
-  color: rgba(254, 226, 226, 0.95);
-  border-color: rgba(254, 202, 202, 0.4);
+  background: color-mix(in srgb, var(--danger-strong) 55%, transparent);
+  color: color-mix(in srgb, var(--danger) 95%, transparent);
+  border-color: color-mix(in srgb, var(--danger) 40%, transparent);
 }
 
 app-profile-evaluations-page .page-alert--success {
-  background: rgba(187, 247, 208, 0.85);
-  color: rgba(22, 101, 52, 0.95);
-  border-color: rgba(34, 197, 94, 0.45);
+  background: color-mix(in srgb, var(--success) 85%, transparent);
+  color: color-mix(in srgb, var(--success-strong) 95%, transparent);
+  border-color: color-mix(in srgb, var(--success) 45%, transparent);
 }
 
 .dark app-profile-evaluations-page .page-alert--success {
-  background: rgba(21, 128, 61, 0.55);
-  color: rgba(220, 252, 231, 0.9);
-  border-color: rgba(134, 239, 172, 0.4);
+  background: color-mix(in srgb, var(--success-strong) 55%, transparent);
+  color: color-mix(in srgb, var(--success-muted) 90%, transparent);
+  border-color: color-mix(in srgb, var(--success) 40%, transparent);
 }
 
 app-profile-evaluations-page .state {
@@ -274,36 +258,36 @@ app-profile-evaluations-page .state {
   place-items: center;
   padding: 3rem 1.5rem;
   border-radius: 1.75rem;
-  border: 2px dashed rgba(148, 163, 184, 0.35);
-  background: rgba(248, 250, 252, 0.65);
+  border: 2px dashed color-mix(in srgb, var(--text-tertiary) 35%, transparent);
+  background: color-mix(in srgb, var(--surface-card-muted) 65%, transparent);
   text-align: center;
-  color: rgba(71, 85, 105, 0.85);
+  color: color-mix(in srgb, var(--text-secondary) 85%, transparent);
 }
 
 .dark app-profile-evaluations-page .state {
-  background: rgba(15, 23, 42, 0.6);
-  border-color: rgba(148, 163, 184, 0.45);
-  color: rgba(226, 232, 240, 0.8);
+  background: color-mix(in srgb, var(--surface-inverse) 60%, transparent);
+  border-color: color-mix(in srgb, var(--text-tertiary) 45%, transparent);
+  color: color-mix(in srgb, var(--text-primary) 80%, transparent);
 }
 
 app-profile-evaluations-page .state--error {
   border-style: solid;
-  border-color: rgba(248, 113, 113, 0.6);
-  background: rgba(254, 226, 226, 0.55);
-  color: rgba(153, 27, 27, 0.9);
+  border-color: color-mix(in srgb, var(--danger) 60%, transparent);
+  background: color-mix(in srgb, var(--danger) 55%, transparent);
+  color: color-mix(in srgb, var(--danger-strong) 90%, transparent);
 }
 
 .dark app-profile-evaluations-page .state--error {
-  background: rgba(127, 29, 29, 0.55);
-  border-color: rgba(254, 202, 202, 0.35);
-  color: rgba(254, 226, 226, 0.92);
+  background: color-mix(in srgb, var(--danger-strong) 55%, transparent);
+  border-color: color-mix(in srgb, var(--danger) 35%, transparent);
+  color: color-mix(in srgb, var(--danger) 92%, transparent);
 }
 
 app-profile-evaluations-page .state__spinner {
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 9999px;
-  border: 3px solid rgba(148, 163, 184, 0.35);
+  border: 3px solid color-mix(in srgb, var(--text-tertiary) 35%, transparent);
   border-top-color: var(--accent);
   animation: spin 1s linear infinite;
 }
@@ -348,11 +332,11 @@ app-profile-evaluations-page .latest__summary {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
-  color: rgba(71, 85, 105, 0.9);
+  color: color-mix(in srgb, var(--text-secondary) 90%, transparent);
 }
 
 .dark app-profile-evaluations-page .latest__summary {
-  color: rgba(226, 232, 240, 0.75);
+  color: color-mix(in srgb, var(--text-primary) 75%, transparent);
 }
 
 app-profile-evaluations-page .latest__eyebrow {
@@ -360,7 +344,7 @@ app-profile-evaluations-page .latest__eyebrow {
   font-weight: 600;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: rgba(37, 99, 235, 0.8);
+  color: color-mix(in srgb, var(--accent) 80%, transparent);
 }
 
 app-profile-evaluations-page .latest__title {
@@ -371,11 +355,11 @@ app-profile-evaluations-page .latest__title {
 
 app-profile-evaluations-page .latest__meta {
   font-size: 0.85rem;
-  color: rgba(71, 85, 105, 0.85);
+  color: color-mix(in srgb, var(--text-secondary) 85%, transparent);
 }
 
 .dark app-profile-evaluations-page .latest__meta {
-  color: rgba(148, 163, 184, 0.85);
+  color: color-mix(in srgb, var(--text-tertiary) 85%, transparent);
 }
 
 app-profile-evaluations-page .latest__score {
@@ -383,15 +367,15 @@ app-profile-evaluations-page .latest__score {
   gap: 0.4rem;
   padding: 1.5rem;
   border-radius: 1.5rem;
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.08));
-  color: rgba(37, 99, 235, 0.95);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 12%, transparent), color-mix(in srgb, var(--accent-strong) 8%, transparent));
+  color: color-mix(in srgb, var(--accent) 95%, transparent);
   text-align: right;
   align-self: flex-start;
 }
 
 .dark app-profile-evaluations-page .latest__score {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.18), rgba(37, 99, 235, 0.12));
-  color: rgba(191, 219, 254, 0.95);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 18%, transparent), color-mix(in srgb, var(--accent) 12%, transparent));
+  color: color-mix(in srgb, var(--accent) 95%, transparent);
 }
 
 app-profile-evaluations-page .latest__score-value {
@@ -413,18 +397,18 @@ app-profile-evaluations-page .latest__score-label {
 
 app-profile-evaluations-page .latest__score-percent {
   font-size: 0.8rem;
-  color: rgba(37, 99, 235, 0.8);
+  color: color-mix(in srgb, var(--accent) 80%, transparent);
 }
 
 .dark app-profile-evaluations-page .latest__score-percent {
-  color: rgba(191, 219, 254, 0.85);
+  color: color-mix(in srgb, var(--accent) 85%, transparent);
 }
 
 app-profile-evaluations-page .latest__progress {
   position: relative;
   height: 0.6rem;
   border-radius: 9999px;
-  background: rgba(148, 163, 184, 0.28);
+  background: color-mix(in srgb, var(--text-tertiary) 28%, transparent);
   overflow: hidden;
 }
 
@@ -432,7 +416,7 @@ app-profile-evaluations-page .latest__progress-bar {
   position: absolute;
   inset: 0;
   border-radius: 9999px;
-  background: linear-gradient(90deg, rgba(37, 99, 235, 0.9), rgba(59, 130, 246, 0.75));
+  background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 90%, transparent), color-mix(in srgb, var(--accent-strong) 75%, transparent));
   transition: width 200ms ease-out;
 }
 
@@ -451,11 +435,11 @@ app-profile-evaluations-page .latest__section h3 {
 app-profile-evaluations-page .latest__text {
   font-size: 0.95rem;
   line-height: 1.8;
-  color: rgba(71, 85, 105, 0.9);
+  color: color-mix(in srgb, var(--text-secondary) 90%, transparent);
 }
 
 .dark app-profile-evaluations-page .latest__text {
-  color: rgba(226, 232, 240, 0.85);
+  color: color-mix(in srgb, var(--text-primary) 85%, transparent);
 }
 
 app-profile-evaluations-page .latest__actions-grid {
@@ -474,8 +458,8 @@ app-profile-evaluations-page .latest__action {
   gap: 1rem;
   padding: 1.5rem;
   border-radius: 1.5rem;
-  border: 1px solid rgba(37, 99, 235, 0.18);
-  background: rgba(219, 234, 254, 0.35);
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, transparent);
+  background: color-mix(in srgb, var(--accent-muted) 35%, transparent);
 }
 
 app-profile-evaluations-page .latest__action h3 {
@@ -485,7 +469,7 @@ app-profile-evaluations-page .latest__action h3 {
 
 app-profile-evaluations-page .latest__action p {
   font-size: 0.85rem;
-  color: rgba(71, 85, 105, 0.85);
+  color: color-mix(in srgb, var(--text-secondary) 85%, transparent);
   line-height: 1.6;
 }
 
@@ -500,12 +484,12 @@ app-profile-evaluations-page .latest__action ul {
 
 app-profile-evaluations-page .latest__empty {
   font-size: 0.85rem;
-  color: rgba(71, 85, 105, 0.75);
+  color: color-mix(in srgb, var(--text-secondary) 75%, transparent);
 }
 
 .dark app-profile-evaluations-page .latest__action {
-  background: rgba(37, 99, 235, 0.12);
-  border-color: rgba(96, 165, 250, 0.25);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
 app-profile-evaluations-page .latest__details {
@@ -546,18 +530,18 @@ app-profile-evaluations-page .latest__item-title {
 
 app-profile-evaluations-page .latest__item-score {
   font-size: 0.85rem;
-  color: rgba(71, 85, 105, 0.75);
+  color: color-mix(in srgb, var(--text-secondary) 75%, transparent);
 }
 
 app-profile-evaluations-page .latest__item-text {
   font-size: 0.9rem;
   line-height: 1.6;
-  color: rgba(71, 85, 105, 0.85);
+  color: color-mix(in srgb, var(--text-secondary) 85%, transparent);
 }
 
 .dark app-profile-evaluations-page .latest__item-score,
 .dark app-profile-evaluations-page .latest__item-text {
-  color: rgba(226, 232, 240, 0.75);
+  color: color-mix(in srgb, var(--text-primary) 75%, transparent);
 }
 
 app-profile-evaluations-page .latest__item-actions {
@@ -570,7 +554,7 @@ app-profile-evaluations-page .latest__item-actions h4 {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   margin-bottom: 0.4rem;
-  color: rgba(71, 85, 105, 0.85);
+  color: color-mix(in srgb, var(--text-secondary) 85%, transparent);
 }
 
 app-profile-evaluations-page .latest__item-actions ul {
@@ -609,7 +593,7 @@ app-profile-evaluations-page .history__header h2 {
 
 app-profile-evaluations-page .history__header p {
   font-size: 0.9rem;
-  color: rgba(71, 85, 105, 0.75);
+  color: color-mix(in srgb, var(--text-secondary) 75%, transparent);
 }
 
 app-profile-evaluations-page .history__count {
@@ -618,8 +602,8 @@ app-profile-evaluations-page .history__count {
   justify-content: center;
   padding: 0.4rem 0.9rem;
   border-radius: 9999px;
-  background: rgba(37, 99, 235, 0.12);
-  color: rgba(37, 99, 235, 0.85);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: color-mix(in srgb, var(--accent) 85%, transparent);
   font-weight: 600;
   font-size: 0.85rem;
 }
@@ -627,9 +611,9 @@ app-profile-evaluations-page .history__count {
 app-profile-evaluations-page .history__empty {
   padding: 1.25rem 1.5rem;
   border-radius: 1.25rem;
-  border: 1px dashed rgba(148, 163, 184, 0.45);
-  background: rgba(248, 250, 252, 0.7);
-  color: rgba(71, 85, 105, 0.75);
+  border: 1px dashed color-mix(in srgb, var(--text-tertiary) 45%, transparent);
+  background: color-mix(in srgb, var(--surface-card-muted) 70%, transparent);
+  color: color-mix(in srgb, var(--text-secondary) 75%, transparent);
   font-size: 0.9rem;
 }
 
@@ -643,15 +627,15 @@ app-profile-evaluations-page .history__list {
 
 app-profile-evaluations-page .history__entry details {
   border-radius: 1.5rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid color-mix(in srgb, var(--text-tertiary) 35%, transparent);
+  background: color-mix(in srgb, var(--surface-card) 85%, transparent);
   padding: 1.1rem 1.3rem;
-  box-shadow: 0 12px 36px -24px rgba(37, 99, 235, 0.25);
+  box-shadow: 0 12px 36px -24px color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
 .dark app-profile-evaluations-page .history__entry details {
-  background: rgba(15, 23, 42, 0.75);
-  border-color: rgba(148, 163, 184, 0.45);
+  background: color-mix(in srgb, var(--surface-inverse) 75%, transparent);
+  border-color: color-mix(in srgb, var(--text-tertiary) 45%, transparent);
 }
 
 app-profile-evaluations-page .history__entry summary {
@@ -682,7 +666,7 @@ app-profile-evaluations-page .history__summary-text {
 app-profile-evaluations-page .history__period {
   font-size: 0.85rem;
   letter-spacing: 0.04em;
-  color: rgba(71, 85, 105, 0.75);
+  color: color-mix(in srgb, var(--text-secondary) 75%, transparent);
   text-transform: uppercase;
 }
 
@@ -697,7 +681,7 @@ app-profile-evaluations-page .history__score {
   align-items: baseline;
   gap: 0.25rem;
   font-weight: 600;
-  color: rgba(37, 99, 235, 0.85);
+  color: color-mix(in srgb, var(--accent) 85%, transparent);
 }
 
 app-profile-evaluations-page .history__score-value {
@@ -720,11 +704,11 @@ app-profile-evaluations-page .history__content {
   display: grid;
   gap: 1rem;
   font-size: 0.9rem;
-  color: rgba(71, 85, 105, 0.8);
+  color: color-mix(in srgb, var(--text-secondary) 80%, transparent);
 }
 
 .dark app-profile-evaluations-page .history__content {
-  color: rgba(226, 232, 240, 0.78);
+  color: color-mix(in srgb, var(--text-primary) 78%, transparent);
 }
 
 app-profile-evaluations-page .history__meta {
@@ -734,7 +718,7 @@ app-profile-evaluations-page .history__meta {
   font-size: 0.8rem;
   letter-spacing: 0.03em;
   text-transform: uppercase;
-  color: rgba(71, 85, 105, 0.65);
+  color: color-mix(in srgb, var(--text-secondary) 65%, transparent);
 }
 
 app-profile-evaluations-page .history__actions {


### PR DESCRIPTION
## Summary
- expand the global theme tokens with shared accent, status, neutral, and overlay colors
- replace hard-coded rgba values in feature and layout styles with color-mix expressions based on the shared tokens
- align buttons, alerts, badges, and gradients across the UI to rely on the unified palette in both light and dark modes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3a43a1ca88320b11b3b7227a605c4