### PR TITLE
Refine board UI to align with design system

### DIFF
--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -1,37 +1,73 @@
 <section class="app-page board-page">
-  <div class="board-page__overview">
+  <app-page-header
+    eyebrow="Workspace Board"
+    title="カード管理ボード"
+    description="ステータスやラベルで整理されたカードを俯瞰し、AI の提案を取り込みながら日々の進捗を調整します。"
+  >
+    <div appPageHeaderActions class="board-page__header-actions">
+      <a routerLink="/input" class="button button--primary board-page__primary-action">
+        AIでタスク起票
+      </a>
+      @if (filtersSignal(); as filters) {
+        <div class="board-page__header-chip-group" aria-label="現在のフィルター">
+          <span class="surface-pill board-page__header-chip">
+            {{ filters.search || '検索なし' }}
+          </span>
+          <span class="surface-pill board-page__header-chip">
+            タスク: {{ groupingLabelSignal() }}
+          </span>
+          <span class="surface-pill board-page__header-chip">
+            サブタスク: ステータス別
+          </span>
+          <span class="surface-pill board-page__header-chip">
+            クイック: {{ quickFilterSummarySignal() }}
+          </span>
+        </div>
+      }
+    </div>
+  </app-page-header>
+
+  <div class="page-grid page-grid--two board-page__overview">
     @if (summarySignal(); as summary) {
-      <section class="surface-panel flex flex-col gap-6 px-6 py-8">
-        <div>
-          <p class="text-xs uppercase tracking-[0.3em] text-slate-400">進捗状況</p>
-          <p class="mt-2 text-xl font-semibold text-on-surface">
-            {{ summary.progressRatio }}% 完了
+      <section class="page-panel surface-panel board-summary">
+        <header class="board-summary__header">
+          <p class="board-summary__eyebrow">進捗状況</p>
+          <p class="board-summary__value">
+            <span class="board-summary__value-number">{{ summary.progressRatio }}</span>
+            <span class="board-summary__value-unit">% 完了</span>
           </p>
-        </div>
-        <div class="space-y-3">
-          <div class="flex items-center justify-between text-sm text-slate-500">
-            <span>完了カード</span>
-            <span class="font-semibold text-on-surface">{{ summary.doneCards }}</span>
+          <p class="board-summary__description">
+            直近のカード進捗とメトリクスのサマリーです。
+          </p>
+        </header>
+        <dl class="board-summary__metrics">
+          <div class="board-summary__metric">
+            <dt>完了カード</dt>
+            <dd>{{ summary.doneCards }}</dd>
           </div>
-          <div class="flex items-center justify-between text-sm text-slate-500">
-            <span>総カード数</span>
-            <span class="font-semibold text-on-surface">{{ summary.totalCards }}</span>
+          <div class="board-summary__metric">
+            <dt>総カード数</dt>
+            <dd>{{ summary.totalCards }}</dd>
           </div>
-          <div class="flex items-center justify-between text-sm text-slate-500">
-            <span>アクティブラベル</span>
-            <span class="font-semibold text-on-surface">{{ summary.activeLabels }}</span>
+          <div class="board-summary__metric">
+            <dt>アクティブラベル</dt>
+            <dd>{{ summary.activeLabels }}</dd>
           </div>
-        </div>
-        <div class="h-2 w-full rounded-full bg-slate-200 dark:bg-slate-800">
-          <div
-            class="h-2 rounded-full bg-accent transition-all"
-            [style.width.%]="summary.progressRatio"
-          ></div>
-        </div>
-        <a
-          routerLink="/profile/evaluations"
-          class="focus-ring inline-flex items-center justify-center gap-2 self-start rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-accent shadow-soft transition hover:bg-accent-muted hover:text-accent-strong dark:bg-slate-900/60"
+        </dl>
+        <div
+          class="board-summary__progress"
+          role="progressbar"
+          [attr.aria-valuenow]="summary.progressRatio"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-label="カード完了率"
         >
+          <div class="board-summary__progress-track">
+            <div class="board-summary__progress-fill" [style.width.%]="summary.progressRatio"></div>
+          </div>
+          <span class="board-summary__progress-caption">達成度</span>
+        </div>
+        <a routerLink="/profile/evaluations" class="button button--secondary board-summary__cta">
           最新のコンピテンシー判定を確認
           <svg
             aria-hidden="true"
@@ -46,195 +82,161 @@
         </a>
       </section>
     }
-    <div class="flex h-full min-w-0 flex-col gap-4">
-      <header class="space-y-3">
-        <div class="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-          <div class="min-w-0">
-            <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Workspace Board</p>
-            <h2 class="text-2xl font-semibold text-on-surface">カード管理ボード</h2>
-          </div>
-          <div class="flex flex-wrap gap-2 text-xs text-slate-500">
-            <span class="surface-pill px-3 py-1">{{ filtersSignal().search || '検索なし' }}</span>
-            <span class="surface-pill px-3 py-1">タスク: {{ groupingLabelSignal() }}</span>
-            <span class="surface-pill px-3 py-1">サブタスク: ステータス別</span>
-            <span class="surface-pill px-3 py-1">クイック: {{ quickFilterSummarySignal() }}</span>
-          </div>
-        </div>
-      </header>
-      <section
-        class="grid min-w-0 gap-6 rounded-3xl border border-subtle bg-surface px-6 py-6 shadow-soft lg:grid-cols-[minmax(0,320px)_minmax(0,1fr)] lg:items-start"
-      >
-        <div class="flex min-w-0 flex-col gap-5">
-          <label class="flex min-w-0 flex-col gap-2 text-sm text-slate-600 dark:text-slate-300">
-            <span
-              class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-              >検索</span
-            >
-            <div class="relative">
-              <span
-                class="pointer-events-none absolute inset-y-0 left-4 flex items-center text-slate-400 dark:text-slate-500"
-                aria-hidden="true"
+
+    <section class="page-panel surface-panel board-controls" aria-label="ボードフィルター">
+      <div class="board-controls__form">
+        <label class="form-field board-controls__search-field">
+          <span class="form-field__label">カードを検索</span>
+          <div class="board-controls__search">
+            <span class="board-controls__search-icon" aria-hidden="true">
+              <svg
+                class="h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
               >
