### PR TITLE
feat: refresh primary layouts with design system

### DIFF
--- a/frontend/src/app/features/analytics/page.html
+++ b/frontend/src/app/features/analytics/page.html
@@ -5,85 +5,86 @@
     description="完了率やポイント配分に加え、指摘の傾向や原因、改善活動の進捗までひと目で確認できます。"
   ></app-page-header>
 
-  <div
-    class="flex flex-col gap-2 rounded-3xl border border-dashed border-subtle bg-white/70 px-4 py-4 text-sm text-slate-600 shadow-soft dark:bg-slate-900/60 dark:text-slate-300 lg:flex-row lg:items-center lg:justify-between"
-  >
-    <p class="leading-relaxed">
-      最新のコンピテンシー判定とあわせてボード分析を見ると、改善の優先度が整理しやすくなります。
-    </p>
-    <a
-      routerLink="/profile/evaluations"
-      class="focus-ring inline-flex items-center gap-2 self-start rounded-full bg-accent px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-on-surface-inverse transition hover:bg-accent-strong"
-    >
-      最新の評価を確認
-      <svg
-        aria-hidden="true"
-        viewBox="0 0 24 24"
-        class="h-4 w-4"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.8"
-      >
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-      </svg>
-    </a>
-  </div>
+  <section class="page-section analytics-page__intro">
+    <div class="analytics-page__intro-content">
+      <p>
+        最新のコンピテンシー判定とあわせてボード分析を見ると、改善の優先度が整理しやすくなります。
+      </p>
+    </div>
+    <div class="analytics-page__intro-actions">
+      <a routerLink="/profile/evaluations" class="button button--secondary button--pill">
+        最新の評価を確認
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          class="analytics-page__intro-icon"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </a>
+    </div>
+  </section>
 
   @if (summarySignal(); as summary) {
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-      <article class="surface-panel px-6 py-6">
-        <p class="text-xs uppercase tracking-[0.3em] text-slate-400">進捗率</p>
-        <p class="mt-3 text-3xl font-semibold">{{ summary.progressRatio }}%</p>
-        <p class="text-sm text-slate-500">
-          完了したカード {{ summary.doneCards }}/{{ summary.totalCards }}
-        </p>
-      </article>
-      <article class="surface-panel px-6 py-6">
-        <p class="text-xs uppercase tracking-[0.3em] text-slate-400">カード総数</p>
-        <p class="mt-3 text-3xl font-semibold">{{ summary.totalCards }}</p>
-        <p class="text-sm text-slate-500">利用中のラベル {{ summary.activeLabels }}</p>
-      </article>
-      <article class="surface-panel px-6 py-6">
-        <p class="text-xs uppercase tracking-[0.3em] text-slate-400">完了ポイント</p>
-        <p class="mt-3 text-3xl font-semibold">{{ pointSummary().done }}</p>
-        <p class="text-sm text-slate-500">残り {{ pointSummary().remaining }}</p>
-      </article>
-      <article class="surface-panel px-6 py-6">
-        <p class="text-xs uppercase tracking-[0.3em] text-slate-400">総ポイント数</p>
-        <p class="mt-3 text-3xl font-semibold">{{ pointSummary().total }}</p>
-        <p class="text-sm text-slate-500">スプリント負荷の目安として活用できます</p>
-      </article>
-    </div>
+    <section class="page-section analytics-summary">
+      <ul class="page-list analytics-summary__metrics">
+        <li class="page-list__item analytics-summary__metric">
+          <p class="analytics-summary__eyebrow">進捗率</p>
+          <p class="analytics-summary__value">{{ summary.progressRatio }}%</p>
+          <p class="analytics-summary__note">
+            完了したカード {{ summary.doneCards }}/{{ summary.totalCards }}
+          </p>
+        </li>
+        <li class="page-list__item analytics-summary__metric">
+          <p class="analytics-summary__eyebrow">カード総数</p>
+          <p class="analytics-summary__value">{{ summary.totalCards }}</p>
+          <p class="analytics-summary__note">利用中のラベル {{ summary.activeLabels }}</p>
+        </li>
+        <li class="page-list__item analytics-summary__metric">
+          <p class="analytics-summary__eyebrow">完了ポイント</p>
+          <p class="analytics-summary__value">{{ pointSummary().done }}</p>
+          <p class="analytics-summary__note">残り {{ pointSummary().remaining }}</p>
+        </li>
+        <li class="page-list__item analytics-summary__metric">
+          <p class="analytics-summary__eyebrow">総ポイント数</p>
+          <p class="analytics-summary__value">{{ pointSummary().total }}</p>
+          <p class="analytics-summary__note">スプリント負荷の目安として活用できます</p>
+        </li>
+      </ul>
+    </section>
   }
 
   <div class="grid gap-4 lg:grid-cols-2">
-    <section class="surface-panel space-y-4 px-6 py-6">
-      <header class="flex items-center justify-between">
-        <h3 class="text-lg font-semibold text-on-surface">ステータス別の件数</h3>
-        <span class="text-xs text-slate-500">{{ statusBreakdown().length }} ステージ</span>
+    <section class="page-section analytics-breakdown">
+      <header class="page-section__header">
+        <h3 class="page-section__title">ステータス別の件数</h3>
+        <span class="page-section__subtitle">{{ statusBreakdown().length }} ステージ</span>
       </header>
-      <ul class="space-y-3">
+      <ul class="page-list analytics-breakdown__list">
         @for (item of statusBreakdown(); track item.id) {
-          <li class="flex items-center gap-4 rounded-2xl border border-subtle px-4 py-3">
-            <span class="h-3 w-3 rounded-full" [style.backgroundColor]="item.color"></span>
-            <span class="flex-1 text-sm text-on-surface">{{ item.name }}</span>
-            <span class="text-sm font-semibold text-on-surface">{{ item.total }}</span>
+          <li class="page-list__item analytics-breakdown__item">
+            <span class="analytics-breakdown__swatch" [style.backgroundColor]="item.color"></span>
+            <span class="analytics-breakdown__label">{{ item.name }}</span>
+            <span class="analytics-breakdown__value">{{ item.total }}</span>
           </li>
         }
       </ul>
     </section>
 
