### PR TITLE
feat(board): enable card detail editing and comment management

### DIFF
--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -379,10 +379,15 @@
     </section>
 
     @if (selectedCardSignal(); as active) {
-      <aside class="surface-panel grid min-w-0 gap-6 px-8 py-8 lg:grid-cols-[2fr_1fr]">
-        <div class="min-w-0 space-y-4">
-          <div class="flex items-center justify-between">
-            <h3 class="text-xl font-semibold text-on-surface">{{ active.title }}</h3>
+      <aside class="surface-panel grid min-w-0 gap-8 px-8 py-8 lg:grid-cols-[2fr_1fr]">
+        <div class="min-w-0 space-y-6">
+          <div class="card-detail-header">
+            <div>
+              <p class="text-xs uppercase tracking-[0.3em] text-slate-400">カード編集</p>
+              <h3 class="text-xl font-semibold text-on-surface">
+                {{ active.title }}
+              </h3>
+            </div>
             <button
               type="button"
               class="surface-pill focus-ring px-4 py-2 text-xs font-semibold"
@@ -391,89 +396,326 @@
               閉じる
             </button>
           </div>
-          <p class="break-words text-sm leading-6 text-slate-600 dark:text-slate-300">
-            {{ active.summary }}
-          </p>
-          <div class="space-y-2">
-            <p class="text-xs uppercase tracking-[0.3em] text-slate-400">サブタスク</p>
-            <ul class="space-y-2 text-sm text-slate-600 dark:text-slate-300">
-              @for (task of active.subtasks; track task.id) {
-                <li
-                  class="flex items-center justify-between rounded-2xl border border-subtle bg-surface px-4 py-3"
+          <form class="card-editor" (submit)="saveCardDetails($event)">
+            <div class="grid gap-4">
+              <label class="card-editor__field">
+                <span class="card-editor__field-label">タイトル</span>
+                <input
+                  type="text"
+                  class="card-editor__input"
+                  placeholder="カード名を入力"
+                  [value]="cardForm.controls.title.value()"
+                  (input)="cardForm.controls.title.setValue($any($event.target).value)"
+                />
+              </label>
+              <label class="card-editor__field">
+                <span class="card-editor__field-label">概要</span>
+                <textarea
+                  class="card-editor__textarea"
+                  rows="3"
+                  placeholder="タスクの背景や目的を記入"
+                  [value]="cardForm.controls.summary.value()"
+                  (input)="cardForm.controls.summary.setValue($any($event.target).value)"
+                ></textarea>
+              </label>
+            </div>
+            <div class="card-editor__grid">
+              <label class="card-editor__field">
+                <span class="card-editor__field-label">ステータス</span>
+                <select
+                  class="card-editor__input"
+                  [value]="cardForm.controls.statusId.value()"
+                  (change)="cardForm.controls.statusId.setValue($any($event.target).value)"
                 >
-                  <span class="break-words">{{ task.title }}</span>
-                  <span class="text-xs text-slate-500">{{ task.status }}</span>
-                </li>
-              }
-            </ul>
-          </div>
-        </div>
-        <div class="min-w-0 space-y-4">
-          <p class="text-xs uppercase tracking-[0.3em] text-slate-400">コメント</p>
-          <form
-            class="grid gap-3 rounded-2xl border border-dashed border-subtle bg-surface px-5 py-5"
-            (submit)="saveComment($event)"
-          >
-            <div class="grid gap-2">
-              <label
-                class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500"
-                for="comment-author"
-                >担当者</label
-              >
-              <input
-                type="text"
-                id="comment-author"
-                class="rounded-2xl border border-subtle bg-surface px-4 py-3 text-sm focus-ring"
-                placeholder="例: 田中太郎"
-                [value]="commentForm.controls.author.value()"
-                (input)="commentForm.controls.author.setValue($any($event.target).value)"
-              />
+                  @for (status of statusesSignal(); track status.id) {
+                    <option [value]="status.id">{{ status.name }}</option>
+                  }
+                </select>
+              </label>
+              <label class="card-editor__field">
+                <span class="card-editor__field-label">優先度</span>
+                <select
+                  class="card-editor__input"
+                  [value]="cardForm.controls.priority.value()"
+                  (change)="cardForm.controls.priority.setValue($any($event.target).value)"
+                >
+                  @for (priority of cardPriorities; track priority.id) {
+                    <option [value]="priority.id">{{ priority.label }}</option>
+                  }
+                </select>
+              </label>
             </div>
-            <div class="grid gap-2">
-              <label
-                class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500"
-                for="comment-message"
-                >コメント</label
-              >
-              <textarea
-                id="comment-message"
-                class="min-h-[80px] rounded-2xl border border-subtle bg-surface px-4 py-3 text-sm focus-ring"
-                placeholder="進捗やメモを追加しましょう"
-                [value]="commentForm.controls.message.value()"
-                (input)="commentForm.controls.message.setValue($any($event.target).value)"
-              ></textarea>
+            <div class="card-editor__grid">
+              <label class="card-editor__field">
+                <span class="card-editor__field-label">担当者</span>
+                <input
+                  type="text"
+                  class="card-editor__input"
+                  placeholder="例: 田中太郎"
+                  [value]="cardForm.controls.assignee.value()"
+                  (input)="cardForm.controls.assignee.setValue($any($event.target).value)"
+                />
+              </label>
+              <label class="card-editor__field">
+                <span class="card-editor__field-label">ストーリーポイント</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.5"
+                  class="card-editor__input"
+                  placeholder="例: 5"
+                  [value]="cardForm.controls.storyPoints.value()"
+                  (input)="cardForm.controls.storyPoints.setValue($any($event.target).value)"
+                />
+              </label>
             </div>
-            <button
-              type="submit"
-              class="surface-primary focus-ring rounded-full px-5 py-3 text-sm font-semibold disabled:pointer-events-none disabled:opacity-60"
-              [disabled]="!isCommentFormValid()"
-            >
-              コメントを追加
-            </button>
+            <div class="card-editor__labels">
+              <span class="card-editor__section-label">ラベル</span>
+              <div class="card-editor__labels-grid">
+                @for (label of labelsSignal(); track label.id) {
+                  <label class="card-editor__label-option">
+                    <input
+                      type="checkbox"
+                      [checked]="isLabelApplied(active, label.id)"
+                      (change)="handleLabelToggle(active, label.id, $any($event.target).checked)"
+                    />
+                    <span>{{ label.name }}</span>
+                  </label>
+                }
+              </div>
+            </div>
+            <div class="card-editor__actions">
+              <button
+                type="submit"
+                class="surface-primary focus-ring rounded-full px-5 py-3 text-sm font-semibold disabled:pointer-events-none disabled:opacity-60"
+                [disabled]="!isCardFormValid()"
+              >
+                カード情報を保存
+              </button>
+            </div>
           </form>
-          @if (active.comments.length === 0) {
-            <p
-              class="rounded-2xl border border-dashed border-subtle px-4 py-6 text-sm text-slate-500"
-            >
-              コメントはまだありません。
-            </p>
-          } @else {
-            <ul class="space-y-3 text-sm text-slate-600 dark:text-slate-300">
-              @for (comment of active.comments; track comment.id) {
-                <li class="space-y-2 rounded-2xl border border-subtle bg-surface px-4 py-3">
-                  <div
-                    class="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500"
-                  >
-                    <span class="text-sm font-semibold text-on-surface">
-                      担当: {{ comment.author }}
-                    </span>
-                    <span>更新: {{ comment.updatedAt | date: 'yyyy/MM/dd HH:mm' }}</span>
-                  </div>
-                  <p class="break-words">{{ comment.message }}</p>
+          <section class="subtask-editor space-y-4">
+            <div class="space-y-1">
+              <p class="text-xs uppercase tracking-[0.3em] text-slate-400">サブタスク管理</p>
+              <h4 class="text-lg font-semibold text-on-surface">カード配下のタスクを編集</h4>
+              <p class="text-xs text-slate-500">
+                タイトルや担当者を直接修正し、不要になったサブタスクは削除できます。
+              </p>
+            </div>
+            <ul class="subtask-editor__list space-y-3">
+              @if (active.subtasks.length === 0) {
+                <li
+                  class="rounded-2xl border border-dashed border-subtle bg-surface px-4 py-6 text-sm text-slate-500"
+                >
+                  サブタスクはまだありません。
                 </li>
+              } @else {
+                @for (task of active.subtasks; track task.id) {
+                  <li class="subtask-editor__item">
+                    <div class="subtask-editor__grid">
+                      <label class="subtask-editor__field">
+                        <span class="subtask-editor__field-label">タイトル</span>
+                        <input
+                          type="text"
+                          class="subtask-editor__input"
+                          [value]="task.title"
+                          (change)="
+                            updateSubtaskTitle(active.id, task.id, $any($event.target).value)
+                          "
+                        />
+                      </label>
+                      <label class="subtask-editor__field">
+                        <span class="subtask-editor__field-label">ステータス</span>
+                        <select
+                          class="subtask-editor__input"
+                          [value]="task.status"
+                          (change)="
+                            changeSubtaskStatus(active.id, task.id, $any($event.target).value)
+                          "
+                        >
+                          @for (status of statusesSignal(); track status.id) {
+                            <option [value]="status.id">{{ status.name }}</option>
+                          }
+                        </select>
+                      </label>
+                    </div>
+                    <div class="subtask-editor__grid">
+                      <label class="subtask-editor__field">
+                        <span class="subtask-editor__field-label">担当者</span>
+                        <input
+                          type="text"
+                          class="subtask-editor__input"
+                          placeholder="任意"
+                          [value]="task.assignee ?? ''"
+                          (change)="
+                            updateSubtaskAssignee(active.id, task.id, $any($event.target).value)
+                          "
+                        />
+                      </label>
+                      <label class="subtask-editor__field">
+                        <span class="subtask-editor__field-label">工数 (h)</span>
+                        <input
+                          type="number"
+                          min="0"
+                          step="0.5"
+                          class="subtask-editor__input"
+                          placeholder="任意"
+                          [value]="task.estimateHours ?? ''"
+                          (change)="
+                            updateSubtaskEstimate(active.id, task.id, $any($event.target).value)
+                          "
+                        />
+                      </label>
+                    </div>
+                    <div class="subtask-editor__actions">
+                      <button
+                        type="button"
+                        class="surface-pill focus-ring px-4 py-2 text-xs font-semibold text-red-600 dark:text-red-400"
+                        (click)="deleteSubtask(active.id, task.id)"
+                      >
+                        サブタスクを削除
+                      </button>
+                    </div>
+                  </li>
+                }
               }
             </ul>
-          }
+            <form class="subtask-editor__form" (submit)="addSubtask($event)">
+              <h5 class="text-sm font-semibold text-on-surface">サブタスクを追加</h5>
+              <div class="subtask-editor__grid">
+                <label class="subtask-editor__field">
+                  <span class="subtask-editor__field-label">タイトル</span>
+                  <input
+                    type="text"
+                    class="subtask-editor__input"
+                    placeholder="作業内容を入力"
+                    [value]="newSubtaskForm.controls.title.value()"
+                    (input)="newSubtaskForm.controls.title.setValue($any($event.target).value)"
+                  />
+                </label>
+                <label class="subtask-editor__field">
+                  <span class="subtask-editor__field-label">ステータス</span>
+                  <select
+                    class="subtask-editor__input"
+                    [value]="newSubtaskForm.controls.status.value()"
+                    (change)="newSubtaskForm.controls.status.setValue($any($event.target).value)"
+                  >
+                    @for (status of statusesSignal(); track status.id) {
+                      <option [value]="status.id">{{ status.name }}</option>
+                    }
+                  </select>
+                </label>
+              </div>
+              <div class="subtask-editor__grid">
+                <label class="subtask-editor__field">
+                  <span class="subtask-editor__field-label">担当者</span>
+                  <input
+                    type="text"
+                    class="subtask-editor__input"
+                    placeholder="任意"
+                    [value]="newSubtaskForm.controls.assignee.value()"
+                    (input)="newSubtaskForm.controls.assignee.setValue($any($event.target).value)"
+                  />
+                </label>
+                <label class="subtask-editor__field">
+                  <span class="subtask-editor__field-label">工数 (h)</span>
+                  <input
+                    type="number"
+                    min="0"
+                    step="0.5"
+                    class="subtask-editor__input"
+                    placeholder="任意"
+                    [value]="newSubtaskForm.controls.estimateHours.value()"
+                    (input)="
+                      newSubtaskForm.controls.estimateHours.setValue($any($event.target).value)
+                    "
+                  />
+                </label>
+              </div>
+              <div class="subtask-editor__actions">
+                <button
+                  type="submit"
+                  class="surface-primary focus-ring rounded-full px-5 py-3 text-sm font-semibold disabled:pointer-events-none disabled:opacity-60"
+                  [disabled]="!isNewSubtaskFormValid()"
+                >
+                  サブタスクを追加
+                </button>
+              </div>
+            </form>
+          </section>
+        </div>
+        <div class="min-w-0 space-y-6">
+          <section class="comment-editor space-y-4">
+            <div class="space-y-1">
+              <p class="text-xs uppercase tracking-[0.3em] text-slate-400">コメント</p>
+              <p class="text-xs text-slate-500">
+                カード全体やサブタスクに関するメモを記録して共有できます。
+              </p>
+            </div>
+            <form
+              class="grid gap-3 rounded-2xl border border-dashed border-subtle bg-surface px-5 py-5"
+              (submit)="saveComment($event)"
+            >
+              <div class="grid gap-2">
+                <label class="comment-editor__label" for="comment-author">担当者</label>
+                <input
+                  type="text"
+                  id="comment-author"
+                  class="comment-editor__input"
+                  placeholder="例: 田中太郎"
+                  [value]="commentForm.controls.author.value()"
+                  (input)="commentForm.controls.author.setValue($any($event.target).value)"
+                />
+              </div>
+              <div class="grid gap-2">
+                <label class="comment-editor__label" for="comment-message">コメント</label>
+                <textarea
+                  id="comment-message"
+                  class="comment-editor__textarea"
+                  placeholder="進捗やメモを追加しましょう"
+                  [value]="commentForm.controls.message.value()"
+                  (input)="commentForm.controls.message.setValue($any($event.target).value)"
+                ></textarea>
+              </div>
+              <button
+                type="submit"
+                class="surface-primary focus-ring rounded-full px-5 py-3 text-sm font-semibold disabled:pointer-events-none disabled:opacity-60"
+                [disabled]="!isCommentFormValid()"
+              >
+                コメントを追加
+              </button>
+            </form>
+            @if (active.comments.length === 0) {
+              <p
+                class="rounded-2xl border border-dashed border-subtle px-4 py-6 text-sm text-slate-500"
+              >
+                コメントはまだありません。
+              </p>
+            } @else {
+              <ul class="comment-editor__list space-y-3">
+                @for (comment of active.comments; track comment.id) {
+                  <li class="comment-editor__item">
+                    <div class="comment-editor__item-header">
+                      <div class="comment-editor__meta">
+                        <span class="comment-editor__author">担当: {{ comment.author }}</span>
+                        <span class="comment-editor__timestamp"
+                          >更新: {{ comment.updatedAt | date: 'yyyy/MM/dd HH:mm' }}</span
+                        >
+                      </div>
+                      <button
+                        type="button"
+                        class="comment-editor__delete"
+                        (click)="removeComment(active.id, comment.id)"
+                      >
+                        削除
+                      </button>
+                    </div>
+                    <p class="comment-editor__message">{{ comment.message }}</p>
+                  </li>
+                }
+              </ul>
+            }
+          </section>
         </div>
       </aside>
     }

--- a/frontend/src/app/features/board/page.scss
+++ b/frontend/src/app/features/board/page.scss
@@ -205,3 +205,248 @@
 .subtask-card-compact-note {
   font-style: italic;
 }
+
+.card-detail-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.card-editor {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-radius: 1.75rem;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface);
+  box-shadow: var(--shadow-soft);
+}
+
+.card-editor__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.card-editor__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card-editor__field-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-secondary) 85%, transparent);
+}
+
+.card-editor__input,
+.card-editor__textarea,
+.subtask-editor__input,
+.comment-editor__input,
+.comment-editor__textarea {
+  width: 100%;
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface);
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.card-editor__input:focus,
+.card-editor__textarea:focus,
+.subtask-editor__input:focus,
+.comment-editor__input:focus,
+.comment-editor__textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.card-editor__textarea,
+.comment-editor__textarea {
+  min-height: 6rem;
+  resize: vertical;
+}
+
+.card-editor__labels {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card-editor__section-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-secondary) 80%, transparent);
+}
+
+.card-editor__labels-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.card-editor__label-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 70%, transparent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.card-editor__label-option input {
+  accent-color: var(--accent);
+}
+
+.card-editor__actions,
+.subtask-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.subtask-editor__item {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  border-radius: 1.75rem;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface);
+  box-shadow: var(--shadow-soft);
+}
+
+.subtask-editor__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.subtask-editor__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.subtask-editor__field-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-secondary) 75%, transparent);
+}
+
+.subtask-editor__form {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-radius: 1.75rem;
+  border: 1px dashed var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 60%, transparent);
+}
+
+.comment-editor__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-secondary) 80%, transparent);
+}
+
+.comment-editor__list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.comment-editor__item {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface);
+  box-shadow: var(--shadow-soft);
+}
+
+.comment-editor__item-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.comment-editor__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--text-secondary) 80%, transparent);
+}
+
+.comment-editor__author {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.comment-editor__timestamp {
+  font-size: 0.75rem;
+}
+
+.comment-editor__delete {
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent-strong);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  transition:
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.comment-editor__delete:hover {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+.comment-editor__message {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+}
+
+:host-context(.dark) .card-editor,
+:host-context(.dark) .subtask-editor__item,
+:host-context(.dark) .subtask-editor__form,
+:host-context(.dark) .comment-editor__item {
+  background: color-mix(in srgb, var(--surface-card) 75%, transparent);
+  border-color: color-mix(in srgb, var(--neutral-border-strong) 80%, transparent);
+}
+
+:host-context(.dark) .card-editor__input,
+:host-context(.dark) .card-editor__textarea,
+:host-context(.dark) .subtask-editor__input,
+:host-context(.dark) .comment-editor__input,
+:host-context(.dark) .comment-editor__textarea {
+  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  border-color: color-mix(in srgb, var(--neutral-border-strong) 75%, transparent);
+  color: var(--text-primary);
+}

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -57,6 +57,18 @@ const QUICK_FILTER_LABEL_LOOKUP = new Map(
   QUICK_FILTER_OPTIONS.map((option) => [option.id, option.label] as const),
 );
 
+interface CardPriorityOption {
+  readonly id: Card['priority'];
+  readonly label: string;
+}
+
+const CARD_PRIORITIES: readonly CardPriorityOption[] = [
+  { id: 'low', label: '低' },
+  { id: 'medium', label: '中' },
+  { id: 'high', label: '高' },
+  { id: 'urgent', label: '緊急' },
+];
+
 type SubtaskStatus = Subtask['status'];
 
 interface SubtaskStatusMeta {
@@ -120,6 +132,7 @@ export class BoardPage {
   public readonly labelsSignal = computed(() => this.workspace.settings().labels);
   public readonly templatesSignal = computed(() => this.workspace.settings().templates);
   public readonly quickFilters = QUICK_FILTER_OPTIONS;
+  public readonly cardPriorities = CARD_PRIORITIES;
 
   public readonly cardsByIdSignal = computed<ReadonlyMap<string, Card>>(() => {
     const lookup = new Map<string, Card>();
@@ -200,6 +213,22 @@ export class BoardPage {
 
   public readonly searchForm = createSignalForm({ search: '' });
 
+  public readonly cardForm = createSignalForm({
+    title: '',
+    summary: '',
+    statusId: '',
+    assignee: '',
+    storyPoints: '',
+    priority: 'medium' as Card['priority'],
+  });
+
+  public readonly newSubtaskForm = createSignalForm({
+    title: '',
+    assignee: '',
+    estimateHours: '',
+    status: 'todo' as SubtaskStatus,
+  });
+
   private readonly syncSearchFormEffect = effect(
     () => {
       const search = this.filtersSignal().search;
@@ -220,10 +249,18 @@ export class BoardPage {
 
   private lastSelectedCardId: string | null = null;
 
+  public readonly isCardFormValid = (): boolean => {
+    const snapshot = this.cardForm.value();
+    return snapshot.title.trim().length > 0 && snapshot.statusId.trim().length > 0;
+  };
+
   public readonly isCommentFormValid = (): boolean => {
     const snapshot = this.commentForm.value();
     return snapshot.author.trim().length > 0 && snapshot.message.trim().length > 0;
   };
+
+  public readonly isNewSubtaskFormValid = (): boolean =>
+    this.newSubtaskForm.controls.title.value().trim().length > 0;
 
   public readonly quickFilterSummarySignal = computed(() => {
     const active = this.filtersSignal().quickFilters;
@@ -324,19 +361,80 @@ export class BoardPage {
 
   public readonly selectedCardSignal = this.workspace.selectedCard;
 
-  private readonly resetCommentFormEffect = effect(() => {
+  private readonly syncSelectedCardFormsEffect = effect(
+    () => {
+      const active = this.selectedCardSignal();
+
+      if (!active) {
+        const statuses = this.statusesSignal();
+        this.cardForm.reset({
+          title: '',
+          summary: '',
+          statusId: statuses[0]?.id ?? '',
+          assignee: '',
+          storyPoints: '',
+          priority: 'medium',
+        });
+        this.commentForm.reset({ author: '', message: '' });
+        this.newSubtaskForm.reset({ title: '', assignee: '', estimateHours: '', status: 'todo' });
+        this.lastSelectedCardId = null;
+        return;
+      }
+
+      this.cardForm.reset({
+        title: active.title,
+        summary: active.summary,
+        statusId: active.statusId,
+        assignee: active.assignee ?? '',
+        storyPoints: active.storyPoints.toString(),
+        priority: active.priority,
+      });
+
+      if (this.lastSelectedCardId !== active.id) {
+        this.commentForm.reset({
+          author: active.assignee ?? '',
+          message: '',
+        });
+        this.newSubtaskForm.reset({
+          title: '',
+          assignee: '',
+          estimateHours: '',
+          status: 'todo',
+        });
+        this.lastSelectedCardId = active.id;
+      }
+    },
+    { allowSignalWrites: true },
+  );
+
+  public readonly saveCardDetails = (event: Event): void => {
+    event.preventDefault();
+
     const active = this.selectedCardSignal();
-    const nextId = active?.id ?? null;
-    if (nextId === this.lastSelectedCardId) {
+    if (!active || !this.isCardFormValid()) {
       return;
     }
 
-    this.lastSelectedCardId = nextId;
-    this.commentForm.reset({
-      author: active?.assignee ?? '',
-      message: '',
+    const snapshot = this.cardForm.value();
+    const title = snapshot.title.trim();
+    const summary = snapshot.summary.trim();
+    const statusId = snapshot.statusId.trim();
+    const assignee = snapshot.assignee.trim();
+    const storyPointsInput = snapshot.storyPoints.trim();
+    const parsedStoryPoints = storyPointsInput.length > 0 ? Number(storyPointsInput) : undefined;
+
+    this.workspace.updateCardDetails(active.id, {
+      title,
+      summary,
+      statusId,
+      priority: snapshot.priority,
+      assignee: assignee.length > 0 ? assignee : undefined,
+      storyPoints:
+        parsedStoryPoints !== undefined && Number.isFinite(parsedStoryPoints)
+          ? parsedStoryPoints
+          : undefined,
     });
-  });
+  };
 
   public readonly saveComment = (event: Event): void => {
     event.preventDefault();
@@ -355,6 +453,93 @@ export class BoardPage {
     this.commentForm.reset({
       author,
       message: '',
+    });
+  };
+
+  public readonly removeComment = (cardId: string, commentId: string): void => {
+    this.workspace.removeComment(cardId, commentId);
+  };
+
+  public readonly updateSubtaskTitle = (cardId: string, subtaskId: string, value: string): void => {
+    const title = value.trim();
+    if (!title) {
+      return;
+    }
+
+    this.workspace.updateSubtaskDetails(cardId, subtaskId, { title });
+  };
+
+  public readonly updateSubtaskAssignee = (
+    cardId: string,
+    subtaskId: string,
+    value: string,
+  ): void => {
+    const assignee = value.trim();
+    this.workspace.updateSubtaskDetails(cardId, subtaskId, {
+      assignee: assignee.length > 0 ? assignee : undefined,
+    });
+  };
+
+  public readonly updateSubtaskEstimate = (
+    cardId: string,
+    subtaskId: string,
+    value: string,
+  ): void => {
+    const raw = value.trim();
+    if (!raw) {
+      this.workspace.updateSubtaskDetails(cardId, subtaskId, { estimateHours: undefined });
+      return;
+    }
+
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) {
+      return;
+    }
+
+    this.workspace.updateSubtaskDetails(cardId, subtaskId, { estimateHours: parsed });
+  };
+
+  public readonly changeSubtaskStatus = (
+    cardId: string,
+    subtaskId: string,
+    status: SubtaskStatus,
+  ): void => {
+    this.workspace.updateSubtaskStatus(cardId, subtaskId, status);
+  };
+
+  public readonly deleteSubtask = (cardId: string, subtaskId: string): void => {
+    this.workspace.removeSubtask(cardId, subtaskId);
+  };
+
+  public readonly addSubtask = (event: Event): void => {
+    event.preventDefault();
+
+    const active = this.selectedCardSignal();
+    if (!active || !this.isNewSubtaskFormValid()) {
+      return;
+    }
+
+    const snapshot = this.newSubtaskForm.value();
+    const title = snapshot.title.trim();
+    const assignee = snapshot.assignee.trim();
+    const rawEstimate = snapshot.estimateHours.trim();
+    const parsedEstimate = rawEstimate.length > 0 ? Number(rawEstimate) : undefined;
+
+    this.workspace.addSubtask(active.id, {
+      title,
+      status: snapshot.status,
+      assignee: assignee.length > 0 ? assignee : undefined,
+      estimateHours:
+        parsedEstimate !== undefined && Number.isFinite(parsedEstimate)
+          ? parsedEstimate
+          : undefined,
+    });
+
+    this.newSubtaskForm.reset({
+      title: '',
+      assignee: '',
+      estimateHours: '',
+      status: snapshot.status,
     });
   };
 


### PR DESCRIPTION
## Summary
- extend the workspace store with helpers to update card attributes, append or delete subtasks, and remove comments so board interactions can mutate card data safely
- redesign the board detail drawer to expose editable card fields, inline subtask controls, subtask creation, and comment deletion while keeping existing filters
- add dedicated styling for the new editor layouts covering card metadata, subtasks, and the comment list

## Testing
- pytest backend/tests *(passes)*
- ruff check backend *(fails: existing repo lint errors outside the change scope)*
- black --check backend/app backend/tests *(fails: baseline formatting deviations in untouched files)*
- npm test -- --watch=false *(fails: Chrome binary not available in container)*
- npm run format:check *(fails: repo contains pre-existing unformatted files)*
- npm run build *(passes with existing CSS budget warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b8872d048320886347b9aba9e38e