### PR TITLE
feat: redesign daily reports analyzer layout

### DIFF
--- a/frontend/src/app/features/daily-reports/page.html
+++ b/frontend/src/app/features/daily-reports/page.html
@@ -1,153 +1,228 @@
 <section class="app-page daily-report-page">
-  <div class="surface-panel page-panel daily-report-page__form">
-    <h1 class="page-title">日報・週報解析</h1>
-    <form class="page-form" [formGroup]="form" (submit)="submit($event)" novalidate>
-      <div class="form-field">
-        <label class="form-field__label" for="tags">タグ</label>
-        <input
-          id="tags"
-          type="text"
-          class="form-control"
-          formControlName="tags"
-          placeholder="例: backend, 障害対応"
-        />
-        <p class="form-field__hint">
-          カンマまたはスペース区切りで入力すると複数タグを追加できます。
-        </p>
-      </div>
+  <app-page-header
+    eyebrow="AI レポートアシスタント"
+    title="日報・週報解析"
+    description="タグと本文を入力すると、AI がカード候補と振り返りの観点を提案します。"
+  >
+    <a appPageHeaderActions class="button button--secondary focus-ring" routerLink="/analytics">
+      分析ダッシュボードを見る
+    </a>
+  </app-page-header>
 
-      <div class="form-collection" formArrayName="sections">
-        <h2>日報・週報セクション</h2>
-        <div
-          class="form-collection__item"
-          *ngFor="let section of sections.controls; index as index"
-          [formGroupName]="index"
-        >
-          <div class="form-collection__header">
-            <h3 class="form-collection__title">セクション {{ index + 1 }}</h3>
-            <button
-              type="button"
-              class="form-collection__remove"
-              (click)="removeSection(index)"
-              [disabled]="sections.length === 1"
-            >
-              削除
-            </button>
-          </div>
-          <label class="form-field__label">タイトル</label>
-          <input
-            type="text"
-            class="form-control"
-            formControlName="title"
-            placeholder="例: 対応内容"
-          />
-          <label class="form-field__label"> 本文 <span aria-hidden="true">*</span> </label>
-          <textarea
-            class="form-control form-control--textarea"
-            formControlName="body"
-            rows="4"
-            placeholder="重要な出来事や気づきを入力してください"
-          ></textarea>
-        </div>
-        <button type="button" class="form-collection__add" (click)="addSection()">
-          セクションを追加
-        </button>
-      </div>
-
-      <div class="form-actions">
-        <button
-          type="submit"
-          class="surface-primary focus-ring rounded-full px-6 py-3 text-sm font-semibold"
-          [disabled]="pending()"
-        >
-          解析を実行
-        </button>
-      </div>
-
-      <p class="form-feedback form-feedback--error" *ngIf="error() as errorMessage">
-        {{ errorMessage }}
-      </p>
-      <p class="form-feedback form-feedback--success" *ngIf="successMessage() as successMessage">
-        {{ successMessage }}
-      </p>
-    </form>
+  <div class="app-alert app-alert--notice daily-report-page__notice" role="status">
+    解析に使用した本文はカード作成後に破棄され、ワークスペースに保存されません。
   </div>
 
-  <aside class="surface-panel page-panel daily-report-page__sidebar">
-    <p class="daily-report-page__retention">
-      解析結果は今回のカード作成のためだけに利用され、日報本文は保存されません。
-    </p>
+  <div class="page-grid page-grid--two daily-report-page__layout">
+    <section class="surface-panel page-panel daily-report-page__form">
+      <header class="page-section__header">
+        <h2 class="page-section__title">解析に送る内容を整理する</h2>
+        <p class="page-section__subtitle">
+          重要な出来事ごとにセクションを分けると、タスクや提案の精度が高まります。
+        </p>
+      </header>
 
