### PR TITLE
feat: add reusable page layout shell

### DIFF
--- a/frontend/src/app/features/admin/page.html
+++ b/frontend/src/app/features/admin/page.html
@@ -1,10 +1,10 @@
-<section class="app-page admin-page">
-  <header class="page-hero">
-    <h1 class="page-title">管理コンソール</h1>
-    <p class="page-subtitle">
-      コンピテンシー設定・判定・ユーザ権限・API キーをまとめて管理できます。
-    </p>
-  </header>
+<app-page-layout
+  class="admin-page app-page-layout--wide"
+  eyebrow="Admin Console"
+  title="管理コンソール"
+  description="コンピテンシー設定・判定・ユーザ権限・API キーをまとめて管理できます。"
+  headingLevel="h1"
+>
 
   @if (error(); as message) {
     <div class="app-alert app-alert--error" role="alert">
@@ -475,4 +475,4 @@
       </form>
     </section>
   }
-</section>
+</app-page-layout>

--- a/frontend/src/app/features/admin/page.ts
+++ b/frontend/src/app/features/admin/page.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 import { HttpErrorResponse } from '@angular/common/http';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -27,7 +28,7 @@ type AdminTab = 'competencies' | 'evaluations' | 'users' | 'settings';
 @Component({
   selector: 'app-admin-page',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PageLayoutComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/analytics/page.html
+++ b/frontend/src/app/features/analytics/page.html
@@ -1,9 +1,10 @@
-<section class="app-page analytics-page">
-  <app-page-header
-    eyebrow="分析ダッシュボード"
-    title="ワークスペース全体の指標"
-    description="完了率やポイント配分に加え、指摘の傾向や原因、改善活動の進捗までひと目で確認できます。"
-  ></app-page-header>
+<app-page-layout
+  class="analytics-page"
+  eyebrow="分析ダッシュボード"
+  title="ワークスペース全体の指標"
+  description="完了率やポイント配分に加え、指摘の傾向や原因、改善活動の進捗までひと目で確認できます。"
+  headingLevel="h1"
+>
 
   <section class="page-section analytics-page__intro">
     <div class="analytics-page__intro-content">
@@ -352,4 +353,4 @@
       <textarea class="report-preview" rows="10" readonly [value]="reportPreview()"></textarea>
     </div>
   </section>
-</section>
+</app-page-layout>

--- a/frontend/src/app/features/analytics/page.ts
+++ b/frontend/src/app/features/analytics/page.ts
@@ -5,7 +5,7 @@ import { RouterLink } from '@angular/router';
 import { FeedbackSeverity } from '@core/models';
 import { ContinuousImprovementStore } from '@core/state/continuous-improvement-store';
 import { WorkspaceStore } from '@core/state/workspace-store';
-import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
+import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 
 /**
  * Analytics dashboard summarizing board metrics for the workspace.
@@ -13,7 +13,7 @@ import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
 @Component({
   selector: 'app-analytics-page',
   standalone: true,
-  imports: [CommonModule, RouterLink, PageHeaderComponent],
+  imports: [CommonModule, RouterLink, PageLayoutComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -1,9 +1,10 @@
-<section class="app-page analyze-page">
-  <app-page-header
-    eyebrow="AI Task Creator"
-    title="メモからタスクを起票"
-    description="作業メモやアイデアを貼り付けると、AI がカード案とサブタスクを提案します。内容を確認し、必要なものだけボードへ追加しましょう。"
-  ></app-page-header>
+<app-page-layout
+  class="analyze-page"
+  eyebrow="AI Task Creator"
+  title="メモからタスクを起票"
+  description="作業メモやアイデアを貼り付けると、AI がカード案とサブタスクを提案します。内容を確認し、必要なものだけボードへ追加しましょう。"
+  headingLevel="h1"
+>
 
   <form class="surface-panel page-panel analyze-page__form" (submit)="handleSubmit($event)">
     <div class="form-grid form-grid--two analyze-page__composer">
@@ -187,4 +188,4 @@
       </div>
     }
   </section>
-</section>
+</app-page-layout>

--- a/frontend/src/app/features/analyze/page.ts
+++ b/frontend/src/app/features/analyze/page.ts
@@ -5,7 +5,7 @@ import { AnalysisGateway } from '@core/api/analysis-gateway';
 import { WorkspaceStore } from '@core/state/workspace-store';
 import { AnalysisProposal, AnalysisRequest } from '@core/models';
 import { createSignalForm } from '@lib/forms/signal-forms';
-import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
+import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 
 /**
  * Analyzer page allowing users to submit notes and review ChatGPT-style proposals.
@@ -13,7 +13,7 @@ import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
 @Component({
   selector: 'app-analyze-page',
   standalone: true,
-  imports: [CommonModule, PageHeaderComponent],
+  imports: [CommonModule, PageLayoutComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/auth/login/page.html
+++ b/frontend/src/app/features/auth/login/page.html
@@ -1,4 +1,10 @@
-<section class="app-page auth-page">
+<app-page-layout
+  class="auth-page app-page-layout--wide"
+  eyebrow="Workspace Access"
+  title="サインインまたは新規登録"
+  description="ワークスペースに参加するには既存のアカウントでログインするか、新しいアカウントを作成してください。"
+  headingLevel="h1"
+>
   <div class="auth-page__container">
     <div class="auth-page__grid">
       <section
@@ -200,4 +206,4 @@
       </section>
     </div>
   </div>
-</section>
+</app-page-layout>

--- a/frontend/src/app/features/auth/login/page.ts
+++ b/frontend/src/app/features/auth/login/page.ts
@@ -7,6 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 import { Router } from '@angular/router';
 
 import { AuthService } from '@core/auth/auth.service';
@@ -31,7 +32,7 @@ interface RegistrationSubmission {
 @Component({
   selector: 'app-login-page',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, PageLayoutComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/daily-reports/page.html
+++ b/frontend/src/app/features/daily-reports/page.html
@@ -1,13 +1,13 @@
-<section class="app-page daily-report-page">
-  <app-page-header
-    eyebrow="AI レポートアシスタント"
-    title="日報・週報解析"
-    description="タグと本文を入力すると、AI がカード候補と振り返りの観点を提案します。"
-  >
-    <a appPageHeaderActions class="button button--secondary focus-ring" routerLink="/analytics">
-      分析ダッシュボードを見る
-    </a>
-  </app-page-header>
+<app-page-layout
+  class="daily-report-page"
+  eyebrow="AI レポートアシスタント"
+  title="日報・週報解析"
+  description="タグと本文を入力すると、AI がカード候補と振り返りの観点を提案します。"
+  headingLevel="h1"
+>
+  <a appPageHeaderActions class="button button--secondary focus-ring" routerLink="/analytics">
+    分析ダッシュボードを見る
+  </a>
 
   <div class="app-alert app-alert--notice daily-report-page__notice" role="status">
     解析に使用した本文はカード作成後に破棄され、ワークスペースに保存されません。
@@ -225,4 +225,4 @@
       </ng-template>
     </aside>
   </div>
-</section>
+</app-page-layout>

--- a/frontend/src/app/features/daily-reports/page.ts
+++ b/frontend/src/app/features/daily-reports/page.ts
@@ -7,12 +7,12 @@ import { RouterLink } from '@angular/router';
 
 import { DailyReportsGateway } from '@core/api/daily-reports-gateway';
 import { DailyReportDetail, DailyReportCreateRequest } from '@core/models';
-import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
+import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 
 @Component({
   selector: 'app-daily-reports-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink, PageHeaderComponent],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, PageLayoutComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/profile/evaluations/page.html
+++ b/frontend/src/app/features/profile/evaluations/page.html
@@ -1,72 +1,66 @@
-<section class="app-page evaluations-page shell-container">
-  <header class="page-header">
-    <div class="page-header__content">
-      <p class="page-eyebrow">Competency Insights</p>
-      <h1 class="page-title">コンピテンシー評価の履歴</h1>
-      <p class="page-description">
-        直近のコンピテンシー判定とアクションプランを確認できます。姿勢面と行動面それぞれの推奨事項を振り返り、
-        次のスプリント計画に活用しましょう。
-      </p>
-    </div>
-    <div class="page-header__actions">
-      <section class="quota-card" aria-live="polite">
-        <p class="quota-card__label">本日の評価判定可能回数</p>
+<app-page-layout
+  class="evaluations-page shell-container"
+  eyebrow="Competency Insights"
+  title="コンピテンシー評価の履歴"
+  description="直近のコンピテンシー判定とアクションプランを確認できます。姿勢面と行動面それぞれの推奨事項を振り返り、次のスプリント計画に活用しましょう。"
+  headingLevel="h1"
+>
+  <section appPageHeaderActions class="quota-card" aria-live="polite">
+    <p class="quota-card__label">本日の評価判定可能回数</p>
 
-        @if (quotaLoading()) {
-          <p class="quota-card__loading">計算中…</p>
-        } @else if (quotaError(); as message) {
-          <p class="quota-card__warning">{{ message }}</p>
-        } @else {
-          <div class="quota-card__values">
-            <span class="quota-card__value">{{ limitLabel(quota()) }}</span>
-            <span class="quota-card__separator">／</span>
-            <span class="quota-card__value quota-card__value--remaining">
-              {{ remainingLabel(quota()) }}
-            </span>
-          </div>
-          <p class="quota-card__meta">実行済み {{ quota()?.used ?? 0 }} 回</p>
-
-          @if (limitReached()) {
-            <p class="quota-card__warning">本日の上限に達しました。</p>
-          }
-        }
-      </section>
-
-      <div class="page-header__buttons">
-        <button
-          type="button"
-          class="refresh-button focus-ring"
-          (click)="runEvaluation()"
-          [disabled]="runningEvaluation() || loading() || !canRunEvaluation()"
-        >
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 24 24"
-            class="h-4 w-4"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.8"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M12 3v2m0 14v2m9-9h-2M5 12H3m12.364-5.364-1.414 1.414M6.05 17.95l-1.414 1.414m12.728 0-1.414-1.414M6.05 6.05 4.636 4.636M9 12a3 3 0 1 0 6 0 3 3 0 0 0-6 0Z"
-            />
-          </svg>
-          評価を実行
-        </button>
-
-        <button
-          type="button"
-          class="secondary-button focus-ring"
-          (click)="exportLatestAsJson()"
-          [disabled]="!latestEvaluation()"
-        >
-          JSON で出力
-        </button>
+    @if (quotaLoading()) {
+      <p class="quota-card__loading">計算中…</p>
+    } @else if (quotaError(); as message) {
+      <p class="quota-card__warning">{{ message }}</p>
+    } @else {
+      <div class="quota-card__values">
+        <span class="quota-card__value">{{ limitLabel(quota()) }}</span>
+        <span class="quota-card__separator">／</span>
+        <span class="quota-card__value quota-card__value--remaining">
+          {{ remainingLabel(quota()) }}
+        </span>
       </div>
-    </div>
-  </header>
+      <p class="quota-card__meta">実行済み {{ quota()?.used ?? 0 }} 回</p>
+
+      @if (limitReached()) {
+        <p class="quota-card__warning">本日の上限に達しました。</p>
+      }
+    }
+  </section>
+
+  <div appPageHeaderActions class="page-header__buttons">
+    <button
+      type="button"
+      class="refresh-button focus-ring"
+      (click)="runEvaluation()"
+      [disabled]="runningEvaluation() || loading() || !canRunEvaluation()"
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        class="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.8"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M12 3v2m0 14v2m9-9h-2M5 12H3m12.364-5.364-1.414 1.414M6.05 17.95l-1.414 1.414m12.728 0-1.414-1.414M6.05 6.05 4.636 4.636M9 12a3 3 0 1 0 6 0 3 3 0 0 0-6 0Z"
+        />
+      </svg>
+      評価を実行
+    </button>
+
+    <button
+      type="button"
+      class="secondary-button focus-ring"
+      (click)="exportLatestAsJson()"
+      [disabled]="!latestEvaluation()"
+    >
+      JSON で出力
+    </button>
+  </div>
 
   @if (actionError(); as message) {
     <p class="page-alert page-alert--error" role="alert">{{ message }}</p>
@@ -308,4 +302,4 @@
       }
     }
   }
-</section>
+</app-page-layout>

--- a/frontend/src/app/features/profile/evaluations/page.ts
+++ b/frontend/src/app/features/profile/evaluations/page.ts
@@ -7,6 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 import { HttpErrorResponse } from '@angular/common/http';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -21,7 +22,7 @@ const DEFAULT_HISTORY_LIMIT = 12;
 @Component({
   selector: 'app-profile-evaluations-page',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, PageLayoutComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/settings/page.html
+++ b/frontend/src/app/features/settings/page.html
@@ -1,9 +1,10 @@
-<section class="app-page settings-page">
-  <app-page-header
-    eyebrow="Workspace Settings"
-    title="ワークスペース設定"
-    description="ステータスやラベル、テンプレートを更新してチームの運用に合わせましょう。"
-  ></app-page-header>
+<app-page-layout
+  class="settings-page"
+  eyebrow="Workspace Settings"
+  title="ワークスペース設定"
+  description="ステータスやラベル、テンプレートを更新してチームの運用に合わせましょう。"
+  headingLevel="h1"
+>
 
   <div class="page-grid page-grid--two settings-page__grid">
     <section class="page-section settings-panel">
@@ -341,4 +342,4 @@
       </div>
     </form>
   </section>
-</section>
+</app-page-layout>

--- a/frontend/src/app/features/settings/page.ts
+++ b/frontend/src/app/features/settings/page.ts
@@ -4,7 +4,7 @@ import { CommonModule } from '@angular/common';
 import { WorkspaceStore } from '@core/state/workspace-store';
 import { TemplatePreset } from '@core/models';
 import { SignalControl, createSignalForm } from '@lib/forms/signal-forms';
-import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
+import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 
 /**
  * Settings page exposing workspace configuration controls.
@@ -12,7 +12,7 @@ import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
 @Component({
   selector: 'app-settings-page',
   standalone: true,
-  imports: [CommonModule, PageHeaderComponent],
+  imports: [CommonModule, PageLayoutComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/shared/ui/page-layout/page-layout.html
+++ b/frontend/src/app/shared/ui/page-layout/page-layout.html
@@ -1,0 +1,16 @@
+<app-page-header
+  [eyebrow]="eyebrow"
+  [title]="title"
+  [description]="description"
+  [headingLevel]="headingLevel"
+>
+  <ng-content select="[pageHeaderMeta]"></ng-content>
+  <ng-content select="[appPageHeaderActions]"></ng-content>
+</app-page-header>
+
+<div class="app-page-layout__body" [class.app-page-layout__body--bleed]="bleed">
+  <div class="app-page-layout__content">
+    <ng-content select="[pageTabs]"></ng-content>
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/frontend/src/app/shared/ui/page-layout/page-layout.scss
+++ b/frontend/src/app/shared/ui/page-layout/page-layout.scss
@@ -1,0 +1,46 @@
+:host {
+  display: block;
+  padding-inline: clamp(1.5rem, 4vw, 4.5rem);
+  padding-block: var(--page-padding-block-start) var(--page-padding-block-end);
+}
+
+:host(.shell-container) {
+  padding-inline: 0;
+}
+
+.app-page-layout__body {
+  display: grid;
+  gap: var(--page-content-gap);
+  margin-top: var(--page-content-gap);
+}
+
+.app-page-layout__body--bleed {
+  margin-inline: calc(clamp(1.5rem, 4vw, 4.5rem) * -1);
+}
+
+:host(.shell-container) .app-page-layout__body--bleed {
+  margin-inline: 0;
+}
+
+.app-page-layout__content {
+  display: grid;
+  gap: var(--page-content-gap);
+  max-width: 76rem;
+  width: 100%;
+  margin-inline: auto;
+}
+
+:host(.app-page-layout--wide) .app-page-layout__content {
+  max-width: none;
+  margin-inline: 0;
+}
+
+@media (min-width: 80rem) {
+  :host {
+    padding-inline: clamp(3rem, 6vw, 6rem);
+  }
+
+  .app-page-layout__body--bleed {
+    margin-inline: calc(clamp(3rem, 6vw, 6rem) * -1);
+  }
+}

--- a/frontend/src/app/shared/ui/page-layout/page-layout.ts
+++ b/frontend/src/app/shared/ui/page-layout/page-layout.ts
@@ -1,0 +1,52 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
+
+type HeadingLevel = 'h1' | 'h2' | 'h3';
+
+/**
+ * Shell layout that provides consistent page headers and content spacing.
+ */
+@Component({
+  selector: 'app-page-layout',
+  standalone: true,
+  imports: [CommonModule, PageHeaderComponent],
+  templateUrl: './page-layout.html',
+  styleUrl: './page-layout.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'app-page app-page-layout',
+  },
+})
+export class PageLayoutComponent {
+  /**
+   * Eyebrow label displayed above the title.
+   */
+  @Input()
+  public eyebrow?: string;
+
+  /**
+   * Main title for the page.
+   */
+  @Input({ required: true })
+  public title!: string;
+
+  /**
+   * Optional description rendered under the title.
+   */
+  @Input()
+  public description?: string;
+
+  /**
+   * Heading level passed to the shared page header.
+   */
+  @Input()
+  public headingLevel: HeadingLevel = 'h1';
+
+  /**
+   * When true the content section spans the full width of the viewport.
+   */
+  @Input()
+  public bleed = false;
+}

--- a/frontend/src/styles/pages/_profile-evaluations.scss
+++ b/frontend/src/styles/pages/_profile-evaluations.scss
@@ -1,12 +1,11 @@
 app-profile-evaluations-page {
   display: block;
   color: var(--text-primary);
-  padding: var(--page-padding-block-start) 0 var(--page-padding-block-end);
   --page-content-gap: clamp(1.75rem, 2vw, 2.5rem);
   --panel-gap: clamp(1.25rem, 2vw, 1.75rem);
 }
 
-app-profile-evaluations-page .evaluations-page {
+app-profile-evaluations-page .app-page-layout {
   display: flex;
   flex-direction: column;
   gap: var(--page-content-gap);


### PR DESCRIPTION
## Summary
- add a shared PageLayoutComponent that wraps the common header slots and spacing
- adopt the new layout shell across admin, analytics, analyze, auth login, daily report, profile evaluation, and settings pages
- tweak profile evaluation styles to work with the new layout container

## Testing
- npm run lint
- npm run format:check *(fails: pre-existing board/page.html template contains invalid nested tags)*
- npm run build *(fails: board/page.html template has long-standing invalid markup; cleaning it is out of scope for this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fd5f183483208a9724bc8b4cb6d1