-                <svg
-                  class="h-4 w-4"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <circle cx="11" cy="11" r="7" />
-                  <path d="M20 20L16.5 16.5" />
-                </svg>
-              </span>
-              <input
-                type="search"
-                class="w-full min-w-0 rounded-2xl border border-subtle bg-surface px-4 py-3 pl-11 text-sm focus-ring"
-                placeholder="キーワードでカードを検索"
-                [value]="searchForm.controls.search.value()"
-                (input)="updateSearch($any($event.target).value)"
-              />
-            </div>
-          </label>
-          <div class="flex flex-col gap-2 text-xs text-slate-500 dark:text-slate-400">
-            <span class="text-xs font-semibold uppercase tracking-[0.2em]">表示形式</span>
-            <div class="flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                class="surface-pill focus-ring px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-                [class.surface-primary-muted]="groupingSignal() === 'status'"
-                (click)="selectGrouping('status')"
-              >
-                ステータス別
-              </button>
-              <button
-                type="button"
-                class="surface-pill focus-ring px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-                [class.surface-primary-muted]="groupingSignal() === 'label'"
-                (click)="selectGrouping('label')"
-              >
-                ラベル別
-              </button>
-            </div>
+                <circle cx="11" cy="11" r="7" />
+                <path d="M20 20L16.5 16.5" />
+              </svg>
+            </span>
+            <input
+              type="search"
+              class="form-control board-controls__search-input"
+              placeholder="キーワードでカードを検索"
+              [value]="searchForm.controls.search.value()"
+              (input)="updateSearch($any($event.target).value)"
+            />
           </div>
-        </div>
-        <div class="flex min-w-0 flex-col gap-4 text-xs text-slate-500 dark:text-slate-400">
-          <div class="flex flex-wrap items-center justify-between gap-2">
-            <span class="text-xs font-semibold uppercase tracking-[0.2em]">クイックフィルター</span>
+        </label>
+
+        <div class="board-controls__group" role="group" aria-label="表示形式">
+          <span class="form-field__label">表示形式</span>
+          <div class="board-controls__toggle-group">
             <button
               type="button"
-              class="surface-pill focus-ring px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
+              class="button button--pill board-controls__toggle"
+              [class.is-active]="groupingSignal() === 'status'"
+              [attr.aria-pressed]="groupingSignal() === 'status'"
+              (click)="selectGrouping('status')"
+            >
+              ステータス別
+            </button>
+            <button
+              type="button"
+              class="button button--pill board-controls__toggle"
+              [class.is-active]="groupingSignal() === 'label'"
+              [attr.aria-pressed]="groupingSignal() === 'label'"
+              (click)="selectGrouping('label')"
+            >
+              ラベル別
+            </button>
+          </div>
+        </div>
+
+        <div class="board-controls__group" aria-label="クイックフィルター">
+          <div class="board-controls__quick-header">
+            <span class="form-field__label">クイックフィルター</span>
+            <button
+              type="button"
+              class="button button--ghost button--pill board-controls__clear"
               (click)="clearFilters()"
             >
               フィルターをクリア
             </button>
           </div>
-          <div
-            class="rounded-2xl border border-dashed border-subtle bg-surface-strong px-4 py-3 dark:bg-slate-900/40"
-          >
-            <div class="flex flex-wrap items-center gap-2">
-              @for (filter of quickFilters; track filter.id) {
-                <button
-                  type="button"
-                  class="surface-pill focus-ring px-3 py-1 text-xs font-semibold text-slate-500 dark:text-slate-300"
-                  [class.surface-primary-muted]="isQuickFilterActive(filter.id)"
-                  [attr.aria-pressed]="isQuickFilterActive(filter.id)"
-                  [title]="filter.description"
-                  (click)="toggleQuickFilter(filter.id)"
-                >
-                  {{ filter.label }}
-                </button>
-              }
-            </div>
+          <div class="board-controls__quick-list">
+            @for (filter of quickFilters; track filter.id) {
+              <button
+                type="button"
+                class="surface-pill board-controls__quick-button"
+                [class.board-controls__quick-button--active]="isQuickFilterActive(filter.id)"
+                [attr.aria-pressed]="isQuickFilterActive(filter.id)"
+                [title]="filter.description"
+                (click)="toggleQuickFilter(filter.id)"
+              >
+                {{ filter.label }}
+              </button>
+            }
           </div>
         </div>
-      </section>
-      <p class="rounded-3xl bg-accent-muted px-6 py-4 text-sm text-accent-strong shadow-soft">
-        タスクはラベルやステータスで切り替えながら管理でき、サブタスクはステータス別ボードでドラッグ＆ドロップ更新できます。選択したタスクに紐づくサブタスクはハイライト表示されます。
-      </p>
-    </div>
+      </div>
+    </section>
   </div>
 