-    <section class="daily-report-page__detail" *ngIf="detail() as active; else emptyState">
-      <h2>解析結果</h2>
-      <p class="daily-report-page__status">ステータス: {{ active.status }}</p>
-      <p class="daily-report-page__failure" *ngIf="active.failure_reason">
-        失敗理由: {{ active.failure_reason }}
-      </p>
-
-      <article>
-        <h3>日報・週報本文</h3>
-        <div
-          class="daily-report-page__content-section"
-          *ngFor="let section of active.sections; index as index"
-        >
-          <h4>{{ section.title || 'セクション ' + (index + 1) }}</h4>
-          <p>{{ section.body }}</p>
+      <form class="page-form" [formGroup]="form" (submit)="submit($event)" novalidate>
+        <div class="form-grid form-grid--two">
+          <div class="form-field form-field--full">
+            <label class="form-field__label" for="tags">タグ</label>
+            <input
+              id="tags"
+              type="text"
+              class="form-control"
+              formControlName="tags"
+              placeholder="例: backend, 障害対応"
+            />
+            <p class="form-note">カンマまたはスペース区切りで入力すると複数タグを追加できます。</p>
+          </div>
         </div>
-      </article>
 
-      <article class="daily-report-page__cards" *ngIf="active.cards.length > 0">
-        <h3>生成されたタスク</h3>
-        <div class="daily-report-page__card" *ngFor="let card of active.cards">
-          <header>
-            <h4>{{ card.title }}</h4>
-            <span class="daily-report-page__priority">優先度: {{ card.priority || 'medium' }}</span>
+        <div class="form-collection daily-report-page__sections" formArrayName="sections">
+          <header class="page-section__header">
+            <h3 class="page-section__title">日報・週報セクション</h3>
+            <p class="page-section__subtitle">
+              セクション内の本文は必須です。見出しを付けると、カードのタイトルに反映されます。
+            </p>
           </header>
-          <p class="daily-report-page__summary">{{ card.summary }}</p>
-          <ul class="daily-report-page__subtasks" *ngIf="card.subtasks.length > 0">
-            <li *ngFor="let subtask of card.subtasks">{{ subtask.title }}</li>
-          </ul>
-        </div>
-      </article>
 
-      <article
-        class="daily-report-page__proposals"
-        *ngIf="active.cards.length === 0 && active.pending_proposals.length > 0"
-      >
-        <h3>提案中のタスク</h3>
-        <div class="daily-report-page__proposal" *ngFor="let proposal of active.pending_proposals">
-          <h4>{{ proposal.title }}</h4>
-          <p class="daily-report-page__summary">{{ proposal.summary }}</p>
-          <ul class="daily-report-page__subtasks" *ngIf="proposal.subtasks.length > 0">
-            <li *ngFor="let sub of proposal.subtasks">{{ sub.title }}</li>
-          </ul>
-        </div>
-      </article>
+          <div
+            class="form-collection__item"
+            *ngFor="let section of sections.controls; index as index"
+            [formGroupName]="index"
+          >
+            <div class="form-collection__header">
+              <h4 class="form-collection__title">セクション {{ index + 1 }}</h4>
+              <button
+                type="button"
+                class="button button--ghost button--pill focus-ring"
+                (click)="removeSection(index)"
+                [disabled]="sections.length === 1"
+              >
+                削除
+              </button>
+            </div>
 
-      <article class="daily-report-page__events">
-        <h3>イベント履歴</h3>
-        <ul class="daily-report-page__events-list">
-          <li class="daily-report-page__events-item" *ngFor="let event of active.events">
-            <span class="daily-report-page__event-type">{{ event.event_type }}</span>
-            <span class="daily-report-page__event-time">{{
-              event.created_at | date: 'short'
-            }}</span>
-          </li>
-        </ul>
-      </article>
+            <div class="form-grid form-grid--two daily-report-page__section-grid">
+              <div class="form-field">
+                <label class="form-field__label">タイトル</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  formControlName="title"
+                  placeholder="例: 対応内容"
+                />
+              </div>
+
+              <div class="form-field form-field--full">
+                <label class="form-field__label"> 本文 <span aria-hidden="true">*</span> </label>
+                <textarea
+                  class="form-control form-control--textarea"
+                  formControlName="body"
+                  rows="4"
+                  placeholder="重要な出来事や気づきを入力してください"
+                ></textarea>
+              </div>
+            </div>
+          </div>
+
+          <button type="button" class="button button--secondary focus-ring" (click)="addSection()">
+            セクションを追加
+          </button>
+        </div>
+
+        <div class="form-actions">
+          <button type="submit" class="button button--primary focus-ring" [disabled]="pending()">
+            解析を実行
+          </button>
+        </div>
+
+        <div class="app-alert app-alert--error" *ngIf="error() as errorMessage" role="alert">
+          {{ errorMessage }}
+        </div>
+        <div
+          class="app-alert app-alert--success"
+          *ngIf="successMessage() as successMessage"
+          role="status"
+        >
+          {{ successMessage }}
+        </div>
+      </form>
     </section>
 
