### PR TITLE
Add SonarQube scan workflow

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,50 @@
+name: SonarQube
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  sonarqube:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v2
+        env:
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: SonarQube Quality Gate
+        uses: SonarSource/sonarqube-quality-gate-action@v1.1.0
+        env:
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          scanMetadataReportFile: .scannerwork/report-task.txt

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=todo-generator
+sonar.projectName=todo-generator
+sonar.sourceEncoding=UTF-8
+sonar.sources=backend/app,frontend/src
+sonar.exclusions=frontend/src/**/*.spec.ts,frontend/src/**/*.stories.ts
+sonar.tests=backend/tests,frontend/src
+sonar.test.inclusions=backend/tests/**/*.py,frontend/src/**/*.spec.ts
+sonar.python.version=3.11


### PR DESCRIPTION
## Summary
- add a SonarQube GitHub Actions workflow that installs backend and frontend dependencies before scanning
- configure a sonar-project.properties file so the scanner analyzes both the FastAPI backend and Angular frontend
- gate the pipeline on the SonarQube quality gate to surface failures in CI

## Testing
- not run (CI configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d50df9b8d48320a194d5fafd0cd24e