### PR TITLE
Align competency evaluations layout with shared design

### DIFF
--- a/frontend/src/app/features/profile/evaluations/page.html
+++ b/frontend/src/app/features/profile/evaluations/page.html
@@ -1,303 +1,334 @@
 <app-page-layout
-  class="evaluations-page shell-container"
+  class="evaluations-page"
   eyebrow="Competency Insights"
   title="コンピテンシー評価の履歴"
   description="直近のコンピテンシー判定とアクションプランを確認できます。姿勢面と行動面それぞれの推奨事項を振り返り、次のスプリント計画に活用しましょう。"
   headingLevel="h1"
 >
-  <section appPageHeaderActions class="quota-card" aria-live="polite">
-    <p class="quota-card__label">本日の評価判定可能回数</p>
+  <section appPageHeaderActions class="evaluations-page__header">
+    <article class="surface-panel page-panel evaluations-page__quota" aria-live="polite">
+      <p class="evaluations-page__quota-label">本日の評価判定可能回数</p>
 
-    @if (quotaLoading()) {
-      <p class="quota-card__loading">計算中…</p>
-    } @else if (quotaError(); as message) {
-      <p class="quota-card__warning">{{ message }}</p>
-    } @else {
-      <div class="quota-card__values">
-        <span class="quota-card__value">{{ limitLabel(quota()) }}</span>
-        <span class="quota-card__separator">／</span>
-        <span class="quota-card__value quota-card__value--remaining">
-          {{ remainingLabel(quota()) }}
-        </span>
-      </div>
-      <p class="quota-card__meta">実行済み {{ quota()?.used ?? 0 }} 回</p>
+      @if (quotaLoading()) {
+        <p class="evaluations-page__quota-loading">計算中…</p>
+      } @else if (quotaError(); as message) {
+        <p class="evaluations-page__quota-warning">{{ message }}</p>
+      } @else {
+        <div class="evaluations-page__quota-values">
+          <span class="evaluations-page__quota-value">{{ limitLabel(quota()) }}</span>
+          <span class="evaluations-page__quota-separator">／</span>
+          <span class="evaluations-page__quota-value evaluations-page__quota-value--remaining">
+            {{ remainingLabel(quota()) }}
+          </span>
+        </div>
+        <p class="evaluations-page__quota-meta">実行済み {{ quota()?.used ?? 0 }} 回</p>
 
-      @if (limitReached()) {
-        <p class="quota-card__warning">本日の上限に達しました。</p>
+        @if (limitReached()) {
+          <p class="evaluations-page__quota-warning">本日の上限に達しました。</p>
+        }
       }
-    }
+    </article>
+
+    <div class="evaluations-page__actions">
+      <button
+        type="button"
+        class="button button--primary button--pill focus-ring"
+        (click)="runEvaluation()"
+        [disabled]="runningEvaluation() || loading() || !canRunEvaluation()"
+      >
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          class="evaluations-page__action-icon"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 3v2m0 14v2m9-9h-2M5 12H3m12.364-5.364-1.414 1.414M6.05 17.95l-1.414 1.414m12.728 0-1.414-1.414M6.05 6.05 4.636 4.636M9 12a3 3 0 1 0 6 0 3 3 0 0 0-6 0Z"
+          />
+        </svg>
+        評価を実行
+      </button>
+
+      <button
+        type="button"
+        class="button button--secondary button--pill focus-ring"
+        (click)="exportLatestAsJson()"
+        [disabled]="!latestEvaluation()"
+      >
+        JSON で出力
+      </button>
+    </div>
   </section>
 
-  <div appPageHeaderActions class="page-header__buttons">
-    <button
-      type="button"
-      class="refresh-button focus-ring"
-      (click)="runEvaluation()"
-      [disabled]="runningEvaluation() || loading() || !canRunEvaluation()"
-    >
-      <svg
-        aria-hidden="true"
-        viewBox="0 0 24 24"
-        class="h-4 w-4"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.8"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          d="M12 3v2m0 14v2m9-9h-2M5 12H3m12.364-5.364-1.414 1.414M6.05 17.95l-1.414 1.414m12.728 0-1.414-1.414M6.05 6.05 4.636 4.636M9 12a3 3 0 1 0 6 0 3 3 0 0 0-6 0Z"
-        />
-      </svg>
-      評価を実行
-    </button>
-
-    <button
-      type="button"
-      class="secondary-button focus-ring"
-      (click)="exportLatestAsJson()"
-      [disabled]="!latestEvaluation()"
-    >
-      JSON で出力
-    </button>
-  </div>
-
   @if (actionError(); as message) {
-    <p class="page-alert page-alert--error" role="alert">{{ message }}</p>
+    <div class="app-alert app-alert--error" role="alert">{{ message }}</div>
   }
 
   @if (feedback(); as message) {
-    <p class="page-alert page-alert--success" role="status">{{ message }}</p>
+    <div class="app-alert app-alert--success" role="status">{{ message }}</div>
   }
 
   @if (loading()) {
-    <div class="state state--loading">
-      <span class="state__spinner" aria-hidden="true"></span>
-      <p>評価履歴を読み込んでいます…</p>
-    </div>
+    <section class="page-section">
+      <div class="surface-panel page-panel page-state evaluations-page__state" role="status">
+        <span class="evaluations-page__spinner" aria-hidden="true"></span>
+        <p>評価履歴を読み込んでいます…</p>
+      </div>
+    </section>
   } @else {
     @if (error(); as message) {
-      <div class="state state--error" role="alert">
-        <h2>取得に失敗しました</h2>
-        <p>{{ message }}</p>
-        <button type="button" class="retry-button focus-ring" (click)="refresh()">
-          再試行する
-        </button>
-      </div>
+      <section class="page-section">
+        <div class="surface-panel page-panel page-state page-state--error" role="alert">
+          <h2>取得に失敗しました</h2>
+          <p>{{ message }}</p>
+          <button type="button" class="button button--secondary focus-ring" (click)="refresh()">
+            再試行する
+          </button>
+        </div>
+      </section>
     } @else {
       @if (!hasEvaluations()) {
-        <div class="state state--empty">
-          <svg aria-hidden="true" viewBox="0 0 24 24" class="h-12 w-12 text-slate-400">
-            <path
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M12 3c3.866 0 7 3.134 7 7 0 2.93-1.877 5.42-4.5 6.4L12 21l-2.5-4.6C6.877 15.42 5 12.93 5 10c0-3.866 3.134-7 7-7Z"
-            />
-          </svg>
-          <h2>まだ評価はありません</h2>
-          <p>コンピテンシー評価が実行されると、ここに結果が表示されます。</p>
-        </div>
+        <section class="page-section">
+          <div class="surface-panel page-panel page-state evaluations-page__state">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="evaluations-page__empty-icon">
+              <path
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M12 3c3.866 0 7 3.134 7 7 0 2.93-1.877 5.42-4.5 6.4L12 21l-2.5-4.6C6.877 15.42 5 12.93 5 10c0-3.866 3.134-7 7-7Z"
+              />
+            </svg>
+            <h2>まだ評価はありません</h2>
+            <p>コンピテンシー評価が実行されると、ここに結果が表示されます。</p>
+          </div>
+        </section>
       } @else {
         @if (latestEvaluation(); as evaluation) {
-          <section class="latest surface-panel">
-            <header class="latest__header">
-              <div class="latest__summary">
-                <p class="latest__eyebrow">最新の評価</p>
-                <h2 class="latest__title">
-                  {{ evaluation.competency?.name || 'コンピテンシー評価' }}
-                </h2>
-                <p class="latest__meta">
-                  評価期間
-                  <span>{{ evaluation.period_start | date: 'yyyy/MM/dd' }}</span>
-                  〜
-                  <span>{{ evaluation.period_end | date: 'yyyy/MM/dd' }}</span>
-                </p>
-                <p class="latest__meta">
-                  判定種別: {{ triggeredLabel(evaluation.triggered_by) }} / モデル:
-                  {{ evaluation.ai_model || '未設定' }}
-                </p>
-              </div>
-              <div class="latest__score" aria-label="評価スコア">
-                <div class="latest__score-value">
-                  <span aria-hidden="true">{{ evaluation.score_value }}</span>
-                  <span class="latest__score-scale" aria-hidden="true"
-                    >/ {{ evaluation.scale }}</span
-                  >
+          <section class="page-section">
+            <article class="surface-panel page-panel evaluations-page__latest">
+              <header class="evaluations-page__latest-header">
+                <div class="evaluations-page__latest-summary">
+                  <p class="evaluations-page__latest-eyebrow">最新の評価</p>
+                  <h2 class="evaluations-page__latest-title">
+                    {{ evaluation.competency?.name || 'コンピテンシ評価' }}
+                  </h2>
+                  <p class="evaluations-page__latest-meta">
+                    評価期間
+                    <span>{{ evaluation.period_start | date: 'yyyy/MM/dd' }}</span>
+                    〜
+                    <span>{{ evaluation.period_end | date: 'yyyy/MM/dd' }}</span>
+                  </p>
+                  <p class="evaluations-page__latest-meta">
+                    判定種別: {{ triggeredLabel(evaluation.triggered_by) }} / モデル:
+                    {{ evaluation.ai_model || '未設定' }}
+                  </p>
                 </div>
-                <p class="latest__score-label">{{ evaluation.score_label }}</p>
-                <p class="latest__score-percent">達成率 {{ scorePercent(evaluation) }}%</p>
-              </div>
-            </header>
-
-            <div class="latest__progress" role="presentation">
-              <div class="latest__progress-bar" [style.width.%]="scorePercent(evaluation)"></div>
-            </div>
-
-            <div class="latest__body">
-              @if (evaluation.rationale) {
-                <section class="latest__section">
-                  <h3>総合所見</h3>
-                  <p class="latest__text">{{ evaluation.rationale }}</p>
-                </section>
-              }
-
-              <section class="latest__actions-grid">
-                <article class="latest__action">
-                  <header>
-                    <h3>姿勢・意識面でのアクション</h3>
-                    <p>モチベーションやコミュニケーションの観点で意識したいポイントです。</p>
-                  </header>
-                  @if (hasActions(evaluation.attitude_actions)) {
-                    <ul>
-                      @for (action of evaluation.attitude_actions; track action) {
-                        <li>{{ action }}</li>
-                      }
-                    </ul>
-                  } @else {
-                    <p class="latest__empty">推奨事項は特にありません。</p>
-                  }
-                </article>
-                <article class="latest__action">
-                  <header>
-                    <h3>具体的な行動プラン</h3>
-                    <p>すぐに実行できるタスクや振り返りポイントをまとめています。</p>
-                  </header>
-                  @if (hasActions(evaluation.behavior_actions)) {
-                    <ul>
-                      @for (action of evaluation.behavior_actions; track action) {
-                        <li>{{ action }}</li>
-                      }
-                    </ul>
-                  } @else {
-                    <p class="latest__empty">特筆すべきアクションはありません。</p>
-                  }
-                </article>
-              </section>
-
-              @if (evaluation.items.length > 0) {
-                <section class="latest__details">
-                  <h3>評価項目の内訳</h3>
-                  <div class="latest__items">
-                    @for (item of evaluation.items; track item.id; let index = $index) {
-                      <article class="latest__item surface-card">
-                        <header>
-                          <p class="latest__item-title">{{ '評価項目 ' + (index + 1) }}</p>
-                          <p class="latest__item-score">
-                            {{ item.score_label }} ({{ item.score_value }} 点)
-                          </p>
-                        </header>
-                        <div class="latest__item-body">
-                          <p class="latest__item-text">
-                            {{ item.rationale || '根拠メモは記録されていません。' }}
-                          </p>
-
-                          @if (hasActions(item.attitude_actions)) {
-                            <div class="latest__item-actions">
-                              <h4>姿勢・意識</h4>
-                              <ul>
-                                @for (action of item.attitude_actions; track action) {
-                                  <li>{{ action }}</li>
-                                }
-                              </ul>
-                            </div>
-                          }
-
-                          @if (hasActions(item.behavior_actions)) {
-                            <div class="latest__item-actions">
-                              <h4>行動プラン</h4>
-                              <ul>
-                                @for (action of item.behavior_actions; track action) {
-                                  <li>{{ action }}</li>
-                                }
-                              </ul>
-                            </div>
-                          }
-                        </div>
-                      </article>
-                    }
+                <div class="evaluations-page__latest-score" aria-label="評価スコア">
+                  <div class="evaluations-page__latest-score-value">
+                    <span aria-hidden="true">{{ evaluation.score_value }}</span>
+                    <span class="evaluations-page__latest-score-scale" aria-hidden="true"
+                      >/ {{ evaluation.scale }}</span
+                    >
                   </div>
+                  <p class="evaluations-page__latest-score-label">{{ evaluation.score_label }}</p>
+                  <p class="evaluations-page__latest-score-percent">
+                    達成率 {{ scorePercent(evaluation) }}%
+                  </p>
+                </div>
+              </header>
+
+              <div class="evaluations-page__latest-progress" role="presentation">
+                <div
+                  class="evaluations-page__latest-progress-bar"
+                  [style.width.%]="scorePercent(evaluation)"
+                ></div>
+              </div>
+
+              <div class="evaluations-page__latest-body">
+                @if (evaluation.rationale) {
+                  <section class="evaluations-page__latest-section">
+                    <h3>総合所見</h3>
+                    <p class="evaluations-page__latest-text">{{ evaluation.rationale }}</p>
+                  </section>
+                }
+
+                <section class="evaluations-page__latest-actions-grid">
+                  <article class="evaluations-page__latest-action">
+                    <header>
+                      <h3>姿勢・意識面でのアクション</h3>
+                      <p>モチベーションやコミュニケーションの観点で意識したいポイントです。</p>
+                    </header>
+                    @if (hasActions(evaluation.attitude_actions)) {
+                      <ul>
+                        @for (action of evaluation.attitude_actions; track action) {
+                          <li>{{ action }}</li>
+                        }
+                      </ul>
+                    } @else {
+                      <p class="evaluations-page__latest-empty">推奨事項は特にありません。</p>
+                    }
+                  </article>
+                  <article class="evaluations-page__latest-action">
+                    <header>
+                      <h3>具体的な行動プラン</h3>
+                      <p>すぐに実行できるタスクや振り返りポイントをまとめています。</p>
+                    </header>
+                    @if (hasActions(evaluation.behavior_actions)) {
+                      <ul>
+                        @for (action of evaluation.behavior_actions; track action) {
+                          <li>{{ action }}</li>
+                        }
+                      </ul>
+                    } @else {
+                      <p class="evaluations-page__latest-empty">
+                        特筆すべきアクションはありません。
+                      </p>
+                    }
+                  </article>
                 </section>
-              }
-            </div>
+
+                @if (evaluation.items.length > 0) {
+                  <section class="evaluations-page__latest-details">
+                    <h3>評価項目の内訳</h3>
+                    <div class="evaluations-page__latest-items">
+                      @for (item of evaluation.items; track item.id; let index = $index) {
+                        <article class="surface-card evaluations-page__latest-item">
+                          <header>
+                            <p class="evaluations-page__latest-item-title">
+                              {{ '評価項目 ' + (index + 1) }}
+                            </p>
+                            <p class="evaluations-page__latest-item-score">
+                              {{ item.score_label }} ({{ item.score_value }} 点)
+                            </p>
+                          </header>
+                          <div class="evaluations-page__latest-item-body">
+                            <p class="evaluations-page__latest-item-text">
+                              {{ item.rationale || '根拠メモは記録されていません。' }}
+                            </p>
+
+                            @if (hasActions(item.attitude_actions)) {
+                              <div class="evaluations-page__latest-item-actions">
+                                <h4>姿勢・意識</h4>
+                                <ul>
+                                  @for (action of item.attitude_actions; track action) {
+                                    <li>{{ action }}</li>
+                                  }
+                                </ul>
+                              </div>
+                            }
+
+                            @if (hasActions(item.behavior_actions)) {
+                              <div class="evaluations-page__latest-item-actions">
+                                <h4>行動プラン</h4>
+                                <ul>
+                                  @for (action of item.behavior_actions; track action) {
+                                    <li>{{ action }}</li>
+                                  }
+                                </ul>
+                              </div>
+                            }
+                          </div>
+                        </article>
+                      }
+                    </div>
+                  </section>
+                }
+              </div>
+            </article>
           </section>
         }
 
-        <section class="history surface-panel">
-          <header class="history__header">
-            <div>
-              <h2>過去の評価履歴</h2>
-              <p>最大 12 件まで表示します。詳細を開いて改善ポイントを再確認できます。</p>
-            </div>
-            <span class="history__count">{{ evaluations().length }} 件表示中</span>
-          </header>
+        <section class="page-section">
+          <article class="surface-panel page-panel evaluations-page__history">
+            <header class="evaluations-page__history-header">
+              <div>
+                <h2>過去の評価履歴</h2>
+                <p>最大 12 件まで表示します。詳細を開いて改善ポイントを再確認できます。</p>
+              </div>
+              <span class="evaluations-page__history-count"
+                >{{ evaluations().length }} 件表示中</span
+              >
+            </header>
 
-          @if (history().length === 0) {
-            <p class="history__empty">最新の判定のみが登録されています。</p>
-          } @else {
-            <ul class="history__list">
-              @for (item of history(); track item.id) {
-                <li class="history__entry">
-                  <details>
-                    <summary>
-                      <div class="history__summary">
-                        <div class="history__summary-text">
-                          <span class="history__period"
-                            >{{ item.period_start | date: 'yyyy/MM/dd' }} 〜
-                            {{ item.period_end | date: 'yyyy/MM/dd' }}</span
-                          >
-                          <span class="history__label">{{
-                            item.competency?.name || 'コンピテンシー評価'
-                          }}</span>
+            @if (history().length === 0) {
+              <p class="evaluations-page__history-empty">最新の判定のみが登録されています。</p>
+            } @else {
+              <ul class="evaluations-page__history-list">
+                @for (item of history(); track item.id) {
+                  <li class="evaluations-page__history-entry">
+                    <details>
+                      <summary>
+                        <div class="evaluations-page__history-summary">
+                          <div class="evaluations-page__history-summary-text">
+                            <span class="evaluations-page__history-period"
+                              >{{ item.period_start | date: 'yyyy/MM/dd' }} 〜
+                              {{ item.period_end | date: 'yyyy/MM/dd' }}</span
+                            >
+                            <span class="evaluations-page__history-label">{{
+                              item.competency?.name || 'コンピテンシー評価'
+                            }}</span>
+                          </div>
+                          <div class="evaluations-page__history-score">
+                            <span class="evaluations-page__history-score-value">{{
+                              item.score_value
+                            }}</span>
+                            <span class="evaluations-page__history-score-scale">
+                              / {{ item.scale }}
+                            </span>
+                            <span class="evaluations-page__history-score-label">{{
+                              item.score_label
+                            }}</span>
+                          </div>
                         </div>
-                        <div class="history__score">
-                          <span class="history__score-value">{{ item.score_value }}</span>
-                          <span class="history__score-scale">/ {{ item.scale }}</span>
-                          <span class="history__score-label">{{ item.score_label }}</span>
+                      </summary>
+                      <div class="evaluations-page__history-content">
+                        @if (item.rationale) {
+                          <p class="evaluations-page__history-text">{{ item.rationale }}</p>
+                        }
+                        <div class="evaluations-page__history-meta">
+                          <span>判定種別: {{ triggeredLabel(item.triggered_by) }}</span>
+                          <span>モデル: {{ item.ai_model || '未設定' }}</span>
+                          <span>記録日時: {{ item.created_at | date: 'yyyy/MM/dd HH:mm' }}</span>
                         </div>
+                        @if (
+                          hasActions(item.attitude_actions) || hasActions(item.behavior_actions)
+                        ) {
+                          <div class="evaluations-page__history-actions">
+                            @if (hasActions(item.attitude_actions)) {
+                              <div>
+                                <h4>姿勢・意識</h4>
+                                <ul>
+                                  @for (action of item.attitude_actions; track action) {
+                                    <li>{{ action }}</li>
+                                  }
+                                </ul>
+                              </div>
+                            }
+                            @if (hasActions(item.behavior_actions)) {
+                              <div>
+                                <h4>行動プラン</h4>
+                                <ul>
+                                  @for (action of item.behavior_actions; track action) {
+                                    <li>{{ action }}</li>
+                                  }
+                                </ul>
+                              </div>
+                            }
+                          </div>
+                        }
                       </div>
-                    </summary>
-                    <div class="history__content">
-                      @if (item.rationale) {
-                        <p class="history__text">{{ item.rationale }}</p>
-                      }
-                      <div class="history__meta">
-                        <span>判定種別: {{ triggeredLabel(item.triggered_by) }}</span>
-                        <span>モデル: {{ item.ai_model || '未設定' }}</span>
-                        <span>記録日時: {{ item.created_at | date: 'yyyy/MM/dd HH:mm' }}</span>
-                      </div>
-                      @if (hasActions(item.attitude_actions) || hasActions(item.behavior_actions)) {
-                        <div class="history__actions">
-                          @if (hasActions(item.attitude_actions)) {
-                            <div>
-                              <h4>姿勢・意識</h4>
-                              <ul>
-                                @for (action of item.attitude_actions; track action) {
-                                  <li>{{ action }}</li>
-                                }
-                              </ul>
-                            </div>
-                          }
-                          @if (hasActions(item.behavior_actions)) {
-                            <div>
-                              <h4>行動プラン</h4>
-                              <ul>
-                                @for (action of item.behavior_actions; track action) {
-                                  <li>{{ action }}</li>
-                                }
-                              </ul>
-                            </div>
-                          }
-                        </div>
-                      }
-                    </div>
-                  </details>
-                </li>
-              }
-            </ul>
-          }
+                    </details>
+                  </li>
+                }
+              </ul>
+            }
+          </article>
         </section>
       }
     }

--- a/frontend/src/styles/pages/_profile-evaluations.scss
+++ b/frontend/src/styles/pages/_profile-evaluations.scss
@@ -1,87 +1,32 @@
-app-profile-evaluations-page {
-  display: block;
-  color: var(--text-primary);
+.evaluations-page {
   --page-content-gap: clamp(1.75rem, 2vw, 2.5rem);
   --panel-gap: clamp(1.25rem, 2vw, 1.75rem);
-}
-
-app-profile-evaluations-page .app-page-layout {
-  display: flex;
-  flex-direction: column;
-  gap: var(--page-content-gap);
-}
-
-app-profile-evaluations-page .page-header {
-  display: flex;
-  flex-direction: column;
-  gap: var(--panel-gap);
-  padding: clamp(1.75rem, 3vw, 2.5rem);
-  border-radius: var(--radius-xl);
-  border: 1px solid var(--border-subtle);
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--accent) 14%, var(--surface-card)),
-    color-mix(in srgb, var(--info) 10%, var(--surface-card))
-  );
-  box-shadow: var(--shadow-soft);
-}
-
-app-profile-evaluations-page .page-header__content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  max-width: 48rem;
-}
-
-app-profile-evaluations-page .page-eyebrow {
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.28em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--accent) 80%, transparent);
-}
-
-app-profile-evaluations-page .page-title {
-  margin: 0;
-  font-size: clamp(2rem, 1.6rem + 1vw, 2.4rem);
-  font-weight: 700;
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .page-description {
-  margin: 0;
-  font-size: 0.95rem;
-  line-height: 1.7;
-  color: var(--text-tertiary);
-}
-
-app-profile-evaluations-page .page-header__actions {
+.evaluations-page__header {
   display: flex;
   flex-direction: column;
   gap: clamp(1rem, 2vw, 1.5rem);
 }
 
-@media (min-width: 48rem) {
-  app-profile-evaluations-page .page-header__actions {
+@media (min-width: 64rem) {
+  .evaluations-page__header {
     flex-direction: row;
     justify-content: space-between;
     align-items: stretch;
+    gap: clamp(1.25rem, 2vw, 1.75rem);
   }
 }
 
-app-profile-evaluations-page .quota-card {
+.evaluations-page__quota {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
-  border-radius: var(--radius-lg);
-  border: 1px solid color-mix(in srgb, var(--accent) 32%, transparent);
-  background: color-mix(in srgb, var(--surface-card) 82%, transparent);
-  padding: 1.25rem 1.5rem;
-  box-shadow: var(--shadow-soft);
   min-width: 0;
 }
 
-app-profile-evaluations-page .quota-card__label {
+.evaluations-page__quota-label {
   font-size: 0.78rem;
   font-weight: 600;
   letter-spacing: 0.18em;
@@ -89,7 +34,7 @@ app-profile-evaluations-page .quota-card__label {
   color: color-mix(in srgb, var(--accent) 85%, transparent);
 }
 
-app-profile-evaluations-page .quota-card__values {
+.evaluations-page__quota-values {
   display: flex;
   align-items: baseline;
   gap: 0.4rem;
@@ -98,150 +43,85 @@ app-profile-evaluations-page .quota-card__values {
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .quota-card__separator {
+.evaluations-page__quota-value--remaining {
+  color: color-mix(in srgb, var(--success) 80%, transparent);
+}
+
+.evaluations-page__quota-separator {
   font-size: 1rem;
   color: color-mix(in srgb, var(--accent) 65%, transparent);
 }
 
-app-profile-evaluations-page .quota-card__value--remaining {
-  color: color-mix(in srgb, var(--success) 80%, transparent);
-}
-
-app-profile-evaluations-page .quota-card__meta {
+.evaluations-page__quota-meta {
   font-size: 0.85rem;
   color: var(--text-muted);
 }
 
-app-profile-evaluations-page .quota-card__warning {
+.evaluations-page__quota-warning {
   font-size: 0.85rem;
   font-weight: 600;
   color: color-mix(in srgb, var(--danger) 85%, transparent);
 }
 
-app-profile-evaluations-page .quota-card__loading {
+.evaluations-page__quota-loading {
   font-size: 0.9rem;
   color: var(--text-secondary);
 }
 
-app-profile-evaluations-page .page-header__buttons {
+.evaluations-page__actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
   align-items: center;
+  justify-content: flex-start;
 }
 
-app-profile-evaluations-page .refresh-button,
-app-profile-evaluations-page .secondary-button,
-app-profile-evaluations-page .retry-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.65rem 1.4rem;
-  border-radius: 9999px;
-  border: 1px solid transparent;
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    transform 150ms ease,
-    box-shadow 150ms ease,
-    filter 150ms ease;
+@media (min-width: 64rem) {
+  .evaluations-page__actions {
+    align-self: stretch;
+    align-items: flex-end;
+    justify-content: flex-end;
+  }
 }
 
-app-profile-evaluations-page .refresh-button,
-app-profile-evaluations-page .retry-button {
-  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: var(--on-surface-inverse);
-  box-shadow: 0 18px 40px -28px var(--accent-shadow-strong-color);
+.evaluations-page__action-icon {
+  width: 1rem;
+  height: 1rem;
 }
 
-app-profile-evaluations-page .secondary-button {
-  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
-  background: color-mix(in srgb, var(--surface-card) 86%, transparent);
-  color: color-mix(in srgb, var(--accent-strong) 85%, var(--text-secondary));
+.evaluations-page__state {
+  gap: 1rem;
 }
 
-app-profile-evaluations-page .refresh-button:hover:not(:disabled),
-app-profile-evaluations-page .retry-button:hover:not(:disabled),
-app-profile-evaluations-page .secondary-button:hover:not(:disabled) {
-  transform: translateY(-1px);
-  filter: brightness(1.05);
-}
-
-app-profile-evaluations-page .refresh-button:disabled,
-app-profile-evaluations-page .secondary-button:disabled,
-app-profile-evaluations-page .retry-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-app-profile-evaluations-page .page-alert {
-  margin: 0;
-  padding: 0.85rem 1.1rem;
-  border-radius: 1rem;
-  border: 1px solid transparent;
-  font-size: 0.9rem;
-  font-weight: 600;
-}
-
-app-profile-evaluations-page .page-alert--error {
-  border-color: color-mix(in srgb, var(--danger) 38%, transparent);
-  background: color-mix(in srgb, var(--danger) 18%, transparent);
-  color: color-mix(in srgb, var(--danger-strong) 92%, var(--text-primary));
-}
-
-app-profile-evaluations-page .page-alert--success {
-  border-color: color-mix(in srgb, var(--success) 38%, transparent);
-  background: color-mix(in srgb, var(--success) 18%, transparent);
-  color: color-mix(in srgb, var(--success-strong) 92%, var(--text-primary));
-}
-
-app-profile-evaluations-page .state {
-  display: grid;
-  gap: 0.75rem;
-  place-items: center;
-  padding: 3rem 1.75rem;
-  border-radius: var(--radius-xl);
-  border: 2px dashed var(--border-subtle);
-  background: color-mix(in srgb, var(--surface-card) 82%, transparent);
-  text-align: center;
-  color: var(--text-secondary);
-}
-
-app-profile-evaluations-page .state--error {
-  border-style: solid;
-  border-color: color-mix(in srgb, var(--danger) 45%, transparent);
-  background: color-mix(in srgb, var(--danger) 22%, transparent);
-  color: color-mix(in srgb, var(--danger-strong) 92%, var(--text-primary));
-}
-
-app-profile-evaluations-page .state__spinner {
+.evaluations-page__spinner {
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 9999px;
   border: 3px solid color-mix(in srgb, var(--text-tertiary) 35%, transparent);
   border-top-color: var(--accent);
-  animation: spin 1s linear infinite;
+  animation: evaluations-page-spin 1s linear infinite;
 }
 
-app-profile-evaluations-page .latest {
+.evaluations-page__empty-icon {
+  width: 3rem;
+  height: 3rem;
+  color: var(--text-muted);
+}
+
+.evaluations-page__latest {
   display: flex;
   flex-direction: column;
   gap: var(--panel-gap);
 }
 
-app-profile-evaluations-page .latest__header {
+.evaluations-page__latest-header {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
 }
 
 @media (min-width: 54rem) {
-  app-profile-evaluations-page .latest__header {
+  .evaluations-page__latest-header {
     flex-direction: row;
     justify-content: space-between;
     align-items: flex-start;
@@ -249,14 +129,14 @@ app-profile-evaluations-page .latest__header {
   }
 }
 
-app-profile-evaluations-page .latest__summary {
+.evaluations-page__latest-summary {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
   color: var(--text-secondary);
 }
 
-app-profile-evaluations-page .latest__eyebrow {
+.evaluations-page__latest-eyebrow {
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.24em;
@@ -264,14 +144,14 @@ app-profile-evaluations-page .latest__eyebrow {
   color: color-mix(in srgb, var(--accent) 75%, transparent);
 }
 
-app-profile-evaluations-page .latest__title {
+.evaluations-page__latest-title {
   margin: 0;
   font-size: clamp(1.4rem, 1.2rem + 0.8vw, 1.8rem);
   font-weight: 700;
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .latest__meta {
+.evaluations-page__latest-meta {
   margin: 0;
   font-size: 0.85rem;
   color: var(--text-muted);
@@ -280,7 +160,7 @@ app-profile-evaluations-page .latest__meta {
   gap: 0.35rem 0.65rem;
 }
 
-app-profile-evaluations-page .latest__score {
+.evaluations-page__latest-score {
   display: grid;
   gap: 0.5rem;
   padding: 1.35rem 1.5rem;
@@ -295,28 +175,28 @@ app-profile-evaluations-page .latest__score {
   min-width: 14rem;
 }
 
-app-profile-evaluations-page .latest__score-value {
+.evaluations-page__latest-score-value {
   font-size: clamp(1.8rem, 1.4rem + 1vw, 2.4rem);
   font-weight: 700;
 }
 
-app-profile-evaluations-page .latest__score-scale {
+.evaluations-page__latest-score-scale {
   margin-left: 0.15em;
   font-size: 1rem;
   font-weight: 600;
 }
 
-app-profile-evaluations-page .latest__score-label {
+.evaluations-page__latest-score-label {
   font-size: 0.9rem;
   font-weight: 600;
 }
 
-app-profile-evaluations-page .latest__score-percent {
+.evaluations-page__latest-score-percent {
   font-size: 0.8rem;
   color: color-mix(in srgb, var(--accent) 85%, transparent);
 }
 
-app-profile-evaluations-page .latest__progress {
+.evaluations-page__latest-progress {
   height: 0.5rem;
   border-radius: 9999px;
   background: color-mix(in srgb, var(--surface-card) 82%, transparent);
@@ -324,49 +204,49 @@ app-profile-evaluations-page .latest__progress {
   overflow: hidden;
 }
 
-app-profile-evaluations-page .latest__progress-bar {
+.evaluations-page__latest-progress-bar {
   height: 100%;
   border-radius: inherit;
   background: linear-gradient(90deg, var(--accent), var(--accent-strong));
 }
 
-app-profile-evaluations-page .latest__body {
+.evaluations-page__latest-body {
   display: flex;
   flex-direction: column;
   gap: clamp(1.2rem, 2vw, 1.8rem);
 }
 
-app-profile-evaluations-page .latest__section {
+.evaluations-page__latest-section {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-app-profile-evaluations-page .latest__section h3 {
+.evaluations-page__latest-section h3 {
   margin: 0;
   font-size: 1.05rem;
   font-weight: 600;
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .latest__text {
+.evaluations-page__latest-text {
   margin: 0;
   color: var(--text-secondary);
   line-height: 1.7;
 }
 
-app-profile-evaluations-page .latest__actions-grid {
+.evaluations-page__latest-actions-grid {
   display: grid;
   gap: 1rem;
 }
 
 @media (min-width: 50rem) {
-  app-profile-evaluations-page .latest__actions-grid {
+  .evaluations-page__latest-actions-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-app-profile-evaluations-page .latest__action {
+.evaluations-page__latest-action {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -376,27 +256,27 @@ app-profile-evaluations-page .latest__action {
   padding: 1rem 1.2rem;
 }
 
-app-profile-evaluations-page .latest__action header {
+.evaluations-page__latest-action header {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
 }
 
-app-profile-evaluations-page .latest__action header h3 {
+.evaluations-page__latest-action header h3 {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .latest__action header p {
+.evaluations-page__latest-action header p {
   margin: 0;
   font-size: 0.85rem;
   color: var(--text-muted);
   line-height: 1.6;
 }
 
-app-profile-evaluations-page .latest__action ul {
+.evaluations-page__latest-action ul {
   margin: 0;
   padding-left: 1.1rem;
   display: grid;
@@ -404,30 +284,30 @@ app-profile-evaluations-page .latest__action ul {
   color: var(--text-secondary);
 }
 
-app-profile-evaluations-page .latest__empty {
+.evaluations-page__latest-empty {
   margin: 0;
   font-size: 0.9rem;
   color: var(--text-muted);
 }
 
-app-profile-evaluations-page .latest__details {
+.evaluations-page__latest-details {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-app-profile-evaluations-page .latest__items {
+.evaluations-page__latest-items {
   display: grid;
   gap: 1rem;
 }
 
 @media (min-width: 60rem) {
-  app-profile-evaluations-page .latest__items {
+  .evaluations-page__latest-items {
     grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
   }
 }
 
-app-profile-evaluations-page .latest__item {
+.evaluations-page__latest-item {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -437,25 +317,25 @@ app-profile-evaluations-page .latest__item {
   padding: 1rem 1.2rem;
 }
 
-app-profile-evaluations-page .latest__item header {
+.evaluations-page__latest-item header {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
   gap: 0.75rem;
 }
 
-app-profile-evaluations-page .latest__item-title {
+.evaluations-page__latest-item-title {
   font-size: 0.95rem;
   font-weight: 600;
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .latest__item-score {
+.evaluations-page__latest-item-score {
   font-size: 0.85rem;
   color: var(--text-muted);
 }
 
-app-profile-evaluations-page .latest__item-body {
+.evaluations-page__latest-item-body {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
@@ -463,24 +343,24 @@ app-profile-evaluations-page .latest__item-body {
   line-height: 1.6;
 }
 
-app-profile-evaluations-page .latest__item-text {
+.evaluations-page__latest-item-text {
   margin: 0;
 }
 
-app-profile-evaluations-page .latest__item-actions {
+.evaluations-page__latest-item-actions {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
 }
 
-app-profile-evaluations-page .latest__item-actions h4 {
+.evaluations-page__latest-item-actions h4 {
   margin: 0;
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .latest__item-actions ul {
+.evaluations-page__latest-item-actions ul {
   margin: 0;
   padding-left: 1.1rem;
   display: grid;
@@ -488,54 +368,52 @@ app-profile-evaluations-page .latest__item-actions ul {
   color: var(--text-secondary);
 }
 
-app-profile-evaluations-page .history {
+.evaluations-page__history {
   display: flex;
   flex-direction: column;
   gap: clamp(1.2rem, 2vw, 1.6rem);
 }
 
-app-profile-evaluations-page .history__header {
+.evaluations-page__history-header {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
 }
 
 @media (min-width: 54rem) {
-  app-profile-evaluations-page .history__header {
+  .evaluations-page__history-header {
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
   }
 }
 
-app-profile-evaluations-page .history__header h2 {
+.evaluations-page__history-header h2 {
   margin: 0;
   font-size: 1.2rem;
   font-weight: 700;
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .history__header p {
+.evaluations-page__history-header p {
   margin: 0;
   font-size: 0.9rem;
   color: var(--text-muted);
 }
 
-app-profile-evaluations-page .history__count {
+.evaluations-page__history-count {
   font-size: 0.85rem;
-  color: var(--text-muted);
-}
-
-app-profile-evaluations-page .history__empty {
-  margin: 0;
-  padding: 0.85rem 1rem;
-  border-radius: 1rem;
-  border: 1px dashed var(--border-subtle);
-  background: color-mix(in srgb, var(--surface-card) 82%, transparent);
+  font-weight: 600;
   color: var(--text-secondary);
 }
 
-app-profile-evaluations-page .history__list {
+.evaluations-page__history-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.evaluations-page__history-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -543,7 +421,7 @@ app-profile-evaluations-page .history__list {
   gap: 1rem;
 }
 
-app-profile-evaluations-page .history__entry details {
+.evaluations-page__history-entry details {
   border-radius: 1.25rem;
   border: 1px solid var(--border-subtle);
   background: color-mix(in srgb, var(--surface-card) 85%, transparent);
@@ -551,48 +429,48 @@ app-profile-evaluations-page .history__entry details {
   box-shadow: var(--shadow-soft);
 }
 
-app-profile-evaluations-page .history__entry summary {
+.evaluations-page__history-entry summary {
   cursor: pointer;
   list-style: none;
   padding: 1rem 1.2rem;
 }
 
-app-profile-evaluations-page .history__entry summary::-webkit-details-marker {
+.evaluations-page__history-entry summary::-webkit-details-marker {
   display: none;
 }
 
-app-profile-evaluations-page .history__summary {
+.evaluations-page__history-summary {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
 
 @media (min-width: 48rem) {
-  app-profile-evaluations-page .history__summary {
+  .evaluations-page__history-summary {
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
   }
 }
 
-app-profile-evaluations-page .history__summary-text {
+.evaluations-page__history-summary-text {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
   color: var(--text-secondary);
 }
 
-app-profile-evaluations-page .history__period {
+.evaluations-page__history-period {
   font-weight: 600;
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .history__label {
+.evaluations-page__history-label {
   font-size: 0.85rem;
   color: var(--text-muted);
 }
 
-app-profile-evaluations-page .history__score {
+.evaluations-page__history-score {
   display: flex;
   align-items: baseline;
   gap: 0.4rem;
@@ -600,21 +478,21 @@ app-profile-evaluations-page .history__score {
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .history__score-value {
+.evaluations-page__history-score-value {
   font-size: 1.2rem;
 }
 
-app-profile-evaluations-page .history__score-scale {
+.evaluations-page__history-score-scale {
   font-size: 0.9rem;
   color: var(--text-muted);
 }
 
-app-profile-evaluations-page .history__score-label {
+.evaluations-page__history-score-label {
   font-size: 0.8rem;
   color: color-mix(in srgb, var(--accent-strong) 80%, transparent);
 }
 
-app-profile-evaluations-page .history__content {
+.evaluations-page__history-content {
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
@@ -622,12 +500,12 @@ app-profile-evaluations-page .history__content {
   color: var(--text-secondary);
 }
 
-app-profile-evaluations-page .history__text {
+.evaluations-page__history-text {
   margin: 0;
   line-height: 1.6;
 }
 
-app-profile-evaluations-page .history__meta {
+.evaluations-page__history-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem 0.85rem;
@@ -635,28 +513,38 @@ app-profile-evaluations-page .history__meta {
   color: var(--text-muted);
 }
 
-app-profile-evaluations-page .history__actions {
+.evaluations-page__history-actions {
   display: grid;
   gap: 1rem;
 }
 
 @media (min-width: 40rem) {
-  app-profile-evaluations-page .history__actions {
+  .evaluations-page__history-actions {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-app-profile-evaluations-page .history__actions h4 {
+.evaluations-page__history-actions h4 {
   margin: 0 0 0.35rem;
   font-size: 0.9rem;
   font-weight: 600;
   color: var(--text-primary);
 }
 
-app-profile-evaluations-page .history__actions ul {
+.evaluations-page__history-actions ul {
   margin: 0;
   padding-left: 1.1rem;
   display: grid;
   gap: 0.3rem;
   color: var(--text-secondary);
+}
+
+@keyframes evaluations-page-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
## Summary
- restructure the competency evaluations page to use the shared page layout wrappers and standard button styles
- swap legacy alert/state markup for app-alert and page-state patterns to match other views
- rewrite the profile evaluations styles with scoped BEM classes that align spacing, typography, and cards with the global design system

## Testing
- npx prettier --check src/app/features/profile/evaluations/page.html src/styles/pages/_profile-evaluations.scss
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless binary not available in container)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d51cfc1e688320b31dc91e911ce052