-    <ng-template #emptyState>
-      <section class="daily-report-page__empty">
-        <h2>解析結果</h2>
-        <p>
-          まだ解析結果はありません。フォームに日報を入力して AI
-          解析を実行すると、ここに提案が表示されます。
-        </p>
-        <p class="daily-report-page__hint">
-          カード化が完了すると日報データは破棄されるため、履歴として保存されません。
-        </p>
+    <aside class="daily-report-page__insights">
+      <section
+        class="surface-panel page-panel daily-report-page__results"
+        *ngIf="detail() as active; else emptyState"
+      >
+        <header class="page-section__header">
+          <h2 class="page-section__title">解析結果</h2>
+          <p class="page-section__subtitle">
+            AI が抽出したタスク案とイベント履歴を確認し、必要に応じてボードへ追加してください。
+          </p>
+        </header>
+
+        <div class="daily-report-page__status-group">
+          <span class="page-badge page-badge--accent">ステータス {{ active.status }}</span>
+          <span class="page-badge">カード {{ active.cards.length }} 件</span>
+          <span class="page-badge">提案 {{ active.pending_proposals.length }} 件</span>
+        </div>
+
+        <div class="app-alert app-alert--error" *ngIf="active.failure_reason" role="alert">
+          失敗理由: {{ active.failure_reason }}
+        </div>
+
+        <section class="daily-report-page__group">
+          <header class="daily-report-page__group-header">
+            <h3 class="page-section__title">日報・週報本文</h3>
+          </header>
+          <ul class="page-list" aria-label="送信した日報の内容">
+            <li class="page-list__item" *ngFor="let section of active.sections; index as index">
+              <div class="page-list__heading">
+                <p class="page-list__title">
+                  {{ section.title || 'セクション ' + (index + 1) }}
+                </p>
+              </div>
+              <p class="page-list__description">{{ section.body }}</p>
+            </li>
+          </ul>
+        </section>
+
+        <section class="daily-report-page__group" *ngIf="active.cards.length > 0">
+          <header class="daily-report-page__group-header">
+            <h3 class="page-section__title">生成されたタスク</h3>
+          </header>
+          <ul class="page-list" aria-label="生成されたタスク">
+            <li class="page-list__item" *ngFor="let card of active.cards">
+              <div class="page-list__heading">
+                <p class="page-list__title">{{ card.title }}</p>
+                <span class="page-badge page-badge--accent">
+                  優先度 {{ card.priority || 'medium' }}
+                </span>
+              </div>
+              <p class="page-list__description">{{ card.summary }}</p>
+              <div class="daily-report-page__subtasks" *ngIf="card.subtasks.length > 0">
+                <span class="surface-pill px-3 py-1" *ngFor="let subtask of card.subtasks">
+                  {{ subtask.title }}
+                </span>
+              </div>
+            </li>
+          </ul>
+        </section>
+
+        <section
+          class="daily-report-page__group"
+          *ngIf="active.cards.length === 0 && active.pending_proposals.length > 0"
+        >
+          <header class="daily-report-page__group-header">
+            <h3 class="page-section__title">提案中のタスク</h3>
+          </header>
+          <ul class="page-list" aria-label="提案中のタスク">
+            <li class="page-list__item" *ngFor="let proposal of active.pending_proposals">
+              <div class="page-list__heading">
+                <p class="page-list__title">{{ proposal.title }}</p>
+              </div>
+              <p class="page-list__description">{{ proposal.summary }}</p>
+              <div class="daily-report-page__subtasks" *ngIf="proposal.subtasks.length > 0">
+                <span class="surface-pill px-3 py-1" *ngFor="let sub of proposal.subtasks">
+                  {{ sub.title }}
+                </span>
+              </div>
+            </li>
+          </ul>
+        </section>
+
+        <section class="daily-report-page__group">
+          <header class="daily-report-page__group-header">
+            <h3 class="page-section__title">イベント履歴</h3>
+          </header>
+          <ul class="page-list" aria-label="イベント履歴">
+            <li class="page-list__item" *ngFor="let event of active.events">
+              <div class="page-list__heading">
+                <p class="page-list__title">{{ event.event_type }}</p>
+              </div>
+              <div class="page-list__meta">
+                <span>{{ event.created_at | date: 'short' }}</span>
+              </div>
+            </li>
+          </ul>
+        </section>
       </section>
