### PR TITLE
Add appeal generation API with fallback content

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from .routers import (
     admin_users,
     analysis,
     analytics,
+    appeals,
     auth,
     cards,
     comments,
@@ -48,6 +49,7 @@ app.add_middleware(
 
 app.include_router(analysis.router)
 app.include_router(analytics.router)
+app.include_router(appeals.router)
 app.include_router(auth.router)
 app.include_router(cards.router)
 app.include_router(daily_reports.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
-from typing import Optional
+from typing import Any, Optional
 from uuid import uuid4
 
 from sqlalchemy import (
@@ -65,12 +65,8 @@ class User(Base, TimestampMixin):
     daily_evaluation_quotas: Mapped[list["DailyEvaluationQuota"]] = relationship(
         "DailyEvaluationQuota", back_populates="owner", cascade="all, delete-orphan"
     )
-    labels: Mapped[list["Label"]] = relationship(
-        "Label", back_populates="owner", cascade="all, delete-orphan"
-    )
-    statuses: Mapped[list["Status"]] = relationship(
-        "Status", back_populates="owner", cascade="all, delete-orphan"
-    )
+    labels: Mapped[list["Label"]] = relationship("Label", back_populates="owner", cascade="all, delete-orphan")
+    statuses: Mapped[list["Status"]] = relationship("Status", back_populates="owner", cascade="all, delete-orphan")
     error_categories: Mapped[list["ErrorCategory"]] = relationship(
         "ErrorCategory", back_populates="owner", cascade="all, delete-orphan"
     )
@@ -86,6 +82,9 @@ class User(Base, TimestampMixin):
     daily_evaluation_quotas: Mapped[list["DailyEvaluationQuota"]] = relationship(
         "DailyEvaluationQuota", back_populates="owner", cascade="all, delete-orphan"
     )
+    appeal_generations: Mapped[list["AppealGeneration"]] = relationship(
+        "AppealGeneration", back_populates="owner", cascade="all, delete-orphan"
+    )
     quota_override: Mapped[Optional["UserQuotaOverride"]] = relationship(
         "UserQuotaOverride", back_populates="user", cascade="all, delete-orphan", uselist=False
     )
@@ -98,9 +97,7 @@ class User(Base, TimestampMixin):
     quota_override: Mapped[Optional["UserQuotaOverride"]] = relationship(
         "UserQuotaOverride", back_populates="user", cascade="all, delete-orphan", uselist=False
     )
-    api_credentials: Mapped[list["ApiCredential"]] = relationship(
-        "ApiCredential", back_populates="created_by_user"
-    )
+    api_credentials: Mapped[list["ApiCredential"]] = relationship("ApiCredential", back_populates="created_by_user")
 
 
 class SessionToken(Base, TimestampMixin):
@@ -171,17 +168,13 @@ class DailyCardQuota(Base):
     __tablename__ = "daily_card_quotas"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    owner_id: Mapped[str] = mapped_column(
-        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
+    owner_id: Mapped[str] = mapped_column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     quota_date: Mapped[date] = mapped_column(Date, nullable=False)
     created_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     owner: Mapped[User] = relationship("User", back_populates="daily_card_quotas")
 
-    __table_args__ = (
-        UniqueConstraint("owner_id", "quota_date", name="uq_daily_card_quota_owner_date"),
-    )
+    __table_args__ = (UniqueConstraint("owner_id", "quota_date", name="uq_daily_card_quota_owner_date"),)
 
 
 class Subtask(Base, TimestampMixin):
@@ -218,9 +211,7 @@ class Label(Base):
     color: Mapped[str | None] = mapped_column(String)
     description: Mapped[str | None] = mapped_column(Text)
     is_system: Mapped[bool] = mapped_column(Boolean, default=False)
-    owner_id: Mapped[str] = mapped_column(
-        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
+    owner_id: Mapped[str] = mapped_column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
 
     cards: Mapped[list[Card]] = relationship("Card", secondary=card_labels, back_populates="labels")
     owner: Mapped[User] = relationship("User", back_populates="labels")
@@ -236,9 +227,7 @@ class Status(Base):
     order: Mapped[int | None] = mapped_column(Integer)
     color: Mapped[str | None] = mapped_column(String)
     wip_limit: Mapped[int | None] = mapped_column(Integer)
-    owner_id: Mapped[str] = mapped_column(
-        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
+    owner_id: Mapped[str] = mapped_column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
 
     cards: Mapped[list[Card]] = relationship("Card", back_populates="status")
     owner: Mapped[User] = relationship("User", back_populates="statuses")
@@ -290,9 +279,7 @@ class ErrorCategory(Base, TimestampMixin):
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
     severity_level: Mapped[str | None] = mapped_column(String)
-    owner_id: Mapped[str] = mapped_column(
-        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
+    owner_id: Mapped[str] = mapped_column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
 
     cards: Mapped[list[Card]] = relationship("Card", back_populates="error_category")
     owner: Mapped[User] = relationship("User", back_populates="error_categories")
@@ -309,9 +296,7 @@ class ImprovementInitiative(Base, TimestampMixin):
     target_metrics: Mapped[dict] = mapped_column(JSON, default=dict)
     status: Mapped[str | None] = mapped_column(String)
     health: Mapped[str | None] = mapped_column(String)
-    owner_id: Mapped[str] = mapped_column(
-        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
+    owner_id: Mapped[str] = mapped_column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
 
     cards: Mapped[list[Card]] = relationship("Card", back_populates="initiative")
     progress_logs: Mapped[list["InitiativeProgressLog"]] = relationship(
@@ -468,12 +453,8 @@ class DailyReportCardLink(Base, TimestampMixin):
     __tablename__ = "daily_report_cards"
 
     id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
-    report_id: Mapped[str] = mapped_column(
-        String, ForeignKey("daily_reports.id", ondelete="CASCADE"), nullable=False
-    )
-    card_id: Mapped[str] = mapped_column(
-        String, ForeignKey("cards.id", ondelete="CASCADE"), nullable=False
-    )
+    report_id: Mapped[str] = mapped_column(String, ForeignKey("daily_reports.id", ondelete="CASCADE"), nullable=False)
+    card_id: Mapped[str] = mapped_column(String, ForeignKey("cards.id", ondelete="CASCADE"), nullable=False)
     link_role: Mapped[str] = mapped_column(String, default="primary")
     confidence: Mapped[float | None] = mapped_column(Float)
 
@@ -485,9 +466,7 @@ class DailyReportEvent(Base, TimestampMixin):
     __tablename__ = "daily_report_events"
 
     id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
-    report_id: Mapped[str] = mapped_column(
-        String, ForeignKey("daily_reports.id", ondelete="CASCADE"), nullable=False
-    )
+    report_id: Mapped[str] = mapped_column(String, ForeignKey("daily_reports.id", ondelete="CASCADE"), nullable=False)
     event_type: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[dict] = mapped_column(JSON, default=dict)
 
@@ -543,9 +522,7 @@ class SavedFilter(Base, TimestampMixin):
     id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     name: Mapped[str] = mapped_column(String, nullable=False)
     definition: Mapped[dict] = mapped_column(JSON, default=dict)
-    created_by: Mapped[str] = mapped_column(
-        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
+    created_by: Mapped[str] = mapped_column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     shared: Mapped[bool] = mapped_column(Boolean, default=False)
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
@@ -686,12 +663,8 @@ class CompetencyEvaluationJob(Base, TimestampMixin):
     summary_stats: Mapped[dict] = mapped_column(JSON, default=dict)
 
     competency: Mapped[Optional[Competency]] = relationship("Competency", back_populates="jobs")
-    triggered_by_user: Mapped[Optional[User]] = relationship(
-        "User", foreign_keys=[triggered_by_id]
-    )
-    target_user: Mapped[Optional[User]] = relationship(
-        "User", foreign_keys=[user_id]
-    )
+    triggered_by_user: Mapped[Optional[User]] = relationship("User", foreign_keys=[triggered_by_id])
+    target_user: Mapped[Optional[User]] = relationship("User", foreign_keys=[user_id])
     evaluations: Mapped[list[CompetencyEvaluation]] = relationship(
         "CompetencyEvaluation", back_populates="job", cascade="all, delete-orphan"
     )
@@ -701,17 +674,13 @@ class DailyEvaluationQuota(Base):
     __tablename__ = "daily_evaluation_quotas"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    owner_id: Mapped[str] = mapped_column(
-        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
-    )
+    owner_id: Mapped[str] = mapped_column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     quota_date: Mapped[date] = mapped_column(Date, nullable=False)
     executed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     owner: Mapped[User] = relationship("User", back_populates="daily_evaluation_quotas")
 
-    __table_args__ = (
-        UniqueConstraint("owner_id", "quota_date", name="uq_daily_evaluation_quota_owner_date"),
-    )
+    __table_args__ = (UniqueConstraint("owner_id", "quota_date", name="uq_daily_evaluation_quota_owner_date"),)
 
 
 class QuotaDefaults(Base, TimestampMixin):
@@ -734,6 +703,23 @@ class UserQuotaOverride(Base, TimestampMixin):
     updated_by: Mapped[str | None] = mapped_column(String)
 
     user: Mapped[User] = relationship("User", back_populates="quota_override")
+
+
+class AppealGeneration(Base, TimestampMixin):
+    __tablename__ = "appeal_generations"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    owner_id: Mapped[str] = mapped_column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    subject_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    subject_value: Mapped[str] = mapped_column(String(255), nullable=False)
+    flow: Mapped[list[str]] = mapped_column(JSON, default=list)
+    formats: Mapped[list[str]] = mapped_column(JSON, default=list)
+    content_json: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    token_usage: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    warnings: Mapped[list[str]] = mapped_column(JSON, default=list)
+    generation_status: Mapped[str] = mapped_column(String(32), default="success", nullable=False)
+
+    owner: Mapped[User] = relationship("User", back_populates="appeal_generations")
 
 
 class ApiCredential(Base, TimestampMixin):

--- a/backend/app/routers/appeals.py
+++ b/backend/app/routers/appeals.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from .. import models, schemas
+from ..auth import get_current_user
+from ..services.appeals import AppealGenerationService, get_appeal_service
+
+router = APIRouter(prefix="/appeals", tags=["appeals"])
+
+
+@router.get("/config", response_model=schemas.AppealConfigResponse)
+def get_appeal_config(
+    current_user: models.User = Depends(get_current_user),
+    service: AppealGenerationService = Depends(get_appeal_service),
+) -> schemas.AppealConfigResponse:
+    """Return available subjects, flows and formats for appeal generation."""
+
+    return service.load_configuration(owner=current_user)
+
+
+@router.post("/generate", response_model=schemas.AppealGenerationResponse)
+def generate_appeal(
+    payload: schemas.AppealGenerationRequest,
+    current_user: models.User = Depends(get_current_user),
+    service: AppealGenerationService = Depends(get_appeal_service),
+) -> schemas.AppealGenerationResponse:
+    """Generate appeal narratives for the requested formats."""
+
+    return service.generate(owner=current_user, request=payload)

--- a/backend/app/services/appeals.py
+++ b/backend/app/services/appeals.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import html
+import logging
+from collections import defaultdict
+from typing import ClassVar, Iterable
+
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..database import get_db
+
+logger = logging.getLogger(__name__)
+
+
+class AppealGenerationService:
+    """Provides helper methods for configuring and generating appeal narratives."""
+
+    _RECOMMENDED_FLOW: ClassVar[list[str]] = ["課題", "対策", "実績", "所感"]
+    _AVAILABLE_FORMATS: ClassVar[list[schemas.AppealFormatDefinition]] = [
+        schemas.AppealFormatDefinition(
+            id="markdown",
+            name="Markdown",
+            description="見出しと箇条書きで構成された Markdown ドキュメント",
+            editor_mode="markdown",
+        ),
+        schemas.AppealFormatDefinition(
+            id="bullet_list",
+            name="Bullet List",
+            description="主要なアピールポイントを箇条書きで整理",
+            editor_mode="markdown",
+        ),
+        schemas.AppealFormatDefinition(
+            id="table",
+            name="CSV Table",
+            description="ステップと要約を 2 列で表現した CSV 形式",
+            editor_mode="csv",
+        ),
+    ]
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def load_configuration(self, *, owner: models.User) -> schemas.AppealConfigResponse:
+        labels = self._load_labels_with_achievements(owner_id=owner.id)
+        return schemas.AppealConfigResponse(
+            labels=labels,
+            recommended_flow=list(self._RECOMMENDED_FLOW),
+            formats=list(self._AVAILABLE_FORMATS),
+        )
+
+    def generate(
+        self,
+        *,
+        owner: models.User,
+        request: schemas.AppealGenerationRequest,
+    ) -> schemas.AppealGenerationResponse:
+        subject_label_id: str | None = None
+        if request.subject.type == "label":
+            subject_label_id = request.subject.value
+            label = (
+                self._db.query(models.Label)
+                .filter(
+                    models.Label.id == request.subject.value,
+                    models.Label.owner_id == owner.id,
+                )
+                .first()
+            )
+            if not label:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Label not found")
+            subject_text = label.name
+        else:
+            subject_text = request.subject.value
+
+        sanitized_subject = self._sanitize_subject(subject_text)
+        achievements = self._resolve_achievements(owner_id=owner.id, label_id=subject_label_id, request=request)
+        warnings = self._derive_flow_warnings(request.flow)
+        generated_formats = {}
+        for format_id in request.formats:
+            content = self._build_fallback_content(format_id, sanitized_subject, request.flow, achievements)
+            generated_formats[format_id] = schemas.AppealGeneratedFormat(content=content, tokens_used=0)
+
+        generation = models.AppealGeneration(
+            owner_id=owner.id,
+            subject_type=request.subject.type,
+            subject_value=sanitized_subject,
+            flow=request.flow,
+            formats=request.formats,
+            content_json={key: value.model_dump() for key, value in generated_formats.items()},
+            token_usage={key: value.tokens_used or 0 for key, value in generated_formats.items()},
+            warnings=warnings,
+            generation_status="fallback",
+        )
+        self._db.add(generation)
+        self._db.commit()
+        self._db.refresh(generation)
+
+        return schemas.AppealGenerationResponse(
+            generation_id=generation.id,
+            subject_echo=sanitized_subject,
+            flow=request.flow,
+            warnings=warnings,
+            formats=generated_formats,
+        )
+
+    def _sanitize_subject(self, value: str) -> str:
+        sanitized = html.escape(value.strip())
+        if len(sanitized) > 120:
+            logger.debug("Truncating subject to 120 characters for appeal generation")
+            return sanitized[:120]
+        return sanitized
+
+    def _resolve_achievements(
+        self,
+        *,
+        owner_id: str,
+        label_id: str | None,
+        request: schemas.AppealGenerationRequest,
+    ) -> list[schemas.AppealAchievement]:
+        achievements: list[schemas.AppealAchievement] = []
+        if label_id:
+            label_achievements = self._load_label_achievements(owner_id=owner_id, label_ids=[label_id])
+            achievements.extend(label_achievements.get(label_id, []))
+        if request.achievements:
+            for item in request.achievements:
+                if all(existing.id != item.id for existing in achievements):
+                    achievements.append(item)
+        return achievements
+
+    def _load_labels_with_achievements(self, *, owner_id: str) -> list[schemas.AppealLabelConfig]:
+        label_records = (
+            self._db.query(models.Label)
+            .filter(models.Label.owner_id == owner_id)
+            .order_by(models.Label.name.asc())
+            .all()
+        )
+        label_ids = [label.id for label in label_records]
+        achievement_map = self._load_label_achievements(owner_id=owner_id, label_ids=label_ids)
+        results: list[schemas.AppealLabelConfig] = []
+        for label in label_records:
+            results.append(
+                schemas.AppealLabelConfig(
+                    id=label.id,
+                    name=label.name,
+                    color=label.color,
+                    description=label.description,
+                    achievements=achievement_map.get(label.id, []),
+                )
+            )
+        return results
+
+    def _load_label_achievements(
+        self,
+        *,
+        owner_id: str,
+        label_ids: Iterable[str],
+        limit_per_label: int = 5,
+    ) -> dict[str, list[schemas.AppealAchievement]]:
+        label_id_list = list(label_ids)
+        if not label_id_list:
+            return {}
+        query = (
+            self._db.query(models.Card, models.card_labels.c.label_id)
+            .join(models.card_labels, models.Card.id == models.card_labels.c.card_id)
+            .filter(models.card_labels.c.label_id.in_(label_id_list), models.Card.owner_id == owner_id)
+            .order_by(models.Card.completed_at.desc().nullslast(), models.Card.updated_at.desc())
+        )
+        grouped: dict[str, list[schemas.AppealAchievement]] = defaultdict(list)
+        for card, label_id in query:
+            bucket = grouped[label_id]
+            if len(bucket) >= limit_per_label:
+                continue
+            summary = card.summary or (card.description[:120] if card.description else None)
+            bucket.append(
+                schemas.AppealAchievement(
+                    id=card.id,
+                    title=card.title,
+                    summary=summary,
+                )
+            )
+        return grouped
+
+    def _derive_flow_warnings(self, flow: list[str]) -> list[str]:
+        normalized = [step.strip() for step in flow if step.strip()]
+        warnings: list[str] = []
+        if any(step.startswith("実績") for step in normalized) and not any(
+            step.startswith("課題") for step in normalized
+        ):
+            warnings.append("課題ステップが設定されていないため、因果関係が伝わりづらくなる可能性があります。")
+        return warnings
+
+    def _build_fallback_content(
+        self,
+        format_id: str,
+        subject: str,
+        flow: list[str],
+        achievements: list[schemas.AppealAchievement],
+    ) -> str:
+        connectors = {"link": "そのため", "result": "結果として"}
+        normalized_flow = [step.strip() for step in flow if step.strip()]
+        if format_id == "markdown":
+            lines: list[str] = [f"# {subject} のアピール"]
+            previous_step: str | None = None
+            for step in normalized_flow:
+                lines.append(f"## {step}")
+                if previous_step is None:
+                    lines.append(f"{connectors['link']}、{subject}に関する{step}の背景を整理しました。")
+                else:
+                    lines.append(f"{connectors['link']}、{previous_step}を踏まえて{step}を推進しました。")
+                previous_step = step
+            if achievements:
+                lines.append("## 実績ハイライト")
+                for item in achievements:
+                    summary = item.summary or "価値提供につながりました。"
+                    lines.append(f"- {connectors['result']}、{item.title}を達成し、{summary}")
+            lines.append(f"{connectors['result']}、{subject}の強みを示すことができました。")
+            return "\n".join(lines)
+
+        if format_id == "bullet_list":
+            items: list[str] = []
+            for step in normalized_flow:
+                prefix = f"{connectors['link']}、"
+                items.append(f"- {prefix}{step}に取り組みました。")
+            if achievements:
+                highlight = achievements[0]
+                summary = highlight.summary or "価値提供につながりました。"
+                items.append(f"- {connectors['result']}、{highlight.title}を示し、{summary}")
+            else:
+                items.append(f"- {connectors['result']}、{subject}の成長を証明しました。")
+            return "\n".join(items)
+
+        if format_id == "table":
+            rows = ["Step,Summary"]
+            previous_step = None
+            for step in normalized_flow:
+                if previous_step is None:
+                    summary = f"{connectors['link']}、{subject}に関する{step}の背景整理"
+                else:
+                    summary = f"{connectors['link']}、{previous_step}を踏まえて{step}を推進"
+                rows.append(f"{step},{summary}")
+                previous_step = step
+            if achievements:
+                combined = achievements[0]
+                summary = combined.summary or "価値提供につながりました"
+                rows.append(f"{connectors['result']},{combined.title} - {summary}")
+            else:
+                rows.append(f"{connectors['result']},{subject}の成果を共有")
+            return "\n".join(rows)
+
+        # Default fallback mirrors markdown to ensure connectors are present.
+        return self._build_fallback_content("markdown", subject, flow, achievements)
+
+
+def get_appeal_service(db: Session = Depends(get_db)) -> AppealGenerationService:
+    return AppealGenerationService(db)

--- a/backend/tests/test_appeals.py
+++ b/backend/tests/test_appeals.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from .test_cards import DEFAULT_PASSWORD as CARD_DEFAULT_PASSWORD
+
+
+def register_and_login(client: TestClient, email: str, password: str = CARD_DEFAULT_PASSWORD) -> dict[str, str]:
+    response = client.post(
+        "/auth/register",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 201, response.text
+    login_response = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert login_response.status_code == 200, login_response.text
+    token = login_response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def create_status(client: TestClient, headers: dict[str, str]) -> str:
+    response = client.post(
+        "/statuses",
+        json={"name": "Todo", "category": "todo", "order": 1},
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def create_label(client: TestClient, headers: dict[str, str]) -> str:
+    response = client.post(
+        "/labels",
+        json={"name": "Growth", "color": "#0088ff", "description": "成果の共有"},
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def create_card_with_label(
+    client: TestClient,
+    headers: dict[str, str],
+    status_id: str,
+    label_id: str,
+    title: str,
+    summary: str,
+) -> None:
+    response = client.post(
+        "/cards",
+        json={
+            "title": title,
+            "summary": summary,
+            "status_id": status_id,
+            "label_ids": [label_id],
+        },
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+
+
+def test_get_config_returns_labels_and_formats(client: TestClient) -> None:
+    headers = register_and_login(client, "appeal-config@example.com")
+    status_id = create_status(client, headers)
+    label_id = create_label(client, headers)
+    create_card_with_label(
+        client,
+        headers,
+        status_id,
+        label_id,
+        title="成果レポートを整理",
+        summary="チームの KPI 達成に貢献した施策をまとめた。",
+    )
+
+    response = client.get("/appeals/config", headers=headers)
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert {fmt["id"] for fmt in payload["formats"]} >= {"markdown", "bullet_list"}
+
+    label_entries = [entry for entry in payload["labels"] if entry["id"] == label_id]
+    assert label_entries, "Expected created label to appear in config"
+    assert label_entries[0]["achievements"], "Expected achievements derived from cards"
+
+
+def test_generate_appeal_with_label_subject_returns_content(client: TestClient) -> None:
+    headers = register_and_login(client, "appeal-generate@example.com")
+    status_id = create_status(client, headers)
+    label_id = create_label(client, headers)
+    create_card_with_label(
+        client,
+        headers,
+        status_id,
+        label_id,
+        title="社内勉強会を主催",
+        summary="最新の開発ベストプラクティスを共有し参加者満足度90%を達成。",
+    )
+
+    payload = {
+        "subject": {"type": "label", "value": label_id},
+        "flow": ["実績"],
+        "formats": ["markdown", "bullet_list", "table"],
+    }
+    response = client.post("/appeals/generate", json=payload, headers=headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["subject_echo"] == "Growth"
+    assert body["warnings"], "Expected warning when 実績 is present without 課題"
+
+    markdown_content = body["formats"]["markdown"]["content"]
+    assert "そのため" in markdown_content
+    assert "結果として" in markdown_content
+
+    bullet_content = body["formats"]["bullet_list"]["content"]
+    assert "結果として" in bullet_content
+
+    table_content = body["formats"]["table"]["content"]
+    assert "結果として" in table_content.splitlines()[-1]
+
+
+def test_generate_appeal_sanitizes_custom_subject(client: TestClient) -> None:
+    headers = register_and_login(client, "appeal-custom@example.com")
+
+    payload = {
+        "subject": {"type": "custom", "value": "<script>alert('x')</script>品質向上"},
+        "flow": ["課題", "対策", "実績"],
+        "formats": ["markdown"],
+        "achievements": [{"id": "manual", "title": "品質改善", "summary": "レビュー体制を強化"}],
+    }
+    response = client.post("/appeals/generate", json=payload, headers=headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["subject_echo"].startswith("&lt;script&gt;alert")
+    markdown_content = body["formats"]["markdown"]["content"]
+    assert "品質改善" in markdown_content
+    assert "そのため" in markdown_content
+    assert "結果として" in markdown_content


### PR DESCRIPTION
## Summary
- add an `AppealGeneration` persistence model and register the appeal router on the FastAPI app
- implement an appeal generation service with configuration lookup, fallback narrative building, and REST endpoints
- cover the new workflow with dedicated Pydantic schemas and backend API tests

## Testing
- pytest backend/tests/test_appeals.py

------
https://chatgpt.com/codex/tasks/task_e_68d4ebfb8a2c8320a3f3b45e88db14d4