-  <div class="board-page__subtasks">
-    <section class="space-y-4">
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <h3 class="text-lg font-semibold text-on-surface">タスク一覧</h3>
-        <span class="text-xs text-slate-500"
-          >完了またはNonIssueのサブタスクのみのタスクは簡易表示になります。</span
+  <div class="app-alert app-alert--notice board-page__hint">
+    タスクはステータスまたはラベルで整理でき、サブタスクはステータス別ボードでドラッグ＆ドロップ更新できます。
+    選択したタスクに紐づくサブタスクは自動でハイライトされます。
+  </div>
+
+  <section class="page-section board-page__section board-page__cards">
+    <div class="page-section__header">
+      <h3 class="page-section__title">タスクボード</h3>
+      <p class="page-section__subtitle">
+        ステータスに沿ってカードを並べ替え、優先度や担当を素早く確認します。
+      </p>
+    </div>
+    <div class="board-columns" cdkDropListGroup>
+      @for (column of columnsSignal(); track column.id) {
+        <section
+          class="board-column"
+          cdkDropList
+          [cdkDropListData]="column.cards"
+          [cdkDropListDisabled]="groupingSignal() !== 'status'"
+          (cdkDropListDropped)="handleDrop(column.id, $event)"
         >
-      </div>
-      <div class="board-columns" cdkDropListGroup>
-        @for (column of columnsSignal(); track column.id) {
-          <section
-            class="board-column"
-            cdkDropList
-            [cdkDropListData]="column.cards"
-            [cdkDropListDisabled]="groupingSignal() !== 'status'"
-            (cdkDropListDropped)="handleDrop(column.id, $event)"
-          >
-            <header class="flex items-center justify-between">
-              <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-slate-400">{{ column.id }}</p>
-                <h3 class="text-lg font-semibold" [style.color]="columnAccent(column)">
-                  {{ column.title }}
-                </h3>
-              </div>
-              <span class="surface-pill px-3 py-1 text-xs font-semibold text-slate-500"
-                >{{ column.count }} 件</span
-              >
-            </header>
-            <div class="board-card-list">
-              @if (column.cards.length === 0) {
-                <p class="board-empty text-sm">
-                  カードがありません。{{
-                    groupingSignal() === 'status'
-                      ? 'ここにカードをドラッグすると移動できます。'
-                      : ''
-                  }}
-                </p>
-              } @else {
-                @for (cardId of column.cards; track cardId) {
-                  @if (cardsByIdSignal().get(cardId); as card) {
-                    <article
-                      class="board-card surface-card flex min-w-0 flex-col gap-4 px-5 py-5"
-                      cdkDrag
-                      [cdkDragData]="card.id"
-                      [cdkDragDisabled]="groupingSignal() !== 'status'"
-                      [style.borderColor]="statusColor(card.statusId) + '55'"
-                      [style.background]="
-                        'linear-gradient(180deg, ' +
-                        statusColor(card.statusId) +
-                        '18 0%, var(--surface-card) 55%, var(--surface-card-muted) 100%)'
-                      "
-                      [class.board-card--compact]="isCardResolved(card)"
-                      [class.board-card--active]="isActiveCard(card.id)"
+          <header class="board-column__header">
+            <div>
+              <p class="board-column__eyebrow">{{ column.id }}</p>
+              <h3 class="board-column__title" [style.color]="columnAccent(column)">
+                {{ column.title }}
+              </h3>
+            </div>
+            <span class="surface-pill board-column__count">{{ column.count }} 件</span>
+          </header>
+          <div class="board-card-list">
+            @if (column.cards.length === 0) {
+              <p class="board-empty">
+                カードがありません。
+                {{ groupingSignal() === 'status' ? 'ここにカードをドラッグすると移動できます。' : '' }}
+              </p>
+            } @else {
+              @for (cardId of column.cards; track cardId) {
+                @if (cardsByIdSignal().get(cardId); as card) {
+                  <article
+                    class="board-card surface-card"
+                    cdkDrag
+                    [cdkDragData]="card.id"
+                    [cdkDragDisabled]="groupingSignal() !== 'status'"
+                    [style.borderColor]="statusColor(card.statusId) + '55'"
+                    [style.background]="
+                      'linear-gradient(180deg, '
+                      + statusColor(card.statusId)
+                      + '18 0%, var(--surface-card) 55%, var(--surface-card-muted) 100%)'
+                    "
+                    [class.board-card--compact]="isCardResolved(card)"
+                    [class.board-card--active]="isActiveCard(card.id)"
+                  >
+                    <button
+                      type="button"
+                      class="board-card__select"
+                      (click)="openCard(card.id)"
+                      [attr.aria-pressed]="isActiveCard(card.id)"
                     >
-                      <button
-                        type="button"
-                        class="board-card__select focus-ring flex min-w-0 flex-col gap-4 text-left"
-                        (click)="openCard(card.id)"
-                        [attr.aria-pressed]="isActiveCard(card.id)"
-                      >
-                        <div class="flex items-start justify-between gap-3">
-                          <div class="min-w-0 space-y-2">
-                            <h4 class="break-words text-base font-semibold text-on-surface">
-                              {{ card.title }}
-                            </h4>
-                            @if (!isCardResolved(card)) {
-                              <p
-                                class="break-words text-sm leading-6 text-slate-600 dark:text-slate-300"
-                              >
-                                {{ card.summary }}
-                              </p>
-                            } @else {
-                              <p class="board-card-compact-note text-xs text-slate-500">
-                                サブタスクはすべて完了または NonIssue です。
-                              </p>
-                            }
-                          </div>
+                      <div class="board-card__body">
+                        <div class="board-card__header">
+                          <h4 class="board-card__title">{{ card.title }}</h4>
+                          @if (!isCardResolved(card)) {
+                            <p class="board-card__summary">{{ card.summary }}</p>
+                          } @else {
+                            <p class="board-card-compact-note">
+                              サブタスクはすべて完了または NonIssue です。
+                            </p>
+                          }
                         </div>
-                        <div class="flex flex-wrap gap-2 text-xs font-medium text-slate-500">
+                        <div class="board-card__meta">
                           <span class="board-badge" [style.color]="statusColor(card.statusId)">
                             {{ statusName(card.statusId) }}
                           </span>
@@ -243,156 +245,132 @@
                           }
                         </div>
                         @if (!isCardResolved(card)) {
-                          <div class="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                          <div class="board-card__footer">
                             <span>SP: {{ card.storyPoints }}</span>
                             @if (card.assignee) {
                               <span>担当: {{ card.assignee }}</span>
                             }
                             @if (card.confidence) {
-                              <span
-                                >AIおすすめ度: {{ card.confidence * 100 | number: '1.0-0' }}%</span
-                              >
+                              <span>AIおすすめ度: {{ card.confidence * 100 | number: '1.0-0' }}%</span>
                             }
                           </div>
                         }
-                      </button>
-                      @if (!isCardResolved(card) && groupingSignal() !== 'status') {
-                        <div class="board-card__actions flex flex-wrap gap-2 text-xs">
-                          @for (status of statusesSignal(); track status.id) {
-                            <button
-                              type="button"
-                              class="surface-pill focus-ring px-3 py-1"
-                              (click)="moveCard(card.id, status.id)"
-                            >
-                              {{ status.name }}
-                            </button>
-                          }
-                        </div>
-                      }
-                    </article>
-                  }
-                }
-              }
-            </div>
-          </section>
-        }
-      </div>
-    </section>
-
-    <section class="space-y-4">
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h3 class="text-lg font-semibold text-on-surface">サブタスク一覧</h3>
-          <p class="text-xs text-slate-500">ステータスごとに並び替え、個別に管理します。</p>
-        </div>
-        <div
-          class="rounded-3xl border border-subtle bg-surface px-4 py-2 text-xs text-slate-500 shadow-soft"
-        >
-          ドラッグ＆ドロップでステータスを更新できます。
-        </div>
-      </div>
-      <div class="board-columns subtask-columns" cdkDropListGroup>
-        @for (column of subtaskColumnsSignal(); track column.id) {
-          <section
-            class="board-column subtask-column"
-            cdkDropList
-            [cdkDropListData]="column.subtasks"
-            (cdkDropListDropped)="handleSubtaskDrop(column.id, $event)"
-          >
-            <header class="flex items-center justify-between">
-              <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-slate-400">{{ column.id }}</p>
-                <h3 class="text-lg font-semibold" [style.color]="column.accent">
-                  {{ column.title }}
-                </h3>
-              </div>
-              <span class="surface-pill px-3 py-1 text-xs font-semibold text-slate-500">
-                {{ column.subtasks.length }} 件
-              </span>
-            </header>
-            <div class="board-card-list">
-              @if (column.subtasks.length === 0) {
-                <p class="board-empty text-sm">このステータスのサブタスクはありません。</p>
-              } @else {
-                @for (subtask of column.subtasks; track subtask.id) {
-                  <article
-                    class="board-card subtask-card surface-card flex min-w-0 flex-col gap-3 px-4 py-4"
-                    cdkDrag
-                    [cdkDragData]="subtask"
-                    [style.borderColor]="column.accent + '55'"
-                    [style.background]="
-                      'linear-gradient(180deg, ' +
-                      column.accent +
-                      '18 0%, var(--surface-card) 55%, var(--surface-card-muted) 100%)'
-                    "
-                    [class.subtask-card--highlight]="subtask.highlight"
-                    [class.subtask-card--compact]="subtask.isCompact"
-                  >
-                    <div class="flex items-start justify-between gap-2">
-                      <h4 class="min-w-0 break-words text-sm font-semibold text-on-surface">
-                        {{ subtask.title }}
-                      </h4>
-                      <span
-                        class="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500"
-                      >
-                        {{ column.title }}
-                      </span>
-                    </div>
-                    <p class="text-xs text-slate-500">
-                      親タスク:
-                      <span class="break-words font-medium text-on-surface">{{
-                        subtask.parentTitle
-                      }}</span>
-                    </p>
-                    <div
-                      class="subtask-card-labels flex flex-wrap gap-2 text-[11px] text-slate-500"
-                    >
-                      @for (labelId of subtask.parentLabels; track labelId) {
-                        <span class="subtask-badge">{{ labelName(labelId) }}</span>
-                      }
-                    </div>
-                    @if (!subtask.isCompact) {
-                      <div class="flex flex-wrap items-center gap-3 text-[11px] text-slate-500">
-                        @if (subtask.assignee) {
-                          <span>担当: {{ subtask.assignee }}</span>
-                        }
-                        @if (subtask.estimateHours) {
-                          <span>工数: {{ subtask.estimateHours }}h</span>
+                      </div>
+                    </button>
+                    @if (!isCardResolved(card) && groupingSignal() !== 'status') {
+                      <div class="board-card__actions">
+                        @for (status of statusesSignal(); track status.id) {
+                          <button
+                            type="button"
+                            class="surface-pill board-card__action"
+                            (click)="moveCard(card.id, status.id)"
+                          >
+                            {{ status.name }}
+                          </button>
                         }
                       </div>
-                    } @else {
-                      <p class="subtask-card-compact-note text-xs text-slate-500">
-                        {{
-                          subtask.status === 'non-issue'
-                            ? 'NonIssue として対応済み'
-                            : '完了済みのサブタスク'
-                        }}
-                      </p>
                     }
                   </article>
                 }
               }
-            </div>
-          </section>
-        }
-      </div>
-    </section>
+            }
+          </div>
+        </section>
+      }
+    </div>
+  </section>
 
-    @if (selectedCardSignal(); as active) {
-      <aside class="surface-panel grid min-w-0 gap-8 px-8 py-8 lg:grid-cols-[2fr_1fr]">
-        <div class="min-w-0 space-y-6">
-          <div class="card-detail-header">
+  <section class="page-section board-page__section board-page__subtasks">
+    <div class="page-section__header">
+      <div>
+        <h3 class="page-section__title">サブタスク一覧</h3>
+        <p class="page-section__subtitle">ステータスごとに並び替え、個別に管理します。</p>
+      </div>
+      <div class="page-section__actions">
+        <span class="page-badge">ドラッグ＆ドロップでステータスを更新できます。</span>
+      </div>
+    </div>
+    <div class="board-columns subtask-columns" cdkDropListGroup>
+      @for (column of subtaskColumnsSignal(); track column.id) {
+        <section
+          class="board-column subtask-column"
+          cdkDropList
+          [cdkDropListData]="column.subtasks"
+          (cdkDropListDropped)="handleSubtaskDrop(column.id, $event)"
+        >
+          <header class="board-column__header">
             <div>
-              <p class="text-xs uppercase tracking-[0.3em] text-slate-400">カード編集</p>
-              <h3 class="text-xl font-semibold text-on-surface">
-                {{ active.title }}
+              <p class="board-column__eyebrow">{{ column.id }}</p>
+              <h3 class="board-column__title" [style.color]="column.accent">
+                {{ column.title }}
               </h3>
             </div>
-            <button
-              type="button"
-              class="surface-pill focus-ring px-4 py-2 text-xs font-semibold"
-              (click)="openCard(null)"
-            >
+            <span class="surface-pill board-column__count">{{ column.subtasks.length }} 件</span>
+          </header>
+          <div class="board-card-list">
+            @if (column.subtasks.length === 0) {
+              <p class="board-empty">このステータスのサブタスクはありません。</p>
+            } @else {
+              @for (subtask of column.subtasks; track subtask.id) {
+                <article
+                  class="board-card subtask-card surface-card"
+                  cdkDrag
+                  [cdkDragData]="subtask"
+                  [style.borderColor]="column.accent + '55'"
+                  [style.background]="
+                    'linear-gradient(180deg, '
+                    + column.accent
+                    + '18 0%, var(--surface-card) 55%, var(--surface-card-muted) 100%)'
+                  "
+                  [class.subtask-card--highlight]="subtask.highlight"
+                  [class.subtask-card--compact]="subtask.isCompact"
+                >
+                  <div class="subtask-card__header">
+                    <h4 class="subtask-card__title">{{ subtask.title }}</h4>
+                    <span class="subtask-card__status">{{ column.title }}</span>
+                  </div>
+                  <p class="subtask-card__parent">
+                    親タスク:
+                    <span>{{ subtask.parentTitle }}</span>
+                  </p>
+                  <div class="subtask-card-labels">
+                    @for (labelId of subtask.parentLabels; track labelId) {
+                      <span class="subtask-badge">{{ labelName(labelId) }}</span>
+                    }
+                  </div>
+                  @if (!subtask.isCompact) {
+                    <div class="subtask-card__meta">
+                      @if (subtask.assignee) {
+                        <span>担当: {{ subtask.assignee }}</span>
+                      }
+                      @if (subtask.estimateHours) {
+                        <span>工数: {{ subtask.estimateHours }}h</span>
+                      }
+                    </div>
+                  } @else {
+                    <p class="subtask-card-compact-note">
+                      {{ subtask.status === 'non-issue' ? 'NonIssue として対応済み' : '完了済みのサブタスク' }}
+                    </p>
+                  }
+                </article>
+              }
+            }
+          </div>
+        </section>
+      }
+    </div>
+  </section>
+
+  @if (selectedCardSignal(); as active) {
+    <aside class="surface-panel board-detail">
+      <div class="board-detail__grid">
+        <div class="board-detail__primary">
+          <div class="card-detail-header">
+            <div>
+              <p class="card-detail-header__eyebrow">カード編集</p>
+              <h3 class="card-detail-header__title">{{ active.title }}</h3>
+            </div>
+            <button type="button" class="button button--ghost button--pill" (click)="openCard(null)">
               閉じる
             </button>
           </div>
@@ -487,7 +465,7 @@
             <div class="card-editor__actions">
               <button
                 type="submit"
-                class="surface-primary focus-ring rounded-full px-5 py-3 text-sm font-semibold disabled:pointer-events-none disabled:opacity-60"
+                class="button button--primary"
                 [disabled]="!isCardFormValid()"
               >
                 カード情報を保存
@@ -496,19 +474,15 @@
           </form>
           <section class="subtask-editor space-y-4">
             <div class="space-y-1">
-              <p class="text-xs uppercase tracking-[0.3em] text-slate-400">サブタスク管理</p>
-              <h4 class="text-lg font-semibold text-on-surface">カード配下のタスクを編集</h4>
-              <p class="text-xs text-slate-500">
+              <p class="card-detail-header__eyebrow">サブタスク管理</p>
+              <h4 class="card-detail-header__subtitle">カード配下のタスクを編集</h4>
+              <p class="card-detail-header__description">
                 タイトルや担当者を直接修正し、不要になったサブタスクは削除できます。
               </p>
             </div>
             <ul class="subtask-editor__list space-y-3">
               @if (active.subtasks.length === 0) {
-                <li
-                  class="rounded-2xl border border-dashed border-subtle bg-surface px-4 py-6 text-sm text-slate-500"
-                >
-                  サブタスクはまだありません。
-                </li>
+                <li class="subtask-editor__empty">サブタスクはまだありません。</li>
               } @else {
                 @for (task of active.subtasks; track task.id) {
                   <li class="subtask-editor__item">
@@ -519,9 +493,7 @@
                           type="text"
                           class="subtask-editor__input"
                           [value]="task.title"
-                          (change)="
-                            updateSubtaskTitle(active.id, task.id, $any($event.target).value)
-                          "
+                          (change)="updateSubtaskTitle(active.id, task.id, $any($event.target).value)"
                         />
                       </label>
                       <label class="subtask-editor__field">
@@ -529,9 +501,7 @@
                         <select
                           class="subtask-editor__input"
                           [value]="task.status"
-                          (change)="
-                            changeSubtaskStatus(active.id, task.id, $any($event.target).value)
-                          "
+                          (change)="changeSubtaskStatus(active.id, task.id, $any($event.target).value)"
                         >
                           @for (status of statusesSignal(); track status.id) {
                             <option [value]="status.id">{{ status.name }}</option>
@@ -547,9 +517,7 @@
                           class="subtask-editor__input"
                           placeholder="任意"
                           [value]="task.assignee ?? ''"
-                          (change)="
-                            updateSubtaskAssignee(active.id, task.id, $any($event.target).value)
-                          "
+                          (change)="updateSubtaskAssignee(active.id, task.id, $any($event.target).value)"
                         />
                       </label>
                       <label class="subtask-editor__field">
@@ -561,16 +529,14 @@
                           class="subtask-editor__input"
                           placeholder="任意"
                           [value]="task.estimateHours ?? ''"
-                          (change)="
-                            updateSubtaskEstimate(active.id, task.id, $any($event.target).value)
-                          "
+                          (change)="updateSubtaskEstimate(active.id, task.id, $any($event.target).value)"
                         />
                       </label>
                     </div>
                     <div class="subtask-editor__actions">
                       <button
                         type="button"
-                        class="surface-pill focus-ring px-4 py-2 text-xs font-semibold text-red-600 dark:text-red-400"
+                        class="button button--ghost button--pill subtask-editor__remove"
                         (click)="deleteSubtask(active.id, task.id)"
                       >
                         サブタスクを削除
@@ -581,7 +547,7 @@
               }
             </ul>
             <form class="subtask-editor__form" (submit)="addSubtask($event)">
-              <h5 class="text-sm font-semibold text-on-surface">サブタスクを追加</h5>
+              <h5 class="subtask-editor__form-title">サブタスクを追加</h5>
               <div class="subtask-editor__grid">
                 <label class="subtask-editor__field">
                   <span class="subtask-editor__field-label">タイトル</span>
@@ -606,36 +572,10 @@
                   </select>
                 </label>
               </div>
-              <div class="subtask-editor__grid">
-                <label class="subtask-editor__field">
-                  <span class="subtask-editor__field-label">担当者</span>
-                  <input
-                    type="text"
-                    class="subtask-editor__input"
-                    placeholder="任意"
-                    [value]="newSubtaskForm.controls.assignee.value()"
-                    (input)="newSubtaskForm.controls.assignee.setValue($any($event.target).value)"
-                  />
-                </label>
-                <label class="subtask-editor__field">
-                  <span class="subtask-editor__field-label">工数 (h)</span>
-                  <input
-                    type="number"
-                    min="0"
-                    step="0.5"
-                    class="subtask-editor__input"
-                    placeholder="任意"
-                    [value]="newSubtaskForm.controls.estimateHours.value()"
-                    (input)="
-                      newSubtaskForm.controls.estimateHours.setValue($any($event.target).value)
-                    "
-                  />
-                </label>
-              </div>
               <div class="subtask-editor__actions">
                 <button
                   type="submit"
-                  class="surface-primary focus-ring rounded-full px-5 py-3 text-sm font-semibold disabled:pointer-events-none disabled:opacity-60"
+                  class="button button--primary"
                   [disabled]="!isNewSubtaskFormValid()"
                 >
                   サブタスクを追加
@@ -644,80 +584,92 @@
             </form>
           </section>
         </div>
-        <div class="min-w-0 space-y-6">
-          <section class="comment-editor space-y-4">
-            <div class="space-y-1">
-              <p class="text-xs uppercase tracking-[0.3em] text-slate-400">コメント</p>
-              <p class="text-xs text-slate-500">
-                カード全体やサブタスクに関するメモを記録して共有できます。
-              </p>
-            </div>
-            <form
-              class="grid gap-3 rounded-2xl border border-dashed border-subtle bg-surface px-5 py-5"
-              (submit)="saveComment($event)"
-            >
-              <div class="grid gap-2">
-                <label class="comment-editor__label" for="comment-author">担当者</label>
-                <input
-                  type="text"
-                  id="comment-author"
-                  class="comment-editor__input"
-                  placeholder="例: 田中太郎"
-                  [value]="commentForm.controls.author.value()"
-                  (input)="commentForm.controls.author.setValue($any($event.target).value)"
-                />
+        <section class="board-detail__secondary">
+          <section class="surface-card board-detail__section">
+            <header class="board-detail__section-header">
+              <h4>コメント</h4>
+              <p>コンテキストや共有事項を残してチームで同期します。</p>
+            </header>
+            <form class="comment-editor" (submit)="saveComment($event)">
+              <div class="comment-editor__grid">
+                <label class="comment-editor__field">
+                  <span class="comment-editor__label">投稿者</span>
+                  <input
+                    type="text"
+                    class="comment-editor__input"
+                    placeholder="氏名またはイニシャル"
+                    [value]="commentForm.controls.author.value()"
+                    (input)="commentForm.controls.author.setValue($any($event.target).value)"
+                  />
+                </label>
+                <label class="comment-editor__field">
+                  <span class="comment-editor__label">メッセージ</span>
+                  <textarea
+                    class="comment-editor__textarea"
+                    rows="3"
+                    placeholder="共有したい内容や次のアクションを記入"
+                    [value]="commentForm.controls.message.value()"
+                    (input)="commentForm.controls.message.setValue($any($event.target).value)"
+                  ></textarea>
+                </label>
               </div>
-              <div class="grid gap-2">
-                <label class="comment-editor__label" for="comment-message">コメント</label>
-                <textarea
-                  id="comment-message"
-                  class="comment-editor__textarea"
-                  placeholder="進捗やメモを追加しましょう"
-                  [value]="commentForm.controls.message.value()"
-                  (input)="commentForm.controls.message.setValue($any($event.target).value)"
-                ></textarea>
+              <div class="comment-editor__actions">
+                <button
+                  type="submit"
+                  class="button button--secondary"
+                  [disabled]="!isCommentFormValid()"
+                >
+                  コメントを追加
+                </button>
               </div>
-              <button
-                type="submit"
-                class="surface-primary focus-ring rounded-full px-5 py-3 text-sm font-semibold disabled:pointer-events-none disabled:opacity-60"
-                [disabled]="!isCommentFormValid()"
-              >
-                コメントを追加
-              </button>
             </form>
-            @if (active.comments.length === 0) {
-              <p
-                class="rounded-2xl border border-dashed border-subtle px-4 py-6 text-sm text-slate-500"
-              >
-                コメントはまだありません。
-              </p>
-            } @else {
-              <ul class="comment-editor__list space-y-3">
+            <ul class="comment-list">
+              @if (active.comments.length === 0) {
+                <li class="comment-list__empty">まだコメントはありません。</li>
+              } @else {
                 @for (comment of active.comments; track comment.id) {
-                  <li class="comment-editor__item">
-                    <div class="comment-editor__item-header">
-                      <div class="comment-editor__meta">
-                        <span class="comment-editor__author">担当: {{ comment.author }}</span>
-                        <span class="comment-editor__timestamp"
+                  <li class="comment-list__item">
+                    <div class="comment-list__meta">
+                      <div class="comment-list__identity">
+                        <span class="comment-list__author">{{ comment.author }}</span>
+                        <span class="comment-list__timestamp"
                           >更新: {{ comment.updatedAt | date: 'yyyy/MM/dd HH:mm' }}</span
                         >
                       </div>
                       <button
                         type="button"
-                        class="comment-editor__delete"
+                        class="button button--ghost button--pill comment-list__remove"
                         (click)="removeComment(active.id, comment.id)"
                       >
                         削除
                       </button>
                     </div>
-                    <p class="comment-editor__message">{{ comment.message }}</p>
+                    <p class="comment-list__message">{{ comment.message }}</p>
                   </li>
                 }
-              </ul>
-            }
+              }
+            </ul>
           </section>
-        </div>
-      </aside>
-    }
-  </div>
+          <section class="surface-card board-detail__section">
+            <header class="board-detail__section-header">
+              <h4>テンプレート可視性</h4>
+              <p>カードが参照するテンプレートの入力項目を確認します。</p>
+            </header>
+            @let fields = templateFieldLabels(active);
+            <ul class="board-detail__template-list">
+              @if (fields.length > 0) {
+                @for (field of fields; track field) {
+                  <li class="board-detail__template-item">{{ field }}</li>
+                }
+              } @else {
+                <li class="board-detail__template-item board-detail__template-item--empty">
+                  テンプレート情報は設定されていません。
+                </li>
+              }
+            </ul>
+          </section>
+        </section>
+      </div>
+    </aside>
+  }
 </section>

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@a
 import { CommonModule } from '@angular/common';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
 import { RouterLink } from '@angular/router';
+import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
 
 import { WorkspaceStore } from '@core/state/workspace-store';
 import {
@@ -121,7 +122,7 @@ const RESOLVED_SUBTASK_STATUSES = new Set<SubtaskStatus>(['done', 'non-issue']);
 @Component({
   selector: 'app-board-page',
   standalone: true,
-  imports: [CommonModule, DragDropModule, RouterLink],
+  imports: [CommonModule, DragDropModule, RouterLink, PageHeaderComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -603,6 +604,30 @@ export class BoardPage {
     }
 
     return this.templateVisibilityByIdSignal().get(card.templateId) ?? DEFAULT_TEMPLATE_FIELDS;
+  };
+
+  public readonly templateFieldLabels = (card: Card): readonly string[] => {
+    if (!card.templateId) {
+      return [];
+    }
+
+    const visibility = this.cardFieldVisibility(card);
+    const fields: string[] = [];
+
+    if (visibility.showStoryPoints) {
+      fields.push('ストーリーポイント');
+    }
+    if (visibility.showDueDate) {
+      fields.push('期限日');
+    }
+    if (visibility.showAssignee) {
+      fields.push('担当者');
+    }
+    if (visibility.showConfidence) {
+      fields.push('AIおすすめ度');
+    }
+
+    return fields;
   };
 
   public readonly columnAccent = (column: BoardColumnView): string => column.accent;

--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -1,46 +1,263 @@
 .board-page {
-  display: grid;
-  min-height: 100%;
+  display: flex;
+  flex-direction: column;
   gap: var(--page-content-gap);
 }
 
-@media (min-width: 64rem) {
-  .board-page {
-    grid-template-rows: auto 1fr;
-  }
+.board-page__header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.board-page__primary-action {
+  flex-shrink: 0;
+}
+
+.board-page__header-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.board-page__header-chip {
+  padding: 0.45rem 0.9rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
 }
 
 .board-page__overview {
-  display: grid;
-  gap: var(--page-content-gap);
-  align-items: start;
+  align-items: stretch;
 }
 
-@media (min-width: 64rem) {
-  .board-page__overview {
-    grid-template-columns: minmax(0, 280px) minmax(0, 1fr);
-  }
+.board-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.board-summary__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.board-summary__eyebrow {
+  margin: 0;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 80%, transparent);
+}
+
+.board-summary__value {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  margin: 0;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.board-summary__value-number {
+  font-size: clamp(2.25rem, 1.8rem + 1.5vw, 3rem);
+  line-height: 1.1;
+}
+
+.board-summary__value-unit {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.board-summary__description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.board-summary__metrics {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.board-summary__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 82%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--surface-card-muted) 40%, transparent);
+}
+
+.board-summary__metric dt {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+}
+
+.board-summary__metric dd {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.board-summary__progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.board-summary__progress-track {
+  position: relative;
+  width: 100%;
+  height: 0.75rem;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--surface-card) 70%, transparent);
+  overflow: hidden;
+}
+
+.board-summary__progress-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  transition: width 200ms ease-in-out;
+}
+
+.board-summary__progress-caption {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+}
+
+.board-summary__cta {
+  align-self: flex-start;
+  font-size: 0.85rem;
+}
+
+.board-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--panel-gap);
+}
+
+.board-controls__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--panel-gap);
+}
+
+.board-controls__search {
+  position: relative;
+}
+
+.board-controls__search-icon {
+  position: absolute;
+  inset-inline-start: 1rem;
+  inset-block-start: 50%;
+  translate: 0 -50%;
+  color: color-mix(in srgb, var(--text-muted) 80%, transparent);
+}
+
+.board-controls__search-input {
+  padding-inline-start: 2.6rem;
+}
+
+.board-controls__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.board-controls__toggle-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.board-controls__toggle {
+  border-color: color-mix(in srgb, var(--text-muted) 35%, transparent);
+  background: color-mix(in srgb, var(--surface-card) 88%, transparent);
+  color: color-mix(in srgb, var(--text-secondary) 92%, transparent);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.board-controls__toggle.is-active {
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  background: var(--accent-muted);
+  color: var(--accent-strong);
+}
+
+.board-controls__quick-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.board-controls__clear {
+  margin-inline-start: auto;
+}
+
+.board-controls__quick-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.board-controls__quick-button {
+  padding: 0.45rem 0.9rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease,
+    background-color 150ms ease;
+}
+
+.board-controls__quick-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px -18px var(--accent-shadow-color);
+}
+
+.board-controls__quick-button--active {
+  background: var(--accent-muted);
+  color: var(--accent-strong);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+.board-page__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.board-page__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--panel-gap);
 }
 
 .board-columns {
   display: flex;
   flex-wrap: wrap;
   gap: 1.5rem;
-  padding: 0 var(--shell-inline-padding, 1.5rem) 1.5rem;
-  margin: 0 calc(var(--shell-inline-padding, 1.5rem) * -1);
-}
-
-@media (min-width: 640px) {
-  .board-columns {
-    justify-content: flex-start;
-  }
-}
-
-@media (min-width: 1024px) {
-  .board-columns {
-    margin: 0;
-    padding-inline: 0;
-  }
+  align-items: stretch;
 }
 
 .board-column {
@@ -53,25 +270,40 @@
   padding: 1.5rem;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
-  background: linear-gradient(180deg, var(--neutral-surface), var(--neutral-surface-strong));
+  background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
   box-shadow: var(--shadow-soft);
   transition:
     border-color 150ms ease,
     box-shadow 150ms ease;
 }
 
-.board-column header {
+.board-column__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.75rem;
 }
 
-.dark .board-page .board-column {
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--surface-strong) 88%, transparent),
-    color-mix(in srgb, var(--surface) 92%, transparent)
-  );
+.board-column__eyebrow {
+  margin: 0 0 0.25rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+}
+
+.board-column__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.board-column__count {
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.35rem 0.85rem;
 }
 
 .board-column.cdk-drop-list-dragging,