-    </ng-template>
-  </aside>
+
+      <ng-template #emptyState>
+        <section class="surface-panel page-panel daily-report-page__results">
+          <header class="page-section__header">
+            <h2 class="page-section__title">解析結果</h2>
+            <p class="page-section__subtitle">
+              日報を送信すると、ここにカード案やイベントが表示されます。
+            </p>
+          </header>
+          <div class="page-state" role="status">
+            <h2>まだ解析結果がありません</h2>
+            <p>フォームに日報を入力して AI 解析を実行すると、ここに提案が表示されます。</p>
+            <p>解析後に本文は破棄されるため、履歴として保存されません。</p>
+          </div>
+        </section>
+      </ng-template>
+    </aside>
+  </div>
 </section>

--- a/frontend/src/app/features/daily-reports/page.ts
+++ b/frontend/src/app/features/daily-reports/page.ts
@@ -1,22 +1,18 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
+import { RouterLink } from '@angular/router';
 
 import { DailyReportsGateway } from '@core/api/daily-reports-gateway';
 import { DailyReportDetail, DailyReportCreateRequest } from '@core/models';
+import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
 
 @Component({
   selector: 'app-daily-reports-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, PageHeaderComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -158,5 +154,4 @@ export class DailyReportsPage {
     }
     return null;
   }
-
 }

--- a/frontend/src/styles/pages/_daily-reports.scss
+++ b/frontend/src/styles/pages/_daily-reports.scss
@@ -1,227 +1,69 @@
 .daily-report-page {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: var(--page-content-gap);
 }
 
