### PR TITLE
Rebrand project to Verbalize Yourself

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Todo Generator
+# Verbalize Yourself
 
-Todo Generator is a full-stack productivity workspace that pairs an Angular 20 single-page
+Verbalize Yourself is a full-stack productivity workspace that pairs an Angular 20 single-page
 application with a FastAPI backend and ChatGPT-powered automation to turn free-form notes into
 structured work, analytics artefacts, and coaching workflows.【F:frontend/src/app/app.routes.ts†L9-L66】【F:backend/app/main.py†L1-L69】【F:backend/app/services/chatgpt.py†L43-L190】【F:backend/app/models.py†L120-L439】
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,4 @@
-# Todo Generator Backend
+# Verbalize Yourself Backend
 
 This FastAPI application implements the backend described in the project requirements. It exposes REST endpoints for analysis, card management, subtasks, labels, statuses, board layouts, comments, and the activity log.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,16 +14,16 @@ from .routers import (
     analytics,
     auth,
     cards,
-    daily_reports,
     comments,
     competencies,
     competency_evaluations,
+    daily_reports,
     error_categories,
     filters,
     initiatives,
     labels,
-    profile,
     preferences,
+    profile,
     reports,
     statuses,
     suggested_actions,
@@ -33,7 +33,7 @@ run_startup_migrations(engine)
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(
-    title="Todo Generator Backend",
+    title="Verbalize Yourself Backend",
     description="API for transforming unstructured input into actionable task boards.",
     version="0.1.0",
 )

--- a/backend/app/services/chatgpt.py
+++ b/backend/app/services/chatgpt.py
@@ -98,7 +98,7 @@ class ChatGPTClient:
     }
 
     _SYSTEM_PROMPT: ClassVar[str] = (
-        "You are Todo Generator's analysis assistant."
+        "You are Verbalize Yourself's analysis assistant."
         " Extract actionable work items from free-form product notes and respond"
         " using the requested JSON schema. Each proposal must contain a concise"
         " title, a summary that elaborates on the goal, optional labels,"

--- a/backend/app/utils/secrets.py
+++ b/backend/app/utils/secrets.py
@@ -12,7 +12,7 @@ _VISIBLE_SEGMENT_LENGTH = 4
 def get_secret_cipher() -> SecretCipher:
     """Return a cipher configured for encrypting stored secrets."""
 
-    key = settings.secret_encryption_key or "todo-generator"
+    key = settings.secret_encryption_key or "verbalize-yourself"
     return SecretCipher(key)
 
 

--- a/docs/appeal-generation-requirements.md
+++ b/docs/appeal-generation-requirements.md
@@ -9,7 +9,7 @@
 | Status | For internal review |
 
 ## 1. Background & Objectives
-Continuous improvement programs within Todo Generator rely on card histories to demonstrate progress and communicate lessons learned. Stakeholders often request concise narratives that explain what challenges were faced, the actions taken, and how those actions delivered results. Currently, teams manually craft these narratives using disparate documents, leading to inconsistent messaging and slow reporting cycles. The Appeal Narrative Generation capability will automate narrative creation from existing card achievements while giving users granular control over structure and tone.
+Continuous improvement programs within Verbalize Yourself rely on card histories to demonstrate progress and communicate lessons learned. Stakeholders often request concise narratives that explain what challenges were faced, the actions taken, and how those actions delivered results. Currently, teams manually craft these narratives using disparate documents, leading to inconsistent messaging and slow reporting cycles. The Appeal Narrative Generation capability will automate narrative creation from existing card achievements while giving users granular control over structure and tone.
 
 Objectives:
 1. Enable users to produce coherent, causal narratives based on existing card accomplishments without rewriting raw data.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture Overview
 
 ## System Context
-Todo Generator combines an Angular single-page application with a FastAPI backend that exposes
+Verbalize Yourself combines an Angular single-page application with a FastAPI backend that exposes
 modular routers for cards, analytics, initiatives, competencies, reporting, and administration while
 sharing a common SQLAlchemy model layer.【F:frontend/package.json†L1-L60】【F:frontend/src/app/app.routes.ts†L9-L66】【F:backend/app/main.py†L1-L69】【F:backend/app/models.py†L120-L439】
 AI assistance is woven into the platform through a dedicated ChatGPT client that structures proposals

--- a/docs/feature-expansion-requirements.md
+++ b/docs/feature-expansion-requirements.md
@@ -1,4 +1,4 @@
-# Todo Generator Feature Expansion Requirements
+# Verbalize Yourself Feature Expansion Requirements
 
 ## Document Control
 | Field | Value |
@@ -9,7 +9,7 @@
 | Status | For stakeholder review |
 
 ## 1. Background & Objectives
-The Todo Generator currently converts free-form input into structured tasks and persists them on a collaborative board. Foundational capabilities such as basic filtering, card management, and webhook-based integrations are already in place. However, teams relying on the product for continuous improvement workflows need deeper insight into recurring mistakes, faster knowledge discovery, and actionable follow-through. The feature expansion outlined in this document pursues three top-level objectives:
+Verbalize Yourself currently converts free-form input into structured tasks and persists them on a collaborative board. Foundational capabilities such as basic filtering, card management, and webhook-based integrations are already in place. However, teams relying on the product for continuous improvement workflows need deeper insight into recurring mistakes, faster knowledge discovery, and actionable follow-through. The feature expansion outlined in this document pursues three top-level objectives:
 
 1. **Insight Acceleration:** surface meaningful patterns about mistakes, their drivers, and high-impact improvement opportunities without requiring manual spreadsheet work.
 2. **Execution Guidance:** guide teams from analytics into concrete actions via AI-assisted recommendations, streamlined conversion to tickets, and initiative tracking.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
-# Todo Generator Frontend
+# Verbalize Yourself Frontend
 
-Angular 20 single-page application that follows the product specification in the repository root README. It provides the ChatGPT-assisted capture flow, kanban board, analytics, and workspace configuration screens required for the Todo Generator experience.
+Angular 20 single-page application that follows the product specification in the repository root README. It provides the ChatGPT-assisted capture flow, kanban board, analytics, and workspace configuration screens required for the Verbalize Yourself experience.
 
 ## Key Features
 

--- a/frontend/src/app/core/layout/shell/help-dialog.html
+++ b/frontend/src/app/core/layout/shell/help-dialog.html
@@ -14,7 +14,7 @@
     <header class="help-dialog__header">
       <div>
         <p class="help-dialog__eyebrow">ガイドとサポート</p>
-        <h2 class="help-dialog__title" id="help-dialog-title">Todo Generator ヘルプセンター</h2>
+        <h2 class="help-dialog__title" id="help-dialog-title">Verbalize Yourself ヘルプセンター</h2>
         <p class="help-dialog__description" id="help-dialog-description">
           代表的なユースケース、主要な画面の使い方、よくある質問への回答をまとめています。
         </p>

--- a/frontend/src/app/core/layout/shell/shell.html
+++ b/frontend/src/app/core/layout/shell/shell.html
@@ -19,9 +19,9 @@
       <div class="shell-header__surface">
         <div class="shell-header__grid">
           <div class="shell-brand">
-            <span class="shell-brand__mark">TG</span>
+            <span class="shell-brand__mark">VY</span>
             <div class="shell-brand__info">
-              <p class="shell-brand__name">Todo Generator</p>
+              <p class="shell-brand__name">Verbalize Yourself</p>
               <p class="shell-brand__tagline">AI ドリブンのタスクプランニングスイート</p>
             </div>
           </div>
@@ -50,7 +50,7 @@
                 aria-haspopup="dialog"
                 [attr.aria-expanded]="isHelpDialogOpen()"
                 [attr.aria-controls]="isHelpDialogOpen() ? 'help-dialog' : null"
-                aria-label="Todo Generator の使い方を開く"
+                aria-label="Verbalize Yourself の使い方を開く"
               >
                 <svg
                   aria-hidden="true"
@@ -206,7 +206,7 @@
     <div
       class="shell-container flex flex-col gap-2 py-5 text-xs text-slate-500 dark:text-slate-400 sm:flex-row sm:items-center sm:justify-between"
     >
-      <p>© {{ year }} Todo Generator</p>
+      <p>© {{ year }} Verbalize Yourself</p>
       <p>Angular 20 Signal Architecture / ChatGPT モック統合</p>
     </div>
   </footer>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,7 @@
 <html lang="ja" class="h-full bg-surface text-on-surface">
   <head>
     <meta charset="utf-8" />
-    <title>Todo Generator</title>
+    <title>Verbalize Yourself</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />

--- a/start-localhost.bat
+++ b/start-localhost.bat
@@ -25,15 +25,15 @@ if not exist "%FRONTEND_DIR%\node_modules" (
 )
 
 echo.
-echo Launching Todo Generator services...
+echo Launching Verbalize Yourself services...
 echo Close the spawned windows to stop the servers.
 echo.
 
 echo Starting backend on http://localhost:8000/ ...
-start "Todo Generator Backend" cmd /k "cd /d ""%BACKEND_DIR%"" && ""%VENV_PYTHON%"" -m uvicorn app.main:app --reload"
+start "Verbalize Yourself Backend" cmd /k "cd /d ""%BACKEND_DIR%"" && ""%VENV_PYTHON%"" -m uvicorn app.main:app --reload"
 
 echo Starting frontend on http://localhost:4200/ ...
-start "Todo Generator Frontend" cmd /k "cd /d ""%FRONTEND_DIR%"" && npm start"
+start "Verbalize Yourself Frontend" cmd /k "cd /d ""%FRONTEND_DIR%"" && npm start"
 
 echo.
 echo Backend docs:   http://localhost:8000/docs


### PR DESCRIPTION
## Summary
- rename documentation, backend metadata, and startup script text to use the Verbalize Yourself brand
- refresh frontend UI copy, HTML title, and help dialog branding while updating theme storage with legacy migration support
- migrate authentication and workspace localStorage keys to the new namespace and update the ChatGPT prompt plus default secret slug

## Testing
- black --check backend/app/main.py backend/app/services/chatgpt.py backend/app/utils/secrets.py
- ruff check backend/app/main.py backend/app/services/chatgpt.py backend/app/utils/secrets.py
- pytest backend/tests
- npx prettier --check "src/app/core/layout/shell/shell.ts" "src/app/core/auth/auth.service.ts" "src/app/core/state/workspace-store.ts"
- npm test -- --watch=false *(fails: Chrome binary unavailable in container)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4dc0b5a808320a0dea2e3c8925e41