### PR TITLE
docs: align karma test documentation with chromium setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ npm test
 npm run lint
 npm run format:check
 ```
+`npm test` は Angular CLI (`ng test`) を実行し、Karma は環境変数 `CHROME_BIN=/usr/bin/chromium-browser` に設定された Chromium を利用します。
 Backend dependencies include pytest, while linting/formatting rules are configured via Ruff and
 Black. Frontend scripts rely on the npm commands declared in `package.json`.【F:backend/requirements.txt†L1-L13】【F:pyproject.toml†L1-L28】【F:frontend/package.json†L4-L12】
 

--- a/docs/development-rules.md
+++ b/docs/development-rules.md
@@ -16,8 +16,9 @@
 3. **品質チェックを実行する**  
    - **実際に修正を加えた領域のみ対象**とし、必要なケースだけテスト・チェックを走らせる。  
    - 実行対象は以下のとおり。  
-     - バックエンド: `pytest backend/tests`  
-     - フロントエンド（Chrome 不要環境対応）: `cd frontend && npm test -- --watchAll=false --runInBand --testEnvironment=jsdom`  
+    - バックエンド: `pytest backend/tests`
+    - フロントエンド: `cd frontend && npm test`
+      - Karma は環境変数 `CHROME_BIN=/usr/bin/chromium-browser` に設定された Chromium を利用する。
      - コードフォーマット: `black --check`（変更ファイルのみを対象とする）  
      - 静的解析: `ruff check`（変更ファイルのみを対象とする）  
      - フロントエンドフォーマット: `cd frontend && npm run format:check`（変更ファイルのみを対象とする）  
@@ -68,7 +69,7 @@
     "quality_checks": {
       "normal_changes": {
         "backend_tests": "pytest backend/tests",
-        "frontend_tests": "cd frontend && npm test -- --watchAll=false --runInBand --testEnvironment=jsdom",
+        "frontend_tests": "cd frontend && npm test",
         "formatting": [
           "black --check （変更ファイルのみ）",
           "cd frontend && npm run format:check （変更ファイルのみ）"


### PR DESCRIPTION
## Summary
- update development rules to reference the correct Angular test command and document the CHROME_BIN-based Chromium setup
- clarify in the README that npm test relies on ng test with Chromium resolved via the CHROME_BIN environment variable

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d527f17f2c8320bf59bfd3d1eb62ba