### PR TITLE
Adjust analyze form note placement

### DIFF
--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -9,15 +9,15 @@
     <div class="form-grid form-grid--two analyze-page__composer">
       <label class="form-field analyze-page__notes">
         <span class="form-field__label">ノート</span>
+        <p class="form-note analyze-page__notes-hint">
+          具体的な課題や観察した事実をまとめると、より正確なカード案が生成されます。
+        </p>
         <textarea
           class="form-control form-control--textarea analyze-page__notes-input"
           placeholder="例: ユーザーからのフィードバックや不具合の状況を貼り付けてください"
           [value]="analyzeForm.controls.notes.value()"
           (input)="analyzeForm.controls.notes.setValue($any($event.target).value)"
         ></textarea>
-        <p class="form-note">
-          具体的な課題や観察した事実をまとめると、より正確なカード案が生成されます。
-        </p>
       </label>
 
       <div class="analyze-page__objective">

--- a/frontend/src/styles/pages/_analyze.scss
+++ b/frontend/src/styles/pages/_analyze.scss
@@ -12,6 +12,10 @@
   min-height: clamp(16rem, 24vw, 20rem);
 }
 
+.analyze-page__notes-hint {
+  margin-bottom: clamp(0.6rem, 1vw, 0.85rem);
+}
+
 .analyze-page__objective {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- move the analyze page note guidance copy above the textarea so users see it before typing
- add spacing styles for the note hint to keep the composer columns visually aligned

## Testing
- npm run build *(fails: existing template errors in frontend/src/app/features/board/page.html)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fbab35e8832096734e5da1217fbe