-    <section class="surface-panel space-y-4 px-6 py-6">
-      <header class="flex items-center justify-between">
-        <h3 class="text-lg font-semibold text-on-surface">ラベル別の件数</h3>
-        <span class="text-xs text-slate-500">{{ labelBreakdown().length }} ラベル</span>
+    <section class="page-section analytics-breakdown">
+      <header class="page-section__header">
+        <h3 class="page-section__title">ラベル別の件数</h3>
+        <span class="page-section__subtitle">{{ labelBreakdown().length }} ラベル</span>
       </header>
-      <ul class="space-y-3">
+      <ul class="page-list analytics-breakdown__list">
         @for (item of labelBreakdown(); track item.id) {
-          <li class="flex items-center gap-4 rounded-2xl border border-subtle px-4 py-3">
-            <span class="h-3 w-3 rounded-full" [style.backgroundColor]="item.color"></span>
-            <span class="flex-1 text-sm text-on-surface">{{ item.name }}</span>
-            <span class="text-sm font-semibold text-on-surface">{{ item.total }}</span>
+          <li class="page-list__item analytics-breakdown__item">
+            <span class="analytics-breakdown__swatch" [style.backgroundColor]="item.color"></span>
+            <span class="analytics-breakdown__label">{{ item.name }}</span>
+            <span class="analytics-breakdown__value">{{ item.total }}</span>
           </li>
         }
       </ul>
@@ -250,7 +251,7 @@
           <div class="flex flex-wrap items-center gap-3">
             <button
               type="button"
-              class="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white disabled:bg-slate-400"
+              class="button button--primary"
               [disabled]="action.status === 'converted'"
               (click)="convertAction(action.id)"
             >
@@ -341,11 +342,7 @@
         (input)="updateReportInstruction($any($event.target).value)"
       ></textarea>
       <div class="flex items-center justify-end">
-        <button
-          type="button"
-          class="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white"
-          (click)="generateReport()"
-        >
+        <button type="button" class="button button--primary" (click)="generateReport()">
           レポートを再作成
         </button>
       </div>

--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -1,194 +1,189 @@
-<section class="app-page analyze-page space-y-10">
-  <form class="surface-panel space-y-6 px-8 py-8" (submit)="handleSubmit($event)">
-    <app-page-header
-      eyebrow="AI Task Creator"
-      title="メモからタスクを起票"
-      description="作業メモやアイデアを貼り付けると、AI がカード案とサブタスクを提案します。内容を確認し、必要なものだけボードへ追加しましょう。"
-    ></app-page-header>
+<section class="app-page analyze-page">
+  <app-page-header
+    eyebrow="AI Task Creator"
+    title="メモからタスクを起票"
+    description="作業メモやアイデアを貼り付けると、AI がカード案とサブタスクを提案します。内容を確認し、必要なものだけボードへ追加しましょう。"
+  ></app-page-header>
 
-    <div class="grid gap-4 lg:grid-cols-2">
-      <label class="flex h-full flex-col gap-2">
-        <span class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">ノート</span>
+  <form class="surface-panel page-panel analyze-page__form" (submit)="handleSubmit($event)">
+    <div class="form-grid form-grid--two analyze-page__composer">
+      <label class="form-field analyze-page__notes">
+        <span class="form-field__label">ノート</span>
         <textarea
-          class="min-h-[260px] flex-1 rounded-2xl border border-subtle bg-surface px-4 py-3 text-sm focus-ring"
+          class="form-control form-control--textarea analyze-page__notes-input"
           placeholder="例: ユーザーからのフィードバックや不具合の状況を貼り付けてください"
           [value]="analyzeForm.controls.notes.value()"
           (input)="analyzeForm.controls.notes.setValue($any($event.target).value)"
         ></textarea>
+        <p class="form-note">
+          具体的な課題や観察した事実をまとめると、より正確なカード案が生成されます。
+        </p>
       </label>
-      <div class="flex h-full flex-col gap-4">
-        <div class="space-y-3 rounded-2xl border border-dashed border-subtle px-4 py-4">
-          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-            ゴールの決め方
-          </p>
-          <p class="text-[11px] text-slate-400 dark:text-slate-500">
-            タスク案を作成するときのゴールの決め方を選んでください。
-          </p>
-          <label class="flex items-start gap-3 text-sm text-slate-600 dark:text-slate-300">
+
+      <div class="analyze-page__objective">
+        <p class="analyze-page__objective-eyebrow">ゴールの決め方</p>
+        <p class="analyze-page__objective-hint">
+          タスク案を作成するときのゴールの決め方を選んでください。
+        </p>
+
+        <div class="analyze-page__options" role="radiogroup" aria-label="ゴールの決め方">
+          <label
+            class="analyze-page__option"
+            [class.analyze-page__option--active]="isAutoObjectiveEnabled()"
+          >
             <input
               type="radio"
               name="autoObjective"
               [checked]="isAutoObjectiveEnabled()"
               (change)="analyzeForm.controls.autoObjective.setValue(true)"
-              class="mt-1 h-4 w-4 text-accent focus-ring"
+              class="analyze-page__option-input focus-ring"
             />
-            <span class="space-y-1">
-              <span class="block font-semibold text-on-surface">AIにおまかせ</span>
-              <span class="block text-xs text-slate-500 dark:text-slate-400">
+            <span class="analyze-page__option-body">
+              <span class="analyze-page__option-title">AIにおまかせ</span>
+              <span class="analyze-page__option-description">
                 ノートの内容から AI がおすすめのゴールを自動設定します。
               </span>
             </span>
           </label>