@@ -88,22 +320,22 @@
 }
 
 .board-empty {
+  margin: 0;
   border-radius: var(--radius-lg);
-  border: 2px dashed var(--neutral-border-strong);
+  border: 1px dashed var(--neutral-border);
   padding: 2rem 1.5rem;
   text-align: center;
+  font-size: 0.9rem;
   color: color-mix(in srgb, var(--text-tertiary) 70%, transparent);
-  background: color-mix(in srgb, var(--surface-card) 55%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-tertiary) 24%, transparent);
-}
-
-.dark .board-page .board-empty {
   background: color-mix(in srgb, var(--surface-card) 60%, transparent);
-  color: var(--text-tertiary);
 }
 
 .board-card {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem;
   border-width: 1px;
   overflow: hidden;
   transition:
@@ -117,7 +349,7 @@
 }
 
 .board-card__select {
-  display: flex;
+  display: block;
   width: 100%;
   padding: 0;
   border: 0;
@@ -142,22 +374,55 @@
   outline: 0;
 }
 
-.board-card--compact {
-  gap: 0.75rem;
-  opacity: 0.9;
+.board-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
 }
 
-.board-card--compact .board-card__select {
-  gap: 0.75rem;
+.board-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.board-card__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.board-card__summary {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--text-secondary) 90%, transparent);
+  word-break: break-word;
 }
 
 .board-card-compact-note {
-  display: inline-flex;
-  align-items: center;
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--text-muted) 88%, transparent);
+}
+
+.board-card__meta {
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  border-radius: 1rem;
-  background: color-mix(in srgb, var(--text-tertiary) 16%, transparent);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.board-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
 }
 
 .board-badge {
@@ -167,12 +432,25 @@
   padding: 0.35rem 0.75rem;
   border-radius: 9999px;
   border: 1px solid var(--neutral-border);
-  background: color-mix(in srgb, var(--surface-card) 60%, transparent);
+  background: color-mix(in srgb, var(--surface-card) 65%, transparent);
+  font-weight: 600;
 }
 
