### PR TITLE
Fix Sonar workflow Node cache path

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
         working-directory: frontend


### PR DESCRIPTION
## Summary
- point the SonarQube workflow's Node cache to the frontend lockfile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5283900988320b60ea0c78ce79ee5