-          <label class="flex items-start gap-3 text-sm text-slate-600 dark:text-slate-300">
+
+          <label
+            class="analyze-page__option"
+            [class.analyze-page__option--active]="!isAutoObjectiveEnabled()"
+          >
             <input
               type="radio"
               name="autoObjective"
               [checked]="!isAutoObjectiveEnabled()"
               (change)="analyzeForm.controls.autoObjective.setValue(false)"
-              class="mt-1 h-4 w-4 text-accent focus-ring"
+              class="analyze-page__option-input focus-ring"
             />
-            <span class="space-y-1">
-              <span class="block font-semibold text-on-surface">自分で指定</span>
-              <span class="block text-xs text-slate-500 dark:text-slate-400">
+            <span class="analyze-page__option-body">
+              <span class="analyze-page__option-title">自分で指定</span>
+              <span class="analyze-page__option-description">
                 ゴールを詳しく入力して AI に具体的な提案を依頼します。
               </span>
             </span>
           </label>
         </div>
+
         @if (isAutoObjectiveEnabled()) {
-          <div
-            class="min-h-[260px] rounded-2xl border border-subtle bg-surface px-4 py-3 text-xs text-slate-600 dark:text-slate-300"
-          >
-            <p class="text-sm font-semibold text-on-surface">AIが推定したゴール候補</p>
-            <p class="mt-1 leading-relaxed">{{ autoObjectivePreview() }}</p>
-            <p class="mt-2 text-[11px] text-slate-400 dark:text-slate-500">
+          <div class="surface-card analyze-page__objective-preview" aria-live="polite">
+            <h3 class="analyze-page__preview-title">AIが推定したゴール候補</h3>
+            <p class="analyze-page__preview-body">{{ autoObjectivePreview() }}</p>
+            <p class="analyze-page__preview-hint">
               提案を作成すると、このゴールを前提にカード案が作成されます。
             </p>
           </div>
         } @else {
-          <label class="flex flex-1 flex-col gap-2">
-            <span class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500"
-              >ゴール</span
-            >
+          <label class="form-field analyze-page__objective-manual">
+            <span class="form-field__label">ゴール</span>
             <textarea
-              class="min-h-[260px] flex-1 rounded-2xl border border-subtle bg-surface px-4 py-3 text-sm focus-ring"
+              class="form-control form-control--textarea"
               placeholder="例: 新規登録フローの離脱率を20%改善する"
               [value]="analyzeForm.controls.objective.value()"
               (input)="analyzeForm.controls.objective.setValue($any($event.target).value)"
             ></textarea>
+            <p class="form-note">
+              ゴールは AI
+              がタスク案を組み立てる際の到達点になります。できるだけ具体的に記載してください。
+            </p>
           </label>
-          <p class="text-[11px] text-slate-400 dark:text-slate-500">
-            ゴールは AI
-            がタスク案を組み立てる際の到達点になります。できるだけ具体的に記載してください。
-          </p>
         }
       </div>
     </div>
 
-    <div class="flex flex-wrap gap-3">
-      <button
-        type="submit"
-        class="surface-primary focus-ring rounded-full px-6 py-3 text-sm font-semibold"
-      >
-        タスク案を作成
-      </button>
-      <button
-        type="button"
-        (click)="resetForm()"
-        class="surface-pill focus-ring px-6 py-3 text-sm font-semibold text-slate-600 dark:text-slate-300"
-      >
+    <div class="form-actions analyze-page__form-actions">
+      <button type="submit" class="button button--primary">タスク案を作成</button>
+      <button type="button" class="button button--ghost" (click)="resetForm()">
         入力をリセット
       </button>
     </div>
   </form>
 
-  <section class="space-y-4">
-    <header class="flex items-center justify-between">
+  <section class="page-section analyze-page__results">
+    <header class="page-section__header analyze-page__results-header">
       <div>
-        <p class="text-xs uppercase tracking-[0.3em] text-slate-400">AI Suggestions</p>
-        <h3 class="text-xl font-semibold text-on-surface">AI が作成したタスク案</h3>
+        <p class="analyze-page__results-eyebrow">AI Suggestions</p>
+        <h3 class="page-section__title">AI が作成したタスク案</h3>
+        <p class="page-section__subtitle">
+          ノートとゴールをもとに、優先度付きのカード案とサブタスクを提案します。
+        </p>
       </div>
