### PR TITLE
Improve responsive card layouts

### DIFF
--- a/docs/ui-design-system.md
+++ b/docs/ui-design-system.md
@@ -86,11 +86,11 @@
 - ホバー時は背景トーンを 6% 明るく（ダークでは 6% 暗く）し、アクションの存在を示す。文字色は変えずに 4.5:1 を維持する。
 
 ### カードコンテナ（Card Container）
-- 複数のカードを並べる場合は `.card-collection` を用意し、`display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 24px;` を基本とする。
-- カンバン形式では `.board-columns` を使用し、列ヘッダーもカードと同じスタイルで揃える。列間余白は 24px。
+- 複数のカードを並べる場合は `.card-collection` を用意し、`display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: 24px;` を基本とする。これにより画面幅に応じて 1〜3 列まで自然にリフローし、余白を保ちながら情報密度を最適化する。
+- カンバン形式では `.board-columns` を使用し、`repeat(auto-fit, minmax(19rem, 1fr))` のグリッドで列幅を自動調整する。列ヘッダーもカードと同じスタイルで揃え、列間余白は 24px を目安にする。
 
 ### リスト & テーブル
-- `.page-list` は縦方向のカード群を軽量に表現するスタイル。各アイテムは 16px の上下余白とボーダーで区切る。
+- `.page-list` は縦方向のカード群を軽量に表現するスタイル。`grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr))` で最大 3 列まで展開し、ビューポートに応じて 1 列へ自動的に戻る。各アイテムは 16px の上下余白とボーダーで区切る。
 - テーブルは `.page-table` を基準に、ヘッダ背景を `--color-surface-alt`、セル余白は 16px とする。斜線や濃い罫線は使用せず、ストライプで視認性を確保。
 
 ### フォーム

--- a/frontend/src/styles/pages/_base.scss
+++ b/frontend/src/styles/pages/_base.scss
@@ -364,6 +364,7 @@
   padding: 0;
   display: grid;
   gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
 }
 
 .page-list__item {
@@ -375,6 +376,8 @@
   background: color-mix(in srgb, var(--surface-card) 85%, transparent);
   padding: 1.1rem 1.2rem;
   box-shadow: var(--shadow-soft);
+  min-width: 0;
+  height: 100%;
 }
 
 .page-list__heading {

--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -485,25 +485,18 @@
 }
 
 .board-columns {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-  align-items: stretch;
-}
-
-.board-columns {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   gap: clamp(1rem, 2vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 19rem), 1fr));
+  align-items: stretch;
 }
 
 .board-column {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  flex: 1 1 20rem;
-  min-width: min(20rem, 100%);
-  max-width: min(24rem, 100%);
+  min-width: 0;
+  height: 100%;
   padding: 1.5rem;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
@@ -874,10 +867,12 @@
   opacity: 0;
 }
 
+.subtask-columns {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+}
+
 .subtask-columns .board-column {
-  flex: 1 1 18rem;
-  min-width: min(18rem, 100%);
-  max-width: min(22rem, 100%);
+  min-width: 0;
 }
 
 .subtask-card {


### PR DESCRIPTION
## Summary
- switch page list and kanban columns to auto-fit grid layouts so cards can flow into multiple columns responsively
- tune subtask column sizing and card stretching to remove unnecessary width
- update the UI design system documentation to capture the new responsive grid guidance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d51e4d65f48320bd44aca21ee6d055