### PR TITLE
Refine page layout tokens and shared styles

### DIFF
--- a/frontend/src/app/core/layout/shell/help-dialog.scss
+++ b/frontend/src/app/core/layout/shell/help-dialog.scss
@@ -27,14 +27,14 @@
   width: min(960px, 100%);
   max-height: min(90vh, 980px);
   overflow-y: auto;
-  border-radius: 1.75rem;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-overlay);
   background: linear-gradient(180deg, var(--surface-overlay-strong), var(--surface-overlay));
   box-shadow: var(--shadow-soft);
   padding: clamp(1.5rem, 3vw, 2.5rem);
   display: flex;
   flex-direction: column;
-  gap: clamp(1.5rem, 3vw, 2.5rem);
+  gap: var(--page-content-gap);
   outline: none;
 }
 

--- a/frontend/src/app/features/analytics/page.scss
+++ b/frontend/src/app/features/analytics/page.scss
@@ -1,6 +1,6 @@
 :host {
   display: block;
-  padding: clamp(1.5rem, 2vw, 2.5rem) 0 4rem;
+  padding: var(--page-padding-block-start) 0 var(--page-padding-block-end);
 }
 
 .snapshot-chip {
@@ -65,7 +65,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
   background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
   padding: clamp(1.25rem, 2vw, 1.65rem);
@@ -129,7 +129,7 @@
 
 .report-preview {
   width: 100%;
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
   background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
   padding: 1.1rem 1.25rem;

--- a/frontend/src/app/features/analyze/page.scss
+++ b/frontend/src/app/features/analyze/page.scss
@@ -1,4 +1,4 @@
 :host {
   display: block;
-  padding: clamp(1.5rem, 2vw, 2.5rem) 0 4rem;
+  padding: var(--page-padding-block-start) 0 var(--page-padding-block-end);
 }

--- a/frontend/src/app/features/auth/login/page.scss
+++ b/frontend/src/app/features/auth/login/page.scss
@@ -86,7 +86,7 @@
   inset: 1.5rem auto auto 1.5rem;
   width: 6rem;
   height: 6rem;
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   background: radial-gradient(
     circle at top,
     color-mix(in srgb, var(--accent) 12%, transparent),

--- a/frontend/src/app/features/board/page.scss
+++ b/frontend/src/app/features/board/page.scss
@@ -1,6 +1,6 @@
 :host {
   display: block;
-  padding: 1.5rem 0 4rem;
+  padding: var(--page-padding-block-start) 0 var(--page-padding-block-end);
 }
 
 .board-columns {
@@ -31,7 +31,7 @@
   min-width: min(20rem, 100%);
   max-width: min(24rem, 100%);
   padding: 1.5rem;
-  border-radius: 1.75rem;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
   background: linear-gradient(180deg, var(--neutral-surface), var(--neutral-surface-strong));
   box-shadow: var(--shadow-soft);
@@ -68,7 +68,7 @@
 }
 
 .board-empty {
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   border: 2px dashed var(--neutral-border-strong);
   padding: 2rem 1.5rem;
   text-align: center;
@@ -156,7 +156,7 @@
 }
 
 .cdk-drag-preview {
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-strong);
 }
 

--- a/frontend/src/app/features/daily-reports/page.scss
+++ b/frontend/src/app/features/daily-reports/page.scss
@@ -1,12 +1,12 @@
 :host {
   display: block;
-  padding: clamp(1.5rem, 2vw, 2.5rem) 0 4rem;
+  padding: var(--page-padding-block-start) 0 var(--page-padding-block-end);
   color: var(--text-primary);
 }
 
 .daily-report-page {
   display: grid;
-  gap: clamp(1.5rem, 3vw, 2.5rem);
+  gap: var(--page-content-gap);
 }
 
 @media (min-width: 60rem) {
@@ -20,9 +20,9 @@
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.25rem, 2vw, 1.75rem);
-  padding: clamp(1.5rem, 2vw, 2.2rem);
-  border-radius: 1.75rem;
+  gap: var(--panel-gap);
+  padding: var(--panel-padding);
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
   background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
   box-shadow: var(--shadow-soft);
@@ -270,7 +270,7 @@ form {
 }
 
 .report-detail article {
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
   background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
   padding: clamp(1.1rem, 1.8vw, 1.5rem);
@@ -390,7 +390,7 @@ form {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   border: 1px dashed var(--border-subtle);
   background: color-mix(in srgb, var(--surface-card) 78%, transparent);
   padding: clamp(1.2rem, 1.8vw, 1.6rem);

--- a/frontend/src/app/features/settings/page.scss
+++ b/frontend/src/app/features/settings/page.scss
@@ -1,4 +1,4 @@
 :host {
   display: block;
-  padding: clamp(1.5rem, 2vw, 2.5rem) 0 4rem;
+  padding: var(--page-padding-block-start) 0 var(--page-padding-block-end);
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -61,6 +61,13 @@
   --border-overlay-strong: color-mix(in srgb, var(--text-tertiary) 32%, transparent);
   --shadow-soft: 0 12px 28px color-mix(in srgb, var(--surface-inverse) 6%, transparent);
   --shadow-strong: 0 18px 42px color-mix(in srgb, var(--surface-inverse) 9%, transparent);
+  --radius-lg: 1.5rem;
+  --radius-xl: 1.75rem;
+  --page-padding-block-start: clamp(1.5rem, 2vw, 2.5rem);
+  --page-padding-block-end: 4rem;
+  --page-content-gap: clamp(1.5rem, 3vw, 2.5rem);
+  --panel-padding: clamp(1.5rem, 2vw, 2.2rem);
+  --panel-gap: clamp(1.25rem, 2vw, 1.75rem);
   color-scheme: light;
 }
 
@@ -198,14 +205,14 @@ a:hover {
 }
 
 .surface-card {
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-card);
   background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
   box-shadow: var(--shadow-soft);
 }
 
 .surface-panel {
-  border-radius: 1.75rem;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
   background: linear-gradient(180deg, var(--neutral-surface), var(--neutral-surface-strong));
   box-shadow: var(--shadow-soft);

--- a/frontend/src/styles/components/_profile-dialog.scss
+++ b/frontend/src/styles/components/_profile-dialog.scss
@@ -21,7 +21,7 @@ app-profile-dialog .profile-dialog__panel {
   width: min(48rem, 100%);
   max-height: calc(100vh - 3rem);
   overflow-y: auto;
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-overlay);
   background: linear-gradient(180deg, var(--surface-overlay-strong), var(--surface-overlay));
   box-shadow: var(--shadow-soft);

--- a/frontend/src/styles/pages/_admin.scss
+++ b/frontend/src/styles/pages/_admin.scss
@@ -1,13 +1,15 @@
 app-admin-page {
   display: block;
-  padding: clamp(1.5rem, 2vw, 2.5rem) 0 4rem;
   color: var(--text-primary);
+  padding: var(--page-padding-block-start) 0 var(--page-padding-block-end);
+  --panel-padding: clamp(1.5rem, 2.4vw, 2rem);
+  --page-content-gap: clamp(1.75rem, 2vw, 2.5rem);
 }
 
 app-admin-page .admin-page {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.75rem, 2vw, 2.5rem);
+  gap: var(--page-content-gap);
 }
 
 app-admin-page .admin-header {
@@ -16,7 +18,7 @@ app-admin-page .admin-header {
   flex-direction: column;
   gap: 0.75rem;
   padding: clamp(1.75rem, 3vw, 2.5rem);
-  border-radius: 1.75rem;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
   background: linear-gradient(
     135deg,
@@ -152,8 +154,8 @@ app-admin-page .admin-section {
   display: flex;
   flex-direction: column;
   gap: clamp(1.1rem, 1.6vw, 1.5rem);
-  padding: clamp(1.5rem, 2.4vw, 2rem);
-  border-radius: 1.75rem;
+  padding: var(--panel-padding);
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
   background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
   box-shadow: var(--shadow-soft);
@@ -447,7 +449,7 @@ app-admin-page .admin-evaluations__items strong {
 }
 
 app-admin-page .admin-table__wrapper {
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
   overflow: hidden;
   background: color-mix(in srgb, var(--surface-card) 85%, transparent);

--- a/frontend/src/styles/pages/_profile-evaluations.scss
+++ b/frontend/src/styles/pages/_profile-evaluations.scss
@@ -1,21 +1,23 @@
 app-profile-evaluations-page {
   display: block;
-  padding: clamp(1.5rem, 2vw, 2.5rem) 0 4rem;
   color: var(--text-primary);
+  padding: var(--page-padding-block-start) 0 var(--page-padding-block-end);
+  --page-content-gap: clamp(1.75rem, 2vw, 2.5rem);
+  --panel-gap: clamp(1.25rem, 2vw, 1.75rem);
 }
 
 app-profile-evaluations-page .evaluations-page {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.75rem, 2vw, 2.5rem);
+  gap: var(--page-content-gap);
 }
 
 app-profile-evaluations-page .page-header {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.25rem, 2vw, 1.75rem);
+  gap: var(--panel-gap);
   padding: clamp(1.75rem, 3vw, 2.5rem);
-  border-radius: 1.75rem;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
   background: linear-gradient(
     135deg,
@@ -72,7 +74,7 @@ app-profile-evaluations-page .quota-card {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--accent) 32%, transparent);
   background: color-mix(in srgb, var(--surface-card) 82%, transparent);
   padding: 1.25rem 1.5rem;
@@ -204,7 +206,7 @@ app-profile-evaluations-page .state {
   gap: 0.75rem;
   place-items: center;
   padding: 3rem 1.75rem;
-  border-radius: 1.75rem;
+  border-radius: var(--radius-xl);
   border: 2px dashed var(--border-subtle);
   background: color-mix(in srgb, var(--surface-card) 82%, transparent);
   text-align: center;
@@ -230,7 +232,7 @@ app-profile-evaluations-page .state__spinner {
 app-profile-evaluations-page .latest {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.25rem, 2vw, 1.75rem);
+  gap: var(--panel-gap);
 }
 
 app-profile-evaluations-page .latest__header {
@@ -283,7 +285,7 @@ app-profile-evaluations-page .latest__score {
   display: grid;
   gap: 0.5rem;
   padding: 1.35rem 1.5rem;
-  border-radius: 1.5rem;
+  border-radius: var(--radius-lg);
   background: linear-gradient(
     135deg,
     color-mix(in srgb, var(--accent) 18%, transparent),


### PR DESCRIPTION
## Summary
- introduce layout spacing and surface radius tokens in the global stylesheet
- standardize host padding and panel spacing across dashboard feature pages using the new variables
- replace hard-coded radii in shared components (board, analytics, admin, profile dialog, help dialog) with the centralized tokens for visual consistency

## Testing
- `pytest backend/tests`
- `ruff check backend`
- `black --check backend/app backend/tests`
- `cd frontend && npm test -- --watch=false`
- `cd frontend && npm run format:check`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d3b576bc188320822a546aff923500