-      <button
-        type="button"
-        class="surface-pill focus-ring px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500"
-        (click)="resetForm()"
-      >
-        結果をクリア
-      </button>
+      <div class="page-section__actions">
+        <button type="button" class="button button--ghost button--pill" (click)="resetForm()">
+          結果をクリア
+        </button>
+      </div>
     </header>
 
     @if (analysisResource.status() === 'loading') {
-      <div class="surface-panel animate-pulse space-y-3 px-6 py-6 text-sm text-slate-500">
-        AI がタスク案を準備しています...
+      <div class="page-state analyze-page__state">
+        <h2>タスク案を生成しています</h2>
+        <p>AI がタスク案を準備しています...</p>
       </div>
     }
 
     @if (analysisResource.error()) {
-      <div
-        class="surface-panel border-red-300 bg-red-50 px-6 py-6 text-sm text-red-700 dark:border-red-500 dark:bg-red-950/40 dark:text-red-200"
-      >
+      <p class="app-alert app-alert--error">
         タスク起票の処理中にエラーが発生しました。内容を確認してからもう一度お試しください。
-      </div>
+      </p>
     }
 
     @if (analysisResource.value()) {
       @if (hasEligibleProposals()) {
-        <div class="grid gap-4 lg:grid-cols-2">
+        <ul class="page-list analyze-page__proposal-list">
           @for (proposal of eligibleProposals(); track proposal.id) {
-            <article class="surface-panel flex flex-col gap-4 px-6 py-6">
-              <div class="flex items-center justify-between">
-                <h4 class="text-lg font-semibold text-on-surface">{{ proposal.title }}</h4>
-                <span class="surface-pill px-3 py-1 text-xs font-semibold text-accent-strong">
+            <li class="page-list__item analyze-page__proposal">
+              <div class="analyze-page__proposal-header">
+                <h4 class="analyze-page__proposal-title">{{ proposal.title }}</h4>
+                <span class="page-badge page-badge--accent">
                   おすすめ度 {{ proposal.confidence * 100 | number: '1.0-0' }}%
                 </span>
               </div>
-              <p class="text-sm text-slate-600 dark:text-slate-300">{{ proposal.summary }}</p>
-              <div class="flex flex-wrap gap-2 text-xs text-slate-500">
-                <span class="surface-pill px-3 py-1"
-                  >推奨ステータス: {{ proposal.suggestedStatusId }}</span
-                >
-                <span class="surface-pill px-3 py-1"
-                  >推奨ラベル: {{ proposal.suggestedLabelIds.join(', ') }}</span
-                >
+              <p class="analyze-page__proposal-summary">{{ proposal.summary }}</p>
+              <div class="analyze-page__proposal-tags">
+                <span class="page-badge"> 推奨ステータス: {{ proposal.suggestedStatusId }} </span>
+                <span class="page-badge">
+                  推奨ラベル: {{ proposal.suggestedLabelIds.join(', ') }}
+                </span>
               </div>
-              <div class="space-y-2">
-                <p class="text-xs uppercase tracking-[0.3em] text-slate-400">サブタスク案</p>
-                <ul class="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+              <div class="analyze-page__proposal-subtasks">
+                <p class="analyze-page__proposal-subtasks-title">サブタスク案</p>
+                <ul class="analyze-page__proposal-subtasks-list">
                   @for (task of proposal.subtasks; track task) {
-                    <li class="flex items-center gap-2">
-                      <span class="h-2 w-2 rounded-full bg-accent"></span>
-                      <span>{{ task }}</span>
-                    </li>
+                    <li>{{ task }}</li>
                   }
                 </ul>
               </div>
               <button
                 type="button"
-                class="surface-primary focus-ring mt-auto self-start rounded-full px-5 py-2 text-sm font-semibold"
+                class="button button--secondary"
                 (click)="publishProposals([proposal])"
               >
                 この案をカードに追加
               </button>
-            </article>
+            </li>
           }
-        </div>
-        <div class="flex justify-end">
+        </ul>
+        <div class="analyze-page__proposal-actions">
           <button
             type="button"
-            class="surface-primary focus-ring rounded-full px-6 py-3 text-sm font-semibold"
+            class="button button--primary"
             (click)="publishProposals(eligibleProposals())"
           >
             すべての案をボードに追加
           </button>
         </div>
       } @else {
-        <div class="surface-panel px-6 py-6 text-sm text-slate-500 dark:text-slate-400">
-          おすすめ度のしきい値より低い案は表示されません。設定を見直して再度お試しください。
+        <div class="page-state analyze-page__state">
+          <h2>表示できる提案がありません</h2>
+          <p>おすすめ度のしきい値より低い案は表示されません。設定を見直して再度お試しください。</p>
         </div>
       }
     } @else {
-      <div class="surface-panel px-6 py-6 text-sm text-slate-500 dark:text-slate-400">
-        まだ提案がありません。ノートを入力してタスク起票を実行してください。
+      <div class="page-state analyze-page__state">
+        <h2>提案がまだありません</h2>
+        <p>ノートを入力してタスク起票を実行してください。</p>
       </div>
     }
   </section>

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -1,42 +1,50 @@
 <section class="app-page board-page">
+  <app-page-header
+    eyebrow="Workspace Board"
+    title="カード管理ボード"
+    description="ステータスやラベルでタスクを俯瞰し、サブタスクはステータス別ボードでドラッグ＆ドロップ更新できます。"
+  >
+    <div appPageHeaderActions class="board-page__header-actions">
+      <span class="page-badge">{{ filtersSignal().search || '検索なし' }}</span>
+      <span class="page-badge">タスク: {{ groupingLabelSignal() }}</span>
+      <span class="page-badge">サブタスク: ステータス別</span>
+      <span class="page-badge">クイック: {{ quickFilterSummarySignal() }}</span>
+    </div>
+  </app-page-header>
+
   <div class="board-page__overview">
     @if (summarySignal(); as summary) {
-      <section class="surface-panel flex flex-col gap-6 px-6 py-8">
-        <div>
-          <p class="text-xs uppercase tracking-[0.3em] text-slate-400">進捗状況</p>
-          <p class="mt-2 text-xl font-semibold text-on-surface">
-            {{ summary.progressRatio }}% 完了
-          </p>
-        </div>
-        <div class="space-y-3">
-          <div class="flex items-center justify-between text-sm text-slate-500">
+      <section class="surface-panel page-panel board-summary">
+        <header class="board-summary__header">
+          <p class="board-summary__eyebrow">進捗状況</p>
+          <p class="board-summary__progress">{{ summary.progressRatio }}% 完了</p>
+        </header>
+        <ul class="board-summary__metrics">
+          <li>
             <span>完了カード</span>
-            <span class="font-semibold text-on-surface">{{ summary.doneCards }}</span>
-          </div>
-          <div class="flex items-center justify-between text-sm text-slate-500">
+            <strong>{{ summary.doneCards }}</strong>
+          </li>
+          <li>
             <span>総カード数</span>
-            <span class="font-semibold text-on-surface">{{ summary.totalCards }}</span>
-          </div>
-          <div class="flex items-center justify-between text-sm text-slate-500">
+            <strong>{{ summary.totalCards }}</strong>
+          </li>
+          <li>
             <span>アクティブラベル</span>
-            <span class="font-semibold text-on-surface">{{ summary.activeLabels }}</span>
-          </div>
-        </div>
-        <div class="h-2 w-full rounded-full bg-slate-200 dark:bg-slate-800">
-          <div
-            class="h-2 rounded-full bg-accent transition-all"
-            [style.width.%]="summary.progressRatio"
-          ></div>
+            <strong>{{ summary.activeLabels }}</strong>
+          </li>
+        </ul>
+        <div class="board-summary__progress-bar" role="presentation">
+          <div class="board-summary__progress-value" [style.width.%]="summary.progressRatio"></div>
         </div>
         <a
           routerLink="/profile/evaluations"
-          class="focus-ring inline-flex items-center justify-center gap-2 self-start rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-accent shadow-soft transition hover:bg-accent-muted hover:text-accent-strong dark:bg-slate-900/60"
+          class="button button--secondary button--pill board-summary__link"
         >
           最新のコンピテンシー判定を確認
           <svg
             aria-hidden="true"
             viewBox="0 0 24 24"
-            class="h-4 w-4"
+            class="board-summary__link-icon"
             fill="none"
             stroke="currentColor"
             stroke-width="1.8"
@@ -47,37 +55,16 @@
       </section>
     }
     <div class="flex h-full min-w-0 flex-col gap-4">