-@media (min-width: 60rem) {
-  .daily-report-page {
-    grid-template-columns: minmax(0, 1.8fr) minmax(0, 1.2fr);
-    align-items: start;
-  }
+.daily-report-page__notice {
+  margin: 0;
 }
 
-.daily-report-page__form {
+.daily-report-page__layout {
+  align-items: start;
+}
+
+.daily-report-page__form,
+.daily-report-page__results {
+  display: flex;
+  flex-direction: column;
   gap: var(--panel-gap);
 }
 
-.daily-report-page__form .page-title {
-  font-size: clamp(2rem, 1.6rem + 1vw, 2.5rem);
+.daily-report-page__sections {
+  gap: clamp(1rem, 1.4vw, 1.5rem);
 }
 
-.daily-report-page__sidebar {
+.daily-report-page__section-grid {
+  align-items: start;
+}
+
+.daily-report-page__insights {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.1rem, 1.8vw, 1.6rem);
+  gap: var(--page-content-gap);
 }
 
-.daily-report-page__sidebar section {
+.daily-report-page__status-group {
   display: flex;
-  flex-direction: column;
-  gap: 1.2rem;
-}
-
-.daily-report-page__sidebar h2 {
-  margin: 0;
-  font-size: 1.3rem;
-  font-weight: 700;
-  color: var(--text-primary);
-}
-
-.daily-report-page__retention {
-  margin: 0;
-  padding: 0.8rem 1.1rem;
-  border-radius: 1rem;
-  border: 1px solid var(--border-subtle);
-  background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
-  color: var(--text-secondary);
-  box-shadow: var(--shadow-soft);
-  font-size: 0.85rem;
-  line-height: 1.6;
-}
-
-.daily-report-page__detail {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1.2rem, 2vw, 1.8rem);
-}
-
-.daily-report-page__status {
-  display: inline-flex;
-  align-items: center;
+  flex-wrap: wrap;
   gap: 0.5rem;
-  padding: 0.4rem 0.9rem;
-  border-radius: 9999px;
-  background: color-mix(in srgb, var(--accent) 14%, transparent);
-  color: var(--accent-strong);
-  font-weight: 600;
 }
 
-.daily-report-page__failure {
-  margin: 0;
-  padding: 0.4rem 0.9rem;
-  border-radius: 0.85rem;
-  background: color-mix(in srgb, var(--danger) 18%, transparent);
-  color: color-mix(in srgb, var(--danger-strong) 90%, var(--text-primary));
-  font-weight: 600;
-}
-
-.daily-report-page__detail article {
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-subtle);
-  background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
-  padding: clamp(1.1rem, 1.8vw, 1.5rem);
+.daily-report-page__group {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
-  box-shadow: var(--shadow-soft);
+  gap: clamp(0.85rem, 1.4vw, 1.1rem);
 }
 
-.daily-report-page__detail article h3 {
-  margin: 0;
-  font-size: 1.05rem;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.daily-report-page__content-section {
-  padding: 0.85rem 1rem;
-  border-radius: 1rem;
-  border: 1px solid var(--border-card);
-  background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
-  display: grid;
-  gap: 0.4rem;
-}
-
-.daily-report-page__content-section h4 {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-}
-
-.daily-report-page__content-section p {
-  margin: 0;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-.daily-report-page__cards,
-.daily-report-page__proposals,
-.daily-report-page__events {
-  gap: 1rem;
-}
-
-.daily-report-page__card,
-.daily-report-page__proposal {
-  border: 1px solid var(--border-card);
-  border-radius: 1.25rem;
-  padding: 1.05rem 1.2rem;
-  background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
-  display: grid;
-  gap: 0.65rem;
-  box-shadow: var(--shadow-soft);
-}
-
-.daily-report-page__card header,
-.daily-report-page__proposal header {
+.daily-report-page__group-header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.daily-report-page__card header h4,
-.daily-report-page__proposal h4 {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.daily-report-page__priority {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-}
-
-.daily-report-page__summary {
-  margin: 0;
-  color: var(--text-secondary);
-  line-height: 1.6;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .daily-report-page__subtasks {
-  margin: 0;
-  padding-left: 1.1rem;
-  display: grid;
-  gap: 0.35rem;
-  color: var(--text-secondary);
-}
-
-.daily-report-page__events-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.daily-report-page__events-item {
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
-  align-items: baseline;
 }
 
-.daily-report-page__event-type {
-  font-weight: 600;
-  color: var(--text-secondary);
-}
-
-.daily-report-page__event-time {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-}
-
-.daily-report-page__empty {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  border-radius: var(--radius-lg);
-  border: 1px dashed var(--border-subtle);
-  background: color-mix(in srgb, var(--surface-card) 78%, transparent);
-  padding: clamp(1.2rem, 1.8vw, 1.6rem);
-}
-
-.daily-report-page__empty h2 {
-  margin: 0;
-  font-size: 1.2rem;
-  font-weight: 700;
-  color: var(--text-primary);
-}
-
-.daily-report-page__empty p {
-  margin: 0;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-.daily-report-page__hint {
-  color: var(--text-muted);
-  font-size: 0.9rem;
+.daily-report-page__subtasks .surface-pill {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.75rem;
 }
 
 @media (max-width: 45rem) {
-  .daily-report-page__retention {
-    font-size: 0.8rem;
+  .daily-report-page__status-group {
+    gap: 0.35rem;
   }
 }


### PR DESCRIPTION
## Summary
- apply the shared app-page-header and two-column page grid to the daily report analyzer for consistent hero, notice, and form hierarchy
- rework the insights area to use page-list, page-badge, and surface-pill components so cards, proposals, and events share design-system spacing and typography
- simplify the daily report SCSS to focus on layout gaps, status cluster, and subtasks chips that match the shared spacing tokens

## Testing
- npx prettier --check src/app/features/daily-reports/page.html src/app/features/daily-reports/page.ts src/styles/pages/_daily-reports.scss
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3eea859a0832084c06bb8805f79e4