-.dark .board-page .board-badge {
-  background: color-mix(in srgb, var(--surface-card) 60%, transparent);
-  border-color: var(--neutral-border-strong);
+.board-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.board-card__action {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.board-card--compact {
+  opacity: 0.85;
 }
 
 .board-page .cdk-drag-preview {
@@ -194,6 +472,63 @@
   gap: 0.75rem;
 }
 
+.subtask-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.subtask-card__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.subtask-card__status {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 80%, transparent);
+}
+
+.subtask-card__parent {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.subtask-card__parent span {
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.subtask-card-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.subtask-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.subtask-card-compact-note {
+  margin: 0;
+  font-size: 0.78rem;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+}
+
 .subtask-card--highlight {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
@@ -204,10 +539,6 @@
   opacity: 0.65;
 }
 
-.subtask-card-labels {
-  gap: 0.5rem;
-}
-
 .subtask-badge {
   display: inline-flex;
   align-items: center;
@@ -215,26 +546,73 @@
   border-radius: 9999px;
   border: 1px solid var(--neutral-border);
   background: color-mix(in srgb, var(--surface-card) 75%, transparent);
+  font-weight: 600;
 }
 
-.dark .board-page .subtask-badge {
-  background: color-mix(in srgb, var(--surface-card) 60%, transparent);
-  border-color: var(--neutral-border-strong);
+.board-detail {
+  margin-block-start: var(--page-content-gap);
+  display: block;
+  padding: var(--panel-padding);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
+  box-shadow: var(--shadow-soft);
 }
 
-.board-page__subtasks {
+.board-detail__grid {
+  display: grid;
+  gap: var(--panel-gap);
+}
+
+@media (min-width: 70rem) {
+  .board-detail__grid {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  }
+}
+
+.board-detail__primary,
+.board-detail__secondary {
   display: flex;
-  min-height: 0;
   flex-direction: column;
-  gap: 2rem;
+  gap: var(--panel-gap);
 }
 
 .card-detail-header {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
+}
+
+.card-detail-header__eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+}
+
+.card-detail-header__title {
+  margin: 0.25rem 0 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.card-detail-header__subtitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.card-detail-header__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.6;
 }
 
 .card-editor {
@@ -342,6 +720,25 @@
   justify-content: flex-end;
 }
 
+.subtask-editor__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.subtask-editor__empty {
+  padding: 1.25rem;
+  border-radius: 1.5rem;
+  border: 1px dashed var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 60%, transparent);
+  text-align: center;
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+}
+
 .subtask-editor__item {
   display: flex;
   flex-direction: column;
@@ -382,6 +779,28 @@
   background: color-mix(in srgb, var(--surface-card) 60%, transparent);
 }
 
+.subtask-editor__form-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.subtask-editor__remove {
+  margin-inline-start: auto;
+}
+
+.comment-editor__grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.comment-editor__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .comment-editor__label {
   font-size: 0.75rem;
   font-weight: 600;
@@ -390,13 +809,34 @@
   color: color-mix(in srgb, var(--text-secondary) 80%, transparent);
 }
 
-.comment-editor__list {
-  display: grid;
-  gap: 0.75rem;
+.comment-editor__actions {
+  display: flex;
+  justify-content: flex-end;
 }
 
-.comment-editor__item {
-  display: grid;
+.comment-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.comment-list__empty {
+  margin: 0;
+  padding: 1.1rem 1.25rem;
+  border-radius: 1.5rem;
+  border: 1px dashed var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 60%, transparent);
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+  text-align: center;
+}
+
+.comment-list__item {
+  display: flex;
+  flex-direction: column;
   gap: 0.75rem;
   padding: 1rem 1.25rem;
   border-radius: 1.5rem;
@@ -405,71 +845,149 @@
   box-shadow: var(--shadow-soft);
 }
 
-.comment-editor__item-header {
+.comment-list__meta {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  gap: 0.75rem;
   align-items: center;
-}
-
-.comment-editor__meta {
-  display: flex;
-  flex-wrap: wrap;
   gap: 0.75rem;
   font-size: 0.75rem;
   color: color-mix(in srgb, var(--text-secondary) 80%, transparent);
 }
 
-.comment-editor__author {
-  font-size: 0.875rem;
+.comment-list__identity {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.comment-list__author {
+  font-size: 0.9rem;
   font-weight: 600;
   color: var(--text-primary);
 }
 
-.comment-editor__timestamp {
-  font-size: 0.75rem;
+.comment-list__timestamp {
+  font-weight: 500;
 }
 
-.comment-editor__delete {
-  padding: 0.35rem 0.75rem;
-  border-radius: 9999px;
-  border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
-  background: color-mix(in srgb, var(--accent) 15%, transparent);
-  color: var(--accent-strong);
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  transition:
-    background 150ms ease,
-    color 150ms ease;
+.comment-list__remove {
+  margin-inline-start: auto;
 }
 
-.comment-editor__delete:hover {
-  background: color-mix(in srgb, var(--accent) 28%, transparent);
-}
-
-.comment-editor__message {
-  font-size: 0.875rem;
+.comment-list__message {
+  margin: 0;
+  font-size: 0.88rem;
   line-height: 1.6;
   color: var(--text-primary);
 }
 
-:host-context(.dark) .card-editor,
-:host-context(.dark) .subtask-editor__item,
-:host-context(.dark) .subtask-editor__form,
-:host-context(.dark) .comment-editor__item {
+.board-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-subtle);
+  background: linear-gradient(180deg, var(--surface-card), var(--surface-card-muted));
+  box-shadow: var(--shadow-soft);
+}
+
+.board-detail__section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.board-detail__section-header h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.board-detail__section-header p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.board-detail__template-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.board-detail__template-item {
+  padding: 0.55rem 0.85rem;
+  border-radius: 9999px;
+  border: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 75%, transparent);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.board-detail__template-item--empty {
+  text-align: center;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+  font-weight: 500;
+}
+
+.dark .board-page .board-column,
+.dark .board-page .board-detail__section {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-strong) 88%, transparent),
+    color-mix(in srgb, var(--surface) 92%, transparent)
+  );
+}
+
+.dark .board-page .board-empty,
+.dark .board-page .comment-list__empty,
+.dark .board-page .subtask-editor__empty,
+.dark .board-page .subtask-editor__form {
+  background: color-mix(in srgb, var(--surface-card) 70%, transparent);
+  border-color: color-mix(in srgb, var(--neutral-border-strong) 80%, transparent);
+}
+
+.dark .board-page .board-controls__toggle {
+  background: color-mix(in srgb, var(--surface-card) 82%, transparent);
+  color: color-mix(in srgb, var(--text-secondary) 85%, transparent);
+}
+
+.dark .board-page .board-controls__quick-button {
+  color: color-mix(in srgb, var(--text-secondary) 85%, transparent);
+}
+
+.dark .board-page .card-editor,
+.dark .board-page .subtask-editor__item,
+.dark .board-page .comment-list__item {
   background: color-mix(in srgb, var(--surface-card) 75%, transparent);
   border-color: color-mix(in srgb, var(--neutral-border-strong) 80%, transparent);
 }
 
-:host-context(.dark) .card-editor__input,
-:host-context(.dark) .card-editor__textarea,
-:host-context(.dark) .subtask-editor__input,
-:host-context(.dark) .comment-editor__input,
-:host-context(.dark) .comment-editor__textarea {
+.dark .board-page .board-badge,
+.dark .board-page .subtask-badge {
+  background: color-mix(in srgb, var(--surface-card) 65%, transparent);
+  border-color: color-mix(in srgb, var(--neutral-border-strong) 80%, transparent);
+}
+
+.dark .board-page .card-editor__input,
+.dark .board-page .card-editor__textarea,
+.dark .board-page .subtask-editor__input,
+.dark .board-page .comment-editor__input,
+.dark .board-page .comment-editor__textarea {
   background: color-mix(in srgb, var(--surface) 80%, transparent);
   border-color: color-mix(in srgb, var(--neutral-border-strong) 75%, transparent);
   color: var(--text-primary);
+}
+
+.dark .board-page .board-summary__metric {
+  background: color-mix(in srgb, var(--surface-card) 70%, transparent);
 }


### PR DESCRIPTION
## Summary
- rebuild the board header and filter layout around the shared page header and page grid patterns
- restyle board panels, cards, and detail panes to use design-system tokens for spacing, typography, and chips
- expose template field labels so the detail sidebar can surface visible inputs consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3eea859a0832084c06bb8805f79e4