-      <header class="space-y-3">
-        <div class="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-          <div class="min-w-0">
-            <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Workspace Board</p>
-            <h2 class="text-2xl font-semibold text-on-surface">カード管理ボード</h2>
-          </div>
-          <div class="flex flex-wrap gap-2 text-xs text-slate-500">
-            <span class="surface-pill px-3 py-1">{{ filtersSignal().search || '検索なし' }}</span>
-            <span class="surface-pill px-3 py-1">タスク: {{ groupingLabelSignal() }}</span>
-            <span class="surface-pill px-3 py-1">サブタスク: ステータス別</span>
-            <span class="surface-pill px-3 py-1">クイック: {{ quickFilterSummarySignal() }}</span>
-          </div>
-        </div>
-      </header>
-      <section
-        class="grid min-w-0 gap-6 rounded-3xl border border-subtle bg-surface px-6 py-6 shadow-soft lg:grid-cols-[minmax(0,320px)_minmax(0,1fr)] lg:items-start"
-      >
-        <div class="flex min-w-0 flex-col gap-5">
-          <label class="flex min-w-0 flex-col gap-2 text-sm text-slate-600 dark:text-slate-300">
-            <span
-              class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-              >検索</span
-            >
-            <div class="relative">
-              <span
-                class="pointer-events-none absolute inset-y-0 left-4 flex items-center text-slate-400 dark:text-slate-500"
-                aria-hidden="true"
-              >
+      <section class="surface-panel page-panel board-filters">
+        <div class="board-filters__grid page-grid page-grid--two">
+          <div class="board-filters__column">
+            <label class="form-field board-filters__field">
+              <span class="form-field__label">検索</span>
+              <div class="board-filters__search">
                 <svg
-                  class="h-4 w-4"
+                  aria-hidden="true"
                   viewBox="0 0 24 24"
+                  class="board-filters__search-icon"
                   fill="none"
                   stroke="currentColor"
                   stroke-width="2"
@@ -87,58 +74,65 @@
                   <circle cx="11" cy="11" r="7" />
                   <path d="M20 20L16.5 16.5" />
                 </svg>
-              </span>
-              <input
-                type="search"
-                class="w-full min-w-0 rounded-2xl border border-subtle bg-surface px-4 py-3 pl-11 text-sm focus-ring"
-                placeholder="キーワードでカードを検索"
-                [value]="searchForm.controls.search.value()"
-                (input)="updateSearch($any($event.target).value)"
-              />
-            </div>
-          </label>
-          <div class="flex flex-col gap-2 text-xs text-slate-500 dark:text-slate-400">
-            <span class="text-xs font-semibold uppercase tracking-[0.2em]">表示形式</span>
-            <div class="flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                class="surface-pill focus-ring px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-                [class.surface-primary-muted]="groupingSignal() === 'status'"
-                (click)="selectGrouping('status')"
-              >
-                ステータス別
-              </button>
-              <button
-                type="button"
-                class="surface-pill focus-ring px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-                [class.surface-primary-muted]="groupingSignal() === 'label'"
-                (click)="selectGrouping('label')"
-              >
-                ラベル別
-              </button>
+                <input
+                  type="search"
+                  class="form-control board-filters__search-input"
+                  placeholder="キーワードでカードを検索"
+                  [value]="searchForm.controls.search.value()"
+                  (input)="updateSearch($any($event.target).value)"
+                />
+              </div>
+            </label>
+            <div class="board-filters__grouping">
+              <span class="board-filters__grouping-label">表示形式</span>
+              <div class="board-filters__grouping-actions">
+                <button
+                  type="button"
+                  class="button button--pill"
+                  [ngClass]="{
+                    'button--secondary': groupingSignal() === 'status',
+                    'button--ghost': groupingSignal() !== 'status',
+                  }"
+                  [attr.aria-pressed]="groupingSignal() === 'status'"
+                  (click)="selectGrouping('status')"
+                >
+                  ステータス別
+                </button>
+                <button
+                  type="button"
+                  class="button button--pill"
+                  [ngClass]="{
+                    'button--secondary': groupingSignal() === 'label',
+                    'button--ghost': groupingSignal() !== 'label',
+                  }"
+                  [attr.aria-pressed]="groupingSignal() === 'label'"
+                  (click)="selectGrouping('label')"
+                >
+                  ラベル別
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="flex min-w-0 flex-col gap-4 text-xs text-slate-500 dark:text-slate-400">
-          <div class="flex flex-wrap items-center justify-between gap-2">
-            <span class="text-xs font-semibold uppercase tracking-[0.2em]">クイックフィルター</span>
-            <button
-              type="button"
-              class="surface-pill focus-ring px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-              (click)="clearFilters()"
-            >
-              フィルターをクリア
-            </button>
-          </div>
-          <div
-            class="rounded-2xl border border-dashed border-subtle bg-surface-strong px-4 py-3 dark:bg-slate-900/40"
-          >
-            <div class="flex flex-wrap items-center gap-2">
+          <div class="board-filters__column">
+            <div class="board-filters__quick-header">
+              <span class="board-filters__quick-label">クイックフィルター</span>
+              <button
+                type="button"
+                class="button button--ghost button--pill"
+                (click)="clearFilters()"
+              >
+                フィルターをクリア
+              </button>
+            </div>
+            <div class="board-filters__quick-list">
               @for (filter of quickFilters; track filter.id) {
                 <button
                   type="button"
-                  class="surface-pill focus-ring px-3 py-1 text-xs font-semibold text-slate-500 dark:text-slate-300"
-                  [class.surface-primary-muted]="isQuickFilterActive(filter.id)"
+                  class="button button--pill"
+                  [ngClass]="{
+                    'button--secondary': isQuickFilterActive(filter.id),
+                    'button--ghost': !isQuickFilterActive(filter.id),
+                  }"
                   [attr.aria-pressed]="isQuickFilterActive(filter.id)"
                   [title]="filter.description"
                   (click)="toggleQuickFilter(filter.id)"
