### PR TITLE
Refine board workspace with the shared design system

### DIFF
--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -1,42 +1,65 @@
 <section class="app-page board-page">
-  <div class="board-page__overview">
-    @if (summarySignal(); as summary) {
-      <section class="surface-panel flex flex-col gap-6 px-6 py-8">
-        <div>
-          <p class="text-xs uppercase tracking-[0.3em] text-slate-400">進捗状況</p>
-          <p class="mt-2 text-xl font-semibold text-on-surface">
+  @let filters = filtersSignal();
+  @let summary = summarySignal();
+  @let groupingLabel = groupingLabelSignal();
+  @let quickSummary = quickFilterSummarySignal();
+
+  <app-page-header
+    eyebrow="Workspace Board"
+    title="カード管理ボード"
+    description="ステータスやラベルでタスクを整理し、サブタスクの進捗をリアルタイムで追跡します。"
+  >
+    <div class="board-page__chip-group" appPageHeaderActions>
+      <span class="surface-pill board-page__chip">
+        {{ filters?.search ? '検索: ' + filters.search : '検索なし' }}
+      </span>
+      <span class="surface-pill board-page__chip">グループ: {{ groupingLabel }}</span>
+      <span class="surface-pill board-page__chip">サブタスク: ステータス別</span>
+      <span class="surface-pill board-page__chip">クイック: {{ quickSummary }}</span>
+    </div>
+  </app-page-header>
+
+  <div class="board-page__overview page-grid page-grid--two">
+    @if (summary) {
+      <section class="surface-panel page-panel board-summary" aria-labelledby="board-summary-title">
+        <div class="board-summary__header">
+          <p class="board-summary__eyebrow">進捗スナップショット</p>
+          <p id="board-summary-title" class="board-summary__value">
             {{ summary.progressRatio }}% 完了
           </p>
         </div>
-        <div class="space-y-3">
-          <div class="flex items-center justify-between text-sm text-slate-500">
-            <span>完了カード</span>
-            <span class="font-semibold text-on-surface">{{ summary.doneCards }}</span>
+        <dl class="board-summary__stats">
+          <div class="board-summary__metric">
+            <dt>完了カード</dt>
+            <dd>{{ summary.doneCards }}</dd>
           </div>
-          <div class="flex items-center justify-between text-sm text-slate-500">
-            <span>総カード数</span>
-            <span class="font-semibold text-on-surface">{{ summary.totalCards }}</span>
+          <div class="board-summary__metric">
+            <dt>総カード数</dt>
+            <dd>{{ summary.totalCards }}</dd>
           </div>
-          <div class="flex items-center justify-between text-sm text-slate-500">
-            <span>アクティブラベル</span>
-            <span class="font-semibold text-on-surface">{{ summary.activeLabels }}</span>
+          <div class="board-summary__metric">
+            <dt>アクティブラベル</dt>
+            <dd>{{ summary.activeLabels }}</dd>
           </div>
-        </div>
-        <div class="h-2 w-full rounded-full bg-slate-200 dark:bg-slate-800">
-          <div
-            class="h-2 rounded-full bg-accent transition-all"
-            [style.width.%]="summary.progressRatio"
-          ></div>
+        </dl>
+        <div
+          class="board-summary__progress"
+          role="img"
+          [attr.aria-label]="'完了率 ' + summary.progressRatio + '%'"
+        >
+          <div class="board-summary__progress-track">
+            <div class="board-summary__progress-fill" [style.width.%]="summary.progressRatio"></div>
+          </div>
         </div>
         <a
           routerLink="/profile/evaluations"
-          class="focus-ring inline-flex items-center justify-center gap-2 self-start rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-accent shadow-soft transition hover:bg-accent-muted hover:text-accent-strong dark:bg-slate-900/60"
+          class="button button--secondary button--pill board-summary__cta focus-ring"
         >
           最新のコンピテンシー判定を確認
           <svg
             aria-hidden="true"
             viewBox="0 0 24 24"
-            class="h-4 w-4"
+            class="board-summary__cta-icon"
             fill="none"
             stroke="currentColor"
             stroke-width="1.8"
@@ -46,143 +69,119 @@
         </a>
       </section>
     }
-    <div class="flex h-full min-w-0 flex-col gap-4">
-      <header class="space-y-3">
-        <div class="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-          <div class="min-w-0">
-            <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Workspace Board</p>
-            <h2 class="text-2xl font-semibold text-on-surface">カード管理ボード</h2>
-          </div>
-          <div class="flex flex-wrap gap-2 text-xs text-slate-500">
-            <span class="surface-pill px-3 py-1">{{ filtersSignal().search || '検索なし' }}</span>
-            <span class="surface-pill px-3 py-1">タスク: {{ groupingLabelSignal() }}</span>
-            <span class="surface-pill px-3 py-1">サブタスク: ステータス別</span>
-            <span class="surface-pill px-3 py-1">クイック: {{ quickFilterSummarySignal() }}</span>
-          </div>
-        </div>
-      </header>
-      <section
-        class="grid min-w-0 gap-6 rounded-3xl border border-subtle bg-surface px-6 py-6 shadow-soft lg:grid-cols-[minmax(0,320px)_minmax(0,1fr)] lg:items-start"
-      >
-        <div class="flex min-w-0 flex-col gap-5">
-          <label class="flex min-w-0 flex-col gap-2 text-sm text-slate-600 dark:text-slate-300">
-            <span
-              class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-              >検索</span
-            >
-            <div class="relative">
-              <span
-                class="pointer-events-none absolute inset-y-0 left-4 flex items-center text-slate-400 dark:text-slate-500"
-                aria-hidden="true"
+    <section
+      class="surface-panel page-panel board-controls"
+      [class.board-controls--full]="!summary"
+    >
+      <div class="board-controls__grid">
+        <label class="form-field board-controls__search">
+          <span class="form-field__label">カードを検索</span>
+          <div class="board-controls__search-input">
+            <span class="board-controls__search-icon" aria-hidden="true">
+              <svg
+                class="board-controls__icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
               >
-                <svg
-                  class="h-4 w-4"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <circle cx="11" cy="11" r="7" />
-                  <path d="M20 20L16.5 16.5" />
-                </svg>
-              </span>
-              <input
-                type="search"
-                class="w-full min-w-0 rounded-2xl border border-subtle bg-surface px-4 py-3 pl-11 text-sm focus-ring"
-                placeholder="キーワードでカードを検索"
-                [value]="searchForm.controls.search.value()"
-                (input)="updateSearch($any($event.target).value)"
-              />
-            </div>
-          </label>
-          <div class="flex flex-col gap-2 text-xs text-slate-500 dark:text-slate-400">
-            <span class="text-xs font-semibold uppercase tracking-[0.2em]">表示形式</span>
-            <div class="flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                class="surface-pill focus-ring px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-                [class.surface-primary-muted]="groupingSignal() === 'status'"
-                (click)="selectGrouping('status')"
-              >
-                ステータス別
-              </button>
-              <button
-                type="button"
-                class="surface-pill focus-ring px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-                [class.surface-primary-muted]="groupingSignal() === 'label'"
-                (click)="selectGrouping('label')"
-              >
-                ラベル別
-              </button>
-            </div>
+                <circle cx="11" cy="11" r="7" />
+                <path d="M20 20L16.5 16.5" />
+              </svg>
+            </span>
+            <input
+              type="search"
+              class="form-control form-control--search"
+              placeholder="キーワードでカードを検索"
+              [value]="searchForm.controls.search.value()"
+              (input)="updateSearch($any($event.target).value)"
+            />
           </div>
-        </div>
-        <div class="flex min-w-0 flex-col gap-4 text-xs text-slate-500 dark:text-slate-400">
-          <div class="flex flex-wrap items-center justify-between gap-2">
-            <span class="text-xs font-semibold uppercase tracking-[0.2em]">クイックフィルター</span>
+        </label>
+        <div class="board-controls__group" role="group" aria-label="カードの表示形式">
+          <span class="board-controls__eyebrow">表示形式</span>
+          <div class="board-controls__chips">
             <button
               type="button"
-              class="surface-pill focus-ring px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
+              class="surface-pill board-controls__chip focus-ring"
+              [class.surface-primary-muted]="groupingSignal() === 'status'"
+              (click)="selectGrouping('status')"
+            >
+              ステータス別
+            </button>
+            <button
+              type="button"
+              class="surface-pill board-controls__chip focus-ring"
+              [class.surface-primary-muted]="groupingSignal() === 'label'"
+              (click)="selectGrouping('label')"
+            >
+              ラベル別
+            </button>
+          </div>
+        </div>
+        <div class="board-controls__group" role="group" aria-label="クイックフィルター">
+          <div class="board-controls__quick-header">
+            <span class="board-controls__eyebrow">クイックフィルター</span>
+            <button
+              type="button"
+              class="button button--ghost button--pill board-controls__clear focus-ring"
               (click)="clearFilters()"
             >
               フィルターをクリア
             </button>
           </div>
-          <div
-            class="rounded-2xl border border-dashed border-subtle bg-surface-strong px-4 py-3 dark:bg-slate-900/40"
-          >
-            <div class="flex flex-wrap items-center gap-2">
-              @for (filter of quickFilters; track filter.id) {
-                <button
-                  type="button"
-                  class="surface-pill focus-ring px-3 py-1 text-xs font-semibold text-slate-500 dark:text-slate-300"
-                  [class.surface-primary-muted]="isQuickFilterActive(filter.id)"
-                  [attr.aria-pressed]="isQuickFilterActive(filter.id)"
-                  [title]="filter.description"
-                  (click)="toggleQuickFilter(filter.id)"
-                >
-                  {{ filter.label }}
-                </button>
-              }
-            </div>
+          <div class="board-controls__quick-list">
+            @for (filter of quickFilters; track filter.id) {
+              <button
+                type="button"
+                class="surface-pill board-controls__chip focus-ring"
+                [class.surface-primary-muted]="isQuickFilterActive(filter.id)"
+                [attr.aria-pressed]="isQuickFilterActive(filter.id)"
+                [title]="filter.description"
+                (click)="toggleQuickFilter(filter.id)"
+              >
+                {{ filter.label }}
+              </button>
+            }
           </div>
         </div>
-      </section>
-      <p class="rounded-3xl bg-accent-muted px-6 py-4 text-sm text-accent-strong shadow-soft">
-        タスクはラベルやステータスで切り替えながら管理でき、サブタスクはステータス別ボードでドラッグ＆ドロップ更新できます。選択したタスクに紐づくサブタスクはハイライト表示されます。
-      </p>
-    </div>
+      </div>
+    </section>
   </div>
 
-  <div class="board-page__subtasks">
-    <section class="space-y-4">
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <h3 class="text-lg font-semibold text-on-surface">タスク一覧</h3>
-        <span class="text-xs text-slate-500"
-          >完了またはNonIssueのサブタスクのみのタスクは簡易表示になります。</span
-        >
-      </div>
+  <div class="board-page__workspace">
+    <div class="app-alert app-alert--notice board-page__hint" role="status">
+      タスクはラベルやステータスで切り替えながら管理でき、サブタスクはステータス別ボードでドラッグ＆ドロップ更新できます。選択したタスクに紐づくサブタスクはハイライト表示されます。
+    </div>
+
+    <section class="board-section" aria-labelledby="board-columns-title">
+      <header class="board-section__header">
+        <div class="board-section__header-stack">
+          <h3 id="board-columns-title" class="board-section__title">タスク一覧</h3>
+          <p class="board-section__description">
+            完了または NonIssue のサブタスクのみのタスクは簡易表示になります。
+          </p>
+        </div>
+      </header>
       <div class="board-columns" cdkDropListGroup>
         @for (column of columnsSignal(); track column.id) {
           <section
-            class="board-column"
+            class="board-column surface-panel"
             cdkDropList
             [cdkDropListData]="column.cards"
             [cdkDropListDisabled]="groupingSignal() !== 'status'"
             (cdkDropListDropped)="handleDrop(column.id, $event)"
           >
-            <header class="flex items-center justify-between">
+            <header class="board-column__header">
               <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-slate-400">{{ column.id }}</p>
-                <h3 class="text-lg font-semibold" [style.color]="columnAccent(column)">
+                <p class="board-column__eyebrow">{{ column.id }}</p>
+                <h3 class="board-column__title" [style.color]="columnAccent(column)">
                   {{ column.title }}
                 </h3>
               </div>
-              <span class="surface-pill px-3 py-1 text-xs font-semibold text-slate-500"
-                >{{ column.count }} 件</span
-              >
+              <span class="surface-pill board-column__count">{{ column.count }} 件</span>
             </header>
             <div class="board-card-list">
               @if (column.cards.length === 0) {
@@ -279,34 +278,30 @@
       </div>
     </section>
 
-    <section class="space-y-4">
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h3 class="text-lg font-semibold text-on-surface">サブタスク一覧</h3>
-          <p class="text-xs text-slate-500">ステータスごとに並び替え、個別に管理します。</p>
+    <section class="board-section" aria-labelledby="subtask-columns-title">
+      <header class="board-section__header">
+        <div class="board-section__header-stack">
+          <h3 id="subtask-columns-title" class="board-section__title">サブタスク一覧</h3>
+          <p class="board-section__description">ステータスごとに並び替え、別に管理します。</p>
         </div>
-        <div
-          class="rounded-3xl border border-subtle bg-surface px-4 py-2 text-xs text-slate-500 shadow-soft"
-        >
-          ドラッグ＆ドロップでステータスを更新できます。
-        </div>
-      </div>
+        <div class="board-section__note">ドラッグ＆ドロップでステータスを更新できます。</div>
+      </header>
       <div class="board-columns subtask-columns" cdkDropListGroup>
         @for (column of subtaskColumnsSignal(); track column.id) {
           <section
-            class="board-column subtask-column"
+            class="board-column subtask-column surface-panel"
             cdkDropList
             [cdkDropListData]="column.subtasks"
             (cdkDropListDropped)="handleSubtaskDrop(column.id, $event)"
           >
-            <header class="flex items-center justify-between">
+            <header class="board-column__header">
               <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-slate-400">{{ column.id }}</p>
-                <h3 class="text-lg font-semibold" [style.color]="column.accent">
+                <p class="board-column__eyebrow">{{ column.id }}</p>
+                <h3 class="board-column__title" [style.color]="column.accent">
                   {{ column.title }}
                 </h3>
               </div>
-              <span class="surface-pill px-3 py-1 text-xs font-semibold text-slate-500">
+              <span class="surface-pill board-column__count">
                 {{ column.subtasks.length }} 件
               </span>
             </header>
@@ -379,271 +374,263 @@
     </section>
 
     @if (selectedCardSignal(); as active) {
-      <aside class="surface-panel grid min-w-0 gap-8 px-8 py-8 lg:grid-cols-[2fr_1fr]">
-        <div class="min-w-0 space-y-6">
-          <div class="card-detail-header">
-            <div>
-              <p class="text-xs uppercase tracking-[0.3em] text-slate-400">カード編集</p>
-              <h3 class="text-xl font-semibold text-on-surface">
-                {{ active.title }}
-              </h3>
+      <aside class="surface-panel page-panel board-detail" aria-labelledby="board-detail-title">
+        <div class="board-detail__header">
+          <div>
+            <p class="board-detail__eyebrow">カード編集</p>
+            <h3 id="board-detail-title" class="board-detail__title">
+              {{ active.title }}
+            </h3>
+          </div>
+          <button type="button" class="button button--ghost button--pill" (click)="openCard(null)">
+            閉じる
+          </button>
+        </div>
+        <form class="card-editor" (submit)="saveCardDetails($event)">
+          <div class="grid gap-4">
+            <label class="card-editor__field">
+              <span class="card-editor__field-label">タイトル</span>
+              <input
+                type="text"
+                class="card-editor__input"
+                placeholder="カード名を入力"
+                [value]="cardForm.controls.title.value()"
+                (input)="cardForm.controls.title.setValue($any($event.target).value)"
+              />
+            </label>
+            <label class="card-editor__field">
+              <span class="card-editor__field-label">概要</span>
+              <textarea
+                class="card-editor__textarea"
+                rows="3"
+                placeholder="タスクの背景や目的を記入"
+                [value]="cardForm.controls.summary.value()"
+                (input)="cardForm.controls.summary.setValue($any($event.target).value)"
+              ></textarea>
+            </label>
+          </div>
+          <div class="card-editor__grid">
+            <label class="card-editor__field">
+              <span class="card-editor__field-label">ステータス</span>
+              <select
+                class="card-editor__input"
+                [value]="cardForm.controls.statusId.value()"
+                (change)="cardForm.controls.statusId.setValue($any($event.target).value)"
+              >
+                @for (status of statusesSignal(); track status.id) {
+                  <option [value]="status.id">{{ status.name }}</option>
+                }
+              </select>
+            </label>
+            <label class="card-editor__field">
+              <span class="card-editor__field-label">優先度</span>
+              <select
+                class="card-editor__input"
+                [value]="cardForm.controls.priority.value()"
+                (change)="cardForm.controls.priority.setValue($any($event.target).value)"
+              >
+                @for (priority of cardPriorities; track priority.id) {
+                  <option [value]="priority.id">{{ priority.label }}</option>
+                }
+              </select>
+            </label>
+          </div>
+          <div class="card-editor__grid">
+            <label class="card-editor__field">
+              <span class="card-editor__field-label">担当者</span>
+              <input
+                type="text"
+                class="card-editor__input"
+                placeholder="例: 田中太郎"
+                [value]="cardForm.controls.assignee.value()"
+                (input)="cardForm.controls.assignee.setValue($any($event.target).value)"
+              />
+            </label>
+            <label class="card-editor__field">
+              <span class="card-editor__field-label">ストーリーポイント</span>
+              <input
+                type="number"
+                min="0"
+                step="0.5"
+                class="card-editor__input"
+                placeholder="例: 5"
+                [value]="cardForm.controls.storyPoints.value()"
+                (input)="cardForm.controls.storyPoints.setValue($any($event.target).value)"
+              />
+            </label>
+          </div>
+          <div class="card-editor__labels">
+            <span class="card-editor__section-label">ラベル</span>
+            <div class="card-editor__labels-grid">
+              @for (label of labelsSignal(); track label.id) {
+                <label class="card-editor__label-option">
+                  <input
+                    type="checkbox"
+                    [checked]="isLabelApplied(active, label.id)"
+                    (change)="handleLabelToggle(active, label.id, $any($event.target).checked)"
+                  />
+                  <span>{{ label.name }}</span>
+                </label>
+              }
             </div>
+          </div>
+          <div class="card-editor__actions">
             <button
-              type="button"
-              class="surface-pill focus-ring px-4 py-2 text-xs font-semibold"
-              (click)="openCard(null)"
+              type="submit"
+              class="button button--primary button--pill"
+              [disabled]="!isCardFormValid()"
             >
-              閉じる
+              カード情報を保存
             </button>
           </div>
-          <form class="card-editor" (submit)="saveCardDetails($event)">
-            <div class="grid gap-4">
-              <label class="card-editor__field">
-                <span class="card-editor__field-label">タイトル</span>
+        </form>
+        <section class="subtask-editor space-y-4">
+          <div class="space-y-1">
+            <p class="text-xs uppercase tracking-[0.3em] text-slate-400">サブタスク管理</p>
+            <h4 class="text-lg font-semibold text-on-surface">カード配下のタスクを編集</h4>
+            <p class="text-xs text-slate-500">
+              タイトルや担当者を直接修正し、不要になったサブタスクは削除できます。
+            </p>
+          </div>
+          <ul class="subtask-editor__list space-y-3">
+            @if (active.subtasks.length === 0) {
+              <li
+                class="rounded-2xl border border-dashed border-subtle bg-surface px-4 py-6 text-sm text-slate-500"
+              >
+                サブタスクはまだありません。
+              </li>
+            } @else {
+              @for (task of active.subtasks; track task.id) {
+                <li class="subtask-editor__item">
+                  <div class="subtask-editor__grid">
+                    <label class="subtask-editor__field">
+                      <span class="subtask-editor__field-label">タイトル</span>
+                      <input
+                        type="text"
+                        class="subtask-editor__input"
+                        [value]="task.title"
+                        (change)="updateSubtaskTitle(active.id, task.id, $any($event.target).value)"
+                      />
+                    </label>
+                    <label class="subtask-editor__field">
+                      <span class="subtask-editor__field-label">ステータス</span>
+                      <select
+                        class="subtask-editor__input"
+                        [value]="task.status"
+                        (change)="
+                          changeSubtaskStatus(active.id, task.id, $any($event.target).value)
+                        "
+                      >
+                        @for (status of statusesSignal(); track status.id) {
+                          <option [value]="status.id">{{ status.name }}</option>
+                        }
+                      </select>
+                    </label>
+                  </div>
+                  <div class="subtask-editor__grid">
+                    <label class="subtask-editor__field">
+                      <span class="subtask-editor__field-label">担当者</span>
+                      <input
+                        type="text"
+                        class="subtask-editor__input"
+                        placeholder="任意"
+                        [value]="task.assignee ?? ''"
+                        (change)="
+                          updateSubtaskAssignee(active.id, task.id, $any($event.target).value)
+                        "
+                      />
+                    </label>
+                    <label class="subtask-editor__field">
+                      <span class="subtask-editor__field-label">工数 (h)</span>
+                      <input
+                        type="number"
+                        min="0"
+                        step="0.5"
+                        class="subtask-editor__input"
+                        placeholder="任意"
+                        [value]="task.estimateHours ?? ''"
+                        (change)="
+                          updateSubtaskEstimate(active.id, task.id, $any($event.target).value)
+                        "
+                      />
+                    </label>
+                  </div>
+                  <div class="subtask-editor__actions">
+                    <button
+                      type="button"
+                      class="surface-pill focus-ring px-4 py-2 text-xs font-semibold text-red-600 dark:text-red-400"
+                      (click)="deleteSubtask(active.id, task.id)"
+                    >
+                      サブタスクを削除
+                    </button>
+                  </div>
+                </li>
+              }
+            }
+          </ul>
+          <form class="subtask-editor__form" (submit)="addSubtask($event)">
+            <h5 class="text-sm font-semibold text-on-surface">サブタスクを追加</h5>
+            <div class="subtask-editor__grid">
+              <label class="subtask-editor__field">
+                <span class="subtask-editor__field-label">タイトル</span>
                 <input
                   type="text"
-                  class="card-editor__input"
-                  placeholder="カード名を入力"
-                  [value]="cardForm.controls.title.value()"
-                  (input)="cardForm.controls.title.setValue($any($event.target).value)"
+                  class="subtask-editor__input"
+                  placeholder="作業内容を入力"
+                  [value]="newSubtaskForm.controls.title.value()"
+                  (input)="newSubtaskForm.controls.title.setValue($any($event.target).value)"
                 />
               </label>
-              <label class="card-editor__field">
-                <span class="card-editor__field-label">概要</span>
-                <textarea
-                  class="card-editor__textarea"
-                  rows="3"
-                  placeholder="タスクの背景や目的を記入"
-                  [value]="cardForm.controls.summary.value()"
-                  (input)="cardForm.controls.summary.setValue($any($event.target).value)"
-                ></textarea>
-              </label>
-            </div>
-            <div class="card-editor__grid">
-              <label class="card-editor__field">
-                <span class="card-editor__field-label">ステータス</span>
+              <label class="subtask-editor__field">
+                <span class="subtask-editor__field-label">ステータス</span>
                 <select
-                  class="card-editor__input"
-                  [value]="cardForm.controls.statusId.value()"
-                  (change)="cardForm.controls.statusId.setValue($any($event.target).value)"
+                  class="subtask-editor__input"
+                  [value]="newSubtaskForm.controls.status.value()"
+                  (change)="newSubtaskForm.controls.status.setValue($any($event.target).value)"
                 >
                   @for (status of statusesSignal(); track status.id) {
                     <option [value]="status.id">{{ status.name }}</option>
                   }
                 </select>
               </label>
-              <label class="card-editor__field">
-                <span class="card-editor__field-label">優先度</span>
-                <select
-                  class="card-editor__input"
-                  [value]="cardForm.controls.priority.value()"
-                  (change)="cardForm.controls.priority.setValue($any($event.target).value)"
-                >
-                  @for (priority of cardPriorities; track priority.id) {
-                    <option [value]="priority.id">{{ priority.label }}</option>
-                  }
-                </select>
-              </label>
             </div>
-            <div class="card-editor__grid">
-              <label class="card-editor__field">
-                <span class="card-editor__field-label">担当者</span>
+            <div class="subtask-editor__grid">
+              <label class="subtask-editor__field">
+                <span class="subtask-editor__field-label">担当者</span>
                 <input
                   type="text"
-                  class="card-editor__input"
-                  placeholder="例: 田中太郎"
-                  [value]="cardForm.controls.assignee.value()"
-                  (input)="cardForm.controls.assignee.setValue($any($event.target).value)"
+                  class="subtask-editor__input"
+                  placeholder="任意"
+                  [value]="newSubtaskForm.controls.assignee.value()"
+                  (input)="newSubtaskForm.controls.assignee.setValue($any($event.target).value)"
                 />
               </label>
-              <label class="card-editor__field">
-                <span class="card-editor__field-label">ストーリーポイント</span>
+              <label class="subtask-editor__field">
+                <span class="subtask-editor__field-label">工数 (h)</span>
                 <input
                   type="number"
                   min="0"
                   step="0.5"
-                  class="card-editor__input"
-                  placeholder="例: 5"
-                  [value]="cardForm.controls.storyPoints.value()"
-                  (input)="cardForm.controls.storyPoints.setValue($any($event.target).value)"
+                  class="subtask-editor__input"
+                  placeholder="任意"
+                  [value]="newSubtaskForm.controls.estimateHours.value()"
+                  (input)="
+                    newSubtaskForm.controls.estimateHours.setValue($any($event.target).value)
+                  "
                 />
               </label>
             </div>
-            <div class="card-editor__labels">
-              <span class="card-editor__section-label">ラベル</span>
-              <div class="card-editor__labels-grid">
-                @for (label of labelsSignal(); track label.id) {
-                  <label class="card-editor__label-option">
-                    <input
-                      type="checkbox"
-                      [checked]="isLabelApplied(active, label.id)"
-                      (change)="handleLabelToggle(active, label.id, $any($event.target).checked)"
-                    />
-                    <span>{{ label.name }}</span>
-                  </label>
-                }
-              </div>
-            </div>
-            <div class="card-editor__actions">
+            <div class="subtask-editor__actions">
               <button
                 type="submit"
                 class="surface-primary focus-ring rounded-full px-5 py-3 text-sm font-semibold disabled:pointer-events-none disabled:opacity-60"
-                [disabled]="!isCardFormValid()"
+                [disabled]="!isNewSubtaskFormValid()"
               >
-                カード情報を保存
+                サブタスクを追加
               </button>
             </div>
           </form>
-          <section class="subtask-editor space-y-4">
-            <div class="space-y-1">
-              <p class="text-xs uppercase tracking-[0.3em] text-slate-400">サブタスク管理</p>
-              <h4 class="text-lg font-semibold text-on-surface">カード配下のタスクを編集</h4>
-              <p class="text-xs text-slate-500">
-                タイトルや担当者を直接修正し、不要になったサブタスクは削除できます。
-              </p>
-            </div>
-            <ul class="subtask-editor__list space-y-3">
-              @if (active.subtasks.length === 0) {
-                <li
-                  class="rounded-2xl border border-dashed border-subtle bg-surface px-4 py-6 text-sm text-slate-500"
-                >
-                  サブタスクはまだありません。
-                </li>
-              } @else {
-                @for (task of active.subtasks; track task.id) {
-                  <li class="subtask-editor__item">
-                    <div class="subtask-editor__grid">
-                      <label class="subtask-editor__field">
-                        <span class="subtask-editor__field-label">タイトル</span>
-                        <input
-                          type="text"
-                          class="subtask-editor__input"
-                          [value]="task.title"
-                          (change)="
-                            updateSubtaskTitle(active.id, task.id, $any($event.target).value)
-                          "
-                        />
-                      </label>
-                      <label class="subtask-editor__field">
-                        <span class="subtask-editor__field-label">ステータス</span>
-                        <select
-                          class="subtask-editor__input"
-                          [value]="task.status"
-                          (change)="
-                            changeSubtaskStatus(active.id, task.id, $any($event.target).value)
-                          "
-                        >
-                          @for (status of statusesSignal(); track status.id) {
-                            <option [value]="status.id">{{ status.name }}</option>
-                          }
-                        </select>
-                      </label>
-                    </div>
-                    <div class="subtask-editor__grid">
-                      <label class="subtask-editor__field">
-                        <span class="subtask-editor__field-label">担当者</span>
-                        <input
-                          type="text"
-                          class="subtask-editor__input"
-                          placeholder="任意"
-                          [value]="task.assignee ?? ''"
-                          (change)="
-                            updateSubtaskAssignee(active.id, task.id, $any($event.target).value)
-                          "
-                        />
-                      </label>
-                      <label class="subtask-editor__field">
-                        <span class="subtask-editor__field-label">工数 (h)</span>
-                        <input
-                          type="number"
-                          min="0"
-                          step="0.5"
-                          class="subtask-editor__input"
-                          placeholder="任意"
-                          [value]="task.estimateHours ?? ''"
-                          (change)="
-                            updateSubtaskEstimate(active.id, task.id, $any($event.target).value)
-                          "
-                        />
-                      </label>
-                    </div>
-                    <div class="subtask-editor__actions">
-                      <button
-                        type="button"
-                        class="surface-pill focus-ring px-4 py-2 text-xs font-semibold text-red-600 dark:text-red-400"
-                        (click)="deleteSubtask(active.id, task.id)"
-                      >
-                        サブタスクを削除
-                      </button>
-                    </div>
-                  </li>
-                }
-              }
-            </ul>
-            <form class="subtask-editor__form" (submit)="addSubtask($event)">
-              <h5 class="text-sm font-semibold text-on-surface">サブタスクを追加</h5>
-              <div class="subtask-editor__grid">
-                <label class="subtask-editor__field">
-                  <span class="subtask-editor__field-label">タイトル</span>
-                  <input
-                    type="text"
-                    class="subtask-editor__input"
-                    placeholder="作業内容を入力"
-                    [value]="newSubtaskForm.controls.title.value()"
-                    (input)="newSubtaskForm.controls.title.setValue($any($event.target).value)"
-                  />
-                </label>
-                <label class="subtask-editor__field">
-                  <span class="subtask-editor__field-label">ステータス</span>
-                  <select
-                    class="subtask-editor__input"
-                    [value]="newSubtaskForm.controls.status.value()"
-                    (change)="newSubtaskForm.controls.status.setValue($any($event.target).value)"
-                  >
-                    @for (status of statusesSignal(); track status.id) {
-                      <option [value]="status.id">{{ status.name }}</option>
-                    }
-                  </select>
-                </label>
-              </div>
-              <div class="subtask-editor__grid">
-                <label class="subtask-editor__field">
-                  <span class="subtask-editor__field-label">担当者</span>
-                  <input
-                    type="text"
-                    class="subtask-editor__input"
-                    placeholder="任意"
-                    [value]="newSubtaskForm.controls.assignee.value()"
-                    (input)="newSubtaskForm.controls.assignee.setValue($any($event.target).value)"
-                  />
-                </label>
-                <label class="subtask-editor__field">
-                  <span class="subtask-editor__field-label">工数 (h)</span>
-                  <input
-                    type="number"
-                    min="0"
-                    step="0.5"
-                    class="subtask-editor__input"
-                    placeholder="任意"
-                    [value]="newSubtaskForm.controls.estimateHours.value()"
-                    (input)="
-                      newSubtaskForm.controls.estimateHours.setValue($any($event.target).value)
-                    "
-                  />
-                </label>
-              </div>
-              <div class="subtask-editor__actions">
-                <button
-                  type="submit"
-                  class="surface-primary focus-ring rounded-full px-5 py-3 text-sm font-semibold disabled:pointer-events-none disabled:opacity-60"
-                  [disabled]="!isNewSubtaskFormValid()"
-                >
-                  サブタスクを追加
-                </button>
-              </div>
-            </form>
-          </section>
-        </div>
+        </section>
         <div class="min-w-0 space-y-6">
           <section class="comment-editor space-y-4">
             <div class="space-y-1">

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@a
 import { CommonModule } from '@angular/common';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
 import { RouterLink } from '@angular/router';
+import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
 
 import { WorkspaceStore } from '@core/state/workspace-store';
 import {
@@ -121,7 +122,7 @@ const RESOLVED_SUBTASK_STATUSES = new Set<SubtaskStatus>(['done', 'non-issue']);
 @Component({
   selector: 'app-board-page',
   standalone: true,
-  imports: [CommonModule, DragDropModule, RouterLink],
+  imports: [CommonModule, DragDropModule, RouterLink, PageHeaderComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -1,46 +1,37 @@
 .board-page {
   display: grid;
-  min-height: 100%;
   gap: var(--page-content-gap);
+  min-height: 100%;
 }
 
-@media (min-width: 64rem) {
-  .board-page {
-    grid-template-rows: auto 1fr;
-  }
+.board-page__chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.board-page__chip {
+  padding: 0.45rem 0.85rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
 
 .board-page__overview {
   display: grid;
   gap: var(--page-content-gap);
-  align-items: start;
+  align-items: stretch;
 }
 
-@media (min-width: 64rem) {
-  .board-page__overview {
-    grid-template-columns: minmax(0, 280px) minmax(0, 1fr);
-  }
+.board-controls--full {
+  grid-column: 1 / -1;
 }
 
 .board-columns {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.5rem;
-  padding: 0 var(--shell-inline-padding, 1.5rem) 1.5rem;
-  margin: 0 calc(var(--shell-inline-padding, 1.5rem) * -1);
-}
-
-@media (min-width: 640px) {
-  .board-columns {
-    justify-content: flex-start;
-  }
-}
-
-@media (min-width: 1024px) {
-  .board-columns {
-    margin: 0;
-    padding-inline: 0;
-  }
+  gap: clamp(1rem, 2vw, 1.5rem);
 }
 
 .board-column {
@@ -50,34 +41,221 @@
   flex: 1 1 20rem;
   min-width: min(20rem, 100%);
   max-width: min(24rem, 100%);
-  padding: 1.5rem;
-  border-radius: var(--radius-xl);
-  border: 1px solid var(--border-subtle);
-  background: linear-gradient(180deg, var(--neutral-surface), var(--neutral-surface-strong));
-  box-shadow: var(--shadow-soft);
+  padding: clamp(1.25rem, 1.8vw, 1.75rem);
   transition:
     border-color 150ms ease,
     box-shadow 150ms ease;
-}
-
-.board-column header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.dark .board-page .board-column {
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--surface-strong) 88%, transparent),
-    color-mix(in srgb, var(--surface) 92%, transparent)
-  );
 }
 
 .board-column.cdk-drop-list-dragging,
 .board-column.cdk-drop-list-receiving {
   border-color: var(--accent);
   box-shadow: var(--shadow-strong);
+}
+
+.board-column__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.board-column__eyebrow {
+  margin: 0 0 0.35rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-tertiary) 78%, transparent);
+}
+
+.board-column__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.board-column__count {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 0.45rem 0.9rem;
+}
+
+.board-summary {
+  display: grid;
+  gap: var(--panel-gap);
+}
+
+.board-summary__header {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.board-summary__eyebrow {
+  margin: 0;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-tertiary) 78%, transparent);
+}
+
+.board-summary__value {
+  margin: 0;
+  font-size: clamp(1.8rem, 1.4rem + 0.8vw, 2.2rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.board-summary__stats {
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 40rem) {
+  .board-summary__stats {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.board-summary__metric {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--surface-card) 65%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 85%, transparent);
+}
+
+.board-summary__metric dt {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.board-summary__metric dd {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.board-summary__progress {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.board-summary__progress-track {
+  position: relative;
+  height: 0.6rem;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--surface-card) 70%, transparent);
+  overflow: hidden;
+}
+
+.board-summary__progress-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  transition: width 200ms ease;
+}
+
+.board-summary__cta {
+  align-self: flex-start;
+  display: inline-flex;
+}
+
+.board-summary__cta-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.board-controls {
+  display: grid;
+}
+
+.board-controls__grid {
+  display: grid;
+  gap: var(--panel-gap);
+}
+
+@media (min-width: 56rem) {
+  .board-controls__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .board-controls__search,
+  .board-controls__group:last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+.board-controls__search-input {
+  position: relative;
+}
+
+.board-controls__search-icon {
+  position: absolute;
+  inset-inline-start: 1.1rem;
+  inset-block: 0;
+  display: flex;
+  align-items: center;
+  color: color-mix(in srgb, var(--text-muted) 70%, transparent);
+}
+
+.board-controls__icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.board-controls__search .form-control {
+  padding-inline-start: 2.75rem;
+}
+
+.board-controls__eyebrow {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-tertiary) 78%, transparent);
+}
+
+.board-controls__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.board-controls__chip {
+  padding: 0.5rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.board-controls__quick-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.board-controls__quick-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px dashed var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 70%, transparent);
 }
 
 .board-card-list {
@@ -222,19 +400,121 @@
   border-color: var(--neutral-border-strong);
 }
 
-.board-page__subtasks {
-  display: flex;
-  min-height: 0;
-  flex-direction: column;
-  gap: 2rem;
+.board-page__workspace {
+  display: grid;
+  gap: var(--page-content-gap);
 }
 
-.card-detail-header {
+.board-page__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.board-section {
+  display: grid;
+  gap: var(--panel-gap);
+}
+
+.board-section__header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+@media (min-width: 50rem) {
+  .board-section__header {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+}
+
+.board-section__header-stack {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.board-section__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.board-section__description {
+  margin: 0;
+  max-width: 48rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+
+.board-section__note {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px dashed var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 70%, transparent);
+  color: color-mix(in srgb, var(--text-secondary) 80%, transparent);
+}
+
+.board-detail {
+  display: grid;
+  gap: var(--panel-gap);
+}
+
+.board-detail__header {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+}
+
+.board-detail__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-tertiary) 78%, transparent);
+}
+
+.board-detail__title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+@media (min-width: 70rem) {
+  .board-columns {
+    justify-content: flex-start;
+  }
+}
+
+@media (min-width: 80rem) {
+  .board-page__workspace {
+    grid-template-columns: minmax(0, 2fr) minmax(18rem, 1fr);
+    align-items: start;
+  }
+
+  .board-section {
+    grid-column: 1 / 2;
+  }
+
+  .board-detail {
+    grid-column: 2 / 3;
+    position: sticky;
+    top: clamp(6rem, 8vw, 7rem);
+    max-height: calc(100vh - clamp(6rem, 8vw, 7rem));
+    overflow: auto;
+  }
 }
 
 .card-editor {
@@ -456,6 +736,9 @@
   color: var(--text-primary);
 }
 
+:host-context(.dark) .board-summary__metric,
+:host-context(.dark) .board-controls__quick-list,
+:host-context(.dark) .board-section__note,
 :host-context(.dark) .card-editor,
 :host-context(.dark) .subtask-editor__item,
 :host-context(.dark) .subtask-editor__form,


### PR DESCRIPTION
## Summary
- replace the board hero region with the shared app-page-header and persist filter context chips
- restructure the board overview, filter controls, and sections to use the design-system panels and responsive grid
- extend board styles for summary metrics, controls, and detail workspace while importing the shared header component

## Testing
- npm run format:check *(fails: existing formatting issues in unrelated files such as core/profile/profile-dialog)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3eea859a0832084c06bb8805f79e4