### PR TITLE
Add unit tests for secrets utilities and signal forms

### DIFF
--- a/backend/tests/utils/test_secrets.py
+++ b/backend/tests/utils/test_secrets.py
@@ -1,0 +1,34 @@
+import pytest
+
+from app.utils.crypto import SecretCipher
+from app.utils.secrets import build_secret_hint, get_secret_cipher
+
+
+@pytest.mark.parametrize(
+    "secret,expected",
+    [
+        ("", ""),
+        ("short", "sh****ort"),
+        ("longersecret", "long****cret"),
+    ],
+)
+def test_build_secret_hint_default_mask(secret: str, expected: str) -> None:
+    assert build_secret_hint(secret) == expected
+
+
+def test_build_secret_hint_allows_custom_mask_character() -> None:
+    result = build_secret_hint("visible", mask_char="#")
+    assert result.startswith("vis")
+    assert result.endswith("ble")
+    assert "#" in result
+
+
+def test_get_secret_cipher_uses_application_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.config.settings.secret_encryption_key", "custom-key")
+
+    cipher = get_secret_cipher()
+
+    assert isinstance(cipher, SecretCipher)
+    encrypted = cipher.encrypt("sensitive value")
+    assert encrypted
+    assert cipher.decrypt(encrypted) == "sensitive value"

--- a/frontend/src/app/lib/forms/signal-forms.spec.ts
+++ b/frontend/src/app/lib/forms/signal-forms.spec.ts
@@ -1,0 +1,58 @@
+import { createSignalForm } from './signal-forms';
+
+describe('createSignalForm', () => {
+  it('exposes writable controls backed by signals', () => {
+    const form = createSignalForm({ email: 'user@example.com', password: 'secret' });
+
+    expect(form.controls.email.value()).toBe('user@example.com');
+    expect(form.controls.password.value()).toBe('secret');
+
+    form.controls.email.setValue('next@example.com');
+    form.controls.password.updateValue((previous) => `${previous}!`);
+
+    expect(form.controls.email.value()).toBe('next@example.com');
+    expect(form.controls.password.value()).toBe('secret!');
+    expect(form.value()).toEqual({ email: 'next@example.com', password: 'secret!' });
+  });
+
+  it('patches a subset of fields without mutating others', () => {
+    const form = createSignalForm({ email: 'user@example.com', password: 'secret' });
+
+    form.patchValue({ password: 'updated' });
+
+    expect(form.value()).toEqual({ email: 'user@example.com', password: 'updated' });
+
+    form.patchValue({ email: 'new@example.com', missing: 'ignore-me' } as unknown as {
+      email: string;
+      password: string;
+    });
+
+    expect(form.value()).toEqual({ email: 'new@example.com', password: 'updated' });
+  });
+
+  it('resets to the initial value or the provided override', () => {
+    const form = createSignalForm({ email: 'user@example.com', password: 'secret' });
+
+    form.patchValue({ email: 'new@example.com', password: 'updated' });
+    expect(form.value()).toEqual({ email: 'new@example.com', password: 'updated' });
+
+    form.reset();
+    expect(form.value()).toEqual({ email: 'user@example.com', password: 'secret' });
+
+    form.reset({ email: 'override@example.com', password: 'override' });
+    expect(form.value()).toEqual({ email: 'override@example.com', password: 'override' });
+  });
+
+  it('invokes submit handlers with the latest snapshot', () => {
+    const form = createSignalForm({ email: 'user@example.com', password: 'secret' });
+
+    const handler =
+      jasmine.createSpy<(value: { email: string; password: string }) => void>('handler');
+    const submit = form.submit(handler);
+
+    form.controls.password.setValue('updated');
+    submit();
+
+    expect(handler).toHaveBeenCalledWith({ email: 'user@example.com', password: 'updated' });
+  });
+});


### PR DESCRIPTION
## Summary
- add pytest coverage for the secrets utility helpers
- verify masking and cipher behaviour across edge cases
- add Angular unit tests for the signal form helper to cover patch, reset, and submit flows

## Testing
- pytest backend/tests/utils/test_secrets.py
- npx prettier --check src/app/lib/forms/signal-forms.spec.ts
- npx eslint src/app/lib/forms/signal-forms.spec.ts
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: Chrome binary unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d52de2fe808320b3a85b7d1c2d87f7