@@ -150,20 +144,23 @@
           </div>
         </div>
       </section>
-      <p class="rounded-3xl bg-accent-muted px-6 py-4 text-sm text-accent-strong shadow-soft">
+      <p class="page-empty board-page__hint">
         タスクはラベルやステータスで切り替えながら管理でき、サブタスクはステータス別ボードでドラッグ＆ドロップ更新できます。選択したタスクに紐づくサブタスクはハイライト表示されます。
       </p>
     </div>
   </div>
 
   <div class="board-page__subtasks">
-    <section class="space-y-4">
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <h3 class="text-lg font-semibold text-on-surface">タスク一覧</h3>
-        <span class="text-xs text-slate-500"
-          >完了またはNonIssueのサブタスクのみのタスクは簡易表示になります。</span
-        >
-      </div>
+    <section class="board-page__task-board">
+      <header class="board-page__task-header">
+        <div>
+          <p class="board-page__task-eyebrow">Task Library</p>
+          <h3 class="board-page__task-title">タスク一覧</h3>
+        </div>
+        <p class="board-page__task-description">
+          完了またはNonIssueのサブタスクのみのタスクは簡易表示になります。
+        </p>
+      </header>
       <div class="board-columns" cdkDropListGroup>
         @for (column of columnsSignal(); track column.id) {
           <section
@@ -173,16 +170,14 @@
             [cdkDropListDisabled]="groupingSignal() !== 'status'"
             (cdkDropListDropped)="handleDrop(column.id, $event)"
           >
-            <header class="flex items-center justify-between">
+            <header class="board-column__header">
               <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-slate-400">{{ column.id }}</p>
-                <h3 class="text-lg font-semibold" [style.color]="columnAccent(column)">
+                <p class="board-column__eyebrow">{{ column.id }}</p>
+                <h3 class="board-column__title" [style.color]="columnAccent(column)">
                   {{ column.title }}
                 </h3>
               </div>
-              <span class="surface-pill px-3 py-1 text-xs font-semibold text-slate-500"
-                >{{ column.count }} 件</span
-              >
+              <span class="page-badge">{{ column.count }} 件</span>
             </header>
             <div class="board-card-list">
               @if (column.cards.length === 0) {
@@ -261,7 +256,7 @@
                           @for (status of statusesSignal(); track status.id) {
                             <button
                               type="button"
-                              class="surface-pill focus-ring px-3 py-1"
+                              class="button button--ghost button--pill"
                               (click)="moveCard(card.id, status.id)"
                             >
                               {{ status.name }}
@@ -279,18 +274,15 @@
       </div>
     </section>
 
-    <section class="space-y-4">
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <section class="board-page__subtask-board">
+      <header class="board-page__task-header board-page__task-header--subtasks">
         <div>
-          <h3 class="text-lg font-semibold text-on-surface">サブタスク一覧</h3>
-          <p class="text-xs text-slate-500">ステータスごとに並び替え、個別に管理します。</p>
+          <p class="board-page__task-eyebrow">Subtasks</p>
+          <h3 class="board-page__task-title">サブタスク一覧</h3>
+          <p class="board-page__task-description">ステータスごとに並び替え、個別に管理します。</p>
         </div>
-        <div
-          class="rounded-3xl border border-subtle bg-surface px-4 py-2 text-xs text-slate-500 shadow-soft"
-        >
-          ドラッグ＆ドロップでステータスを更新できます。
-        </div>
-      </div>
+        <p class="board-page__task-hint">ドラッグ＆ドロップでステータスを更新できます。</p>
+      </header>
       <div class="board-columns subtask-columns" cdkDropListGroup>
         @for (column of subtaskColumnsSignal(); track column.id) {
           <section
@@ -299,16 +291,14 @@
             [cdkDropListData]="column.subtasks"
             (cdkDropListDropped)="handleSubtaskDrop(column.id, $event)"
           >
-            <header class="flex items-center justify-between">
+            <header class="board-column__header">
               <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-slate-400">{{ column.id }}</p>
-                <h3 class="text-lg font-semibold" [style.color]="column.accent">
+                <p class="board-column__eyebrow">{{ column.id }}</p>
+                <h3 class="board-column__title" [style.color]="column.accent">
                   {{ column.title }}
                 </h3>
               </div>
-              <span class="surface-pill px-3 py-1 text-xs font-semibold text-slate-500">
-                {{ column.subtasks.length }} 件
-              </span>
+              <span class="page-badge">{{ column.subtasks.length }} 件</span>
             </header>
             <div class="board-card-list">
               @if (column.subtasks.length === 0) {

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
 import { RouterLink } from '@angular/router';
 
+import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
+
 import { WorkspaceStore } from '@core/state/workspace-store';
 import {
   BoardColumnView,
@@ -121,7 +123,7 @@ const RESOLVED_SUBTASK_STATUSES = new Set<SubtaskStatus>(['done', 'non-issue']);
 @Component({
   selector: 'app-board-page',
   standalone: true,
-  imports: [CommonModule, DragDropModule, RouterLink],
+  imports: [CommonModule, DragDropModule, RouterLink, PageHeaderComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/shared/ui/page-header/page-header.html
+++ b/frontend/src/app/shared/ui/page-header/page-header.html
@@ -1,26 +1,28 @@
 <header class="page-header">
   <div class="page-header__content">
     @if (eyebrow) {
-      <p class="text-xs uppercase tracking-[0.3em] text-slate-400">{{ eyebrow }}</p>
+      <p class="page-header__eyebrow">{{ eyebrow }}</p>
     }
 
     @switch (headingLevel) {
       @case ('h1') {
-        <h1 class="text-3xl font-semibold text-on-surface">{{ title }}</h1>
+        <h1 class="page-header__title">{{ title }}</h1>
       }
       @case ('h3') {
-        <h3 class="text-xl font-semibold text-on-surface">{{ title }}</h3>
+        <h3 class="page-header__title">{{ title }}</h3>
       }
       @default {
-        <h2 class="text-2xl font-semibold text-on-surface">{{ title }}</h2>
+        <h2 class="page-header__title">{{ title }}</h2>
       }
     }
 
     @if (description) {
-      <p class="text-sm text-slate-500 dark:text-slate-400">{{ description }}</p>
+      <p class="page-header__description">{{ description }}</p>
     }
 
-    <ng-content></ng-content>
+    <div class="page-header__meta">
+      <ng-content></ng-content>
+    </div>
   </div>
 
   <div class="page-header__actions">

--- a/frontend/src/app/shared/ui/page-header/page-header.scss
+++ b/frontend/src/app/shared/ui/page-header/page-header.scss
@@ -3,22 +3,68 @@
 }
 
 .page-header {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+  display: grid;
+  gap: clamp(1.25rem, 2vw, 1.75rem);
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 64rem) {
   .page-header {
-    flex-direction: row;
-    align-items: flex-end;
-    justify-content: space-between;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
   }
 }
 
 .page-header__content {
   display: grid;
-  gap: 0.5rem;
+  gap: clamp(0.6rem, 1vw, 0.85rem);
+  max-width: 54rem;
+}
+
+.page-header__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.page-header__title {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+  line-height: 1.1;
+}
+
+h1.page-header__title {
+  font-size: clamp(2.4rem, 2rem + 1vw, 3rem);
+}
+
+h2.page-header__title {
+  font-size: clamp(2rem, 1.6rem + 0.9vw, 2.6rem);
+}
+
+h3.page-header__title {
+  font-size: clamp(1.6rem, 1.3rem + 0.6vw, 2rem);
+}
+
+.page-header__description {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: var(--text-muted);
+}
+
+.page-header__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.page-header__meta:empty {
+  display: none;
 }
 
 .page-header__actions {
@@ -28,7 +74,7 @@
   justify-content: flex-start;
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 64rem) {
   .page-header__actions {
     justify-content: flex-end;
   }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -2,6 +2,7 @@
 @use './styles/pages/base';
 @use './styles/pages/board';
 @use './styles/pages/analytics';
+@use './styles/pages/analyze';
 @use './styles/pages/daily-reports';
 @use './styles/pages/auth';
 @use './styles/pages/admin';

--- a/frontend/src/styles/pages/_analytics.scss
+++ b/frontend/src/styles/pages/_analytics.scss
@@ -4,6 +4,110 @@
   gap: var(--page-content-gap);
 }
 
+.analytics-page__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 48rem) {
+  .analytics-page__intro {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.analytics-page__intro-content {
+  max-width: 48rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.analytics-page__intro-content p {
+  margin: 0;
+}
+
+.analytics-page__intro-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+@media (min-width: 48rem) {
+  .analytics-page__intro-actions {
+    justify-content: flex-end;
+  }
+}
+
+.analytics-page__intro-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.analytics-summary__metrics {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(0, min(18rem, 100%)));
+}
+
+.analytics-summary__metric {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.analytics-summary__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.analytics-summary__value {
+  margin: 0;
+  font-size: clamp(1.8rem, 1.4rem + 0.8vw, 2.2rem);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.analytics-summary__note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.analytics-breakdown__list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.analytics-breakdown__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+}
+
+.analytics-breakdown__swatch {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--on-surface-inverse) 10%, transparent);
+}
+
+.analytics-breakdown__label {
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.analytics-breakdown__value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
 .analytics-page .snapshot-chip {
   display: flex;
   flex-direction: column;

--- a/frontend/src/styles/pages/_analyze.scss
+++ b/frontend/src/styles/pages/_analyze.scss
@@ -1,0 +1,269 @@
+.analyze-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--page-content-gap);
+}
+
+.analyze-page__composer {
+  align-items: stretch;
+}
+
+.analyze-page__notes-input {
+  min-height: clamp(16rem, 24vw, 20rem);
+}
+
+.analyze-page__objective {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.85rem, 1.4vw, 1.35rem);
+  padding: clamp(1.1rem, 1.6vw, 1.5rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 82%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--on-surface-inverse) 8%, transparent);
+}
+
+.analyze-page__objective-eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.analyze-page__objective-hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.analyze-page__options {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.analyze-page__option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 80%, transparent);
+  color: var(--text-secondary);
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    background-color 150ms ease,
+    color 150ms ease;
+}
+
+.analyze-page__option:hover {
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.analyze-page__option--active {
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  background: color-mix(in srgb, var(--accent) 16%, var(--surface-card));
+  color: var(--accent-strong);
+  box-shadow: 0 12px 28px -22px var(--accent-shadow-color);
+}
+
+.analyze-page__option-input {
+  margin-top: 0.2rem;
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.analyze-page__option-body {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.analyze-page__option-title {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.analyze-page__option-description {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.analyze-page__objective-preview {
+  display: grid;
+  gap: 0.75rem;
+  padding: clamp(1rem, 1.4vw, 1.4rem);
+}
+
+.analyze-page__preview-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.analyze-page__preview-body {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.analyze-page__preview-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.analyze-page__objective-manual textarea {
+  min-height: clamp(12rem, 18vw, 16rem);
+}
+
+.analyze-page__form-actions {
+  justify-content: flex-start;
+  gap: 0.75rem;
+}
+
+.analyze-page__results-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+@media (min-width: 48rem) {
+  .analyze-page__results-header {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+}
+
+.analyze-page__results-eyebrow {
+  margin: 0 0 0.3rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.analyze-page__state {
+  margin-top: 1.1rem;
+}
+
+.analyze-page__proposal-list {
+  margin-top: 1.1rem;
+}
+
+.analyze-page__proposal {
+  gap: clamp(0.9rem, 1.4vw, 1.4rem);
+}
+
+.analyze-page__proposal-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 40rem) {
+  .analyze-page__proposal-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.analyze-page__proposal-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.analyze-page__proposal-summary {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+
+.analyze-page__proposal-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.analyze-page__proposal-subtasks {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.analyze-page__proposal-subtasks-title {
+  margin: 0;
+  font-size: 0.82rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.analyze-page__proposal-subtasks-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.analyze-page__proposal-subtasks-list li {
+  position: relative;
+  padding-left: 1.25rem;
+}
+
+.analyze-page__proposal-subtasks-list li::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  margin: auto 0;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: var(--accent);
+}
+
+.analyze-page__proposal-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 48rem) {
+  .analyze-page__proposal-actions {
+    justify-content: flex-start;
+  }
+}
+
+.dark .analyze-page__objective {
+  background: color-mix(in srgb, var(--surface-card) 70%, transparent);
+}
+
+.dark .analyze-page__option {
+  background: color-mix(in srgb, var(--surface-card) 68%, transparent);
+}
+
+.dark .analyze-page__option--active {
+  background: color-mix(in srgb, var(--accent) 20%, var(--surface-card));
+}
+
+.dark .analyze-page__objective-preview {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-card) 88%, transparent),
+    color-mix(in srgb, var(--surface-card) 76%, transparent)
+  );
+}

--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -16,6 +16,241 @@
   align-items: start;
 }
 
+.board-page__header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.board-summary {
+  gap: clamp(1rem, 1.6vw, 1.4rem);
+}
+
+.board-summary__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.board-summary__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.board-summary__progress {
+  margin: 0;
+  font-size: clamp(1.8rem, 1.4rem + 0.8vw, 2.2rem);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.board-summary__metrics {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.board-summary__metrics li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.board-summary__metrics strong {
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.board-summary__progress-bar {
+  position: relative;
+  width: 100%;
+  height: 0.65rem;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--text-tertiary) 14%, transparent);
+  overflow: hidden;
+}
+
+.board-summary__progress-value {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  transition: width 200ms ease;
+}
+
+.board-summary__link {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.board-summary__link-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.board-filters__grid {
+  gap: clamp(1.1rem, 1.8vw, 1.6rem);
+}
+
+.board-filters__column {
+  display: grid;
+  gap: clamp(1rem, 1.6vw, 1.4rem);
+}
+
+.board-filters__field {
+  gap: 0.75rem;
+}
+
+.board-filters__search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.board-filters__search-icon {
+  position: absolute;
+  left: 1.1rem;
+  width: 1rem;
+  height: 1rem;
+  color: var(--text-muted);
+}
+
+.board-filters__search-input {
+  padding-left: 2.6rem;
+}
+
+.board-filters__grouping {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.board-filters__grouping-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.board-filters__grouping-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.board-filters__quick-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.board-filters__quick-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.board-filters__quick-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.board-page__hint {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.board-page__task-board,
+.board-page__subtask-board {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 1.6vw, 1.5rem);
+}
+
+.board-page__task-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 48rem) {
+  .board-page__task-header {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+}
+
+.board-page__task-eyebrow {
+  margin: 0 0 0.25rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.board-page__task-title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.board-page__task-description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.board-page__task-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--surface-card) 75%, transparent);
+  border-radius: 9999px;
+  padding: 0.5rem 1.25rem;
+  border: 1px solid var(--border-subtle);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--on-surface-inverse) 8%, transparent);
+}
+
+.board-column__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.board-column__eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.board-column__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
 @media (min-width: 64rem) {
   .board-page__overview {
     grid-template-columns: minmax(0, 280px) minmax(0, 1fr);
@@ -58,12 +293,6 @@
   transition:
     border-color 150ms ease,
     box-shadow 150ms ease;
-}
-
-.board-column header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 }
 
 .dark .board-page .board-column {


### PR DESCRIPTION
## Summary
- redesign the analyze workflow with form-grid structure, shared buttons, and accessible status states
- modernize the board page header, filters, and card overview using page-section patterns and reusable badges
- unify analytics hero and summary blocks with shared page sections and introduce styling tokens for analyze/board/analytics

## Testing
- npm run format:check *(fails: repository contains pre-existing prettier violations in unrelated files)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3eea859a0832084c06bb8805f79e4