### PR TITLE
Adjust analyze form textarea height

### DIFF
--- a/frontend/src/styles/pages/_analyze.scss
+++ b/frontend/src/styles/pages/_analyze.scss
@@ -1,4 +1,6 @@
 .analyze-page {
+  --analyze-composer-input-min-block-size: clamp(12rem, 18vw, 16rem);
+
   display: flex;
   flex-direction: column;
   gap: var(--page-content-gap);
@@ -9,7 +11,7 @@
 }
 
 .analyze-page__notes-input {
-  min-height: clamp(16rem, 24vw, 20rem);
+  min-height: var(--analyze-composer-input-min-block-size);
 }
 
 .analyze-page__notes-hint {
@@ -124,7 +126,7 @@
 }
 
 .analyze-page__objective-manual textarea {
-  min-height: clamp(12rem, 18vw, 16rem);
+  min-height: var(--analyze-composer-input-min-block-size);
 }
 
 .analyze-page__form-actions {


### PR DESCRIPTION
## Summary
- unify the analyze page composer textarea heights with a shared CSS custom property
- reduce the note textarea minimum height to align with the goal section and remove excess whitespace

## Testing
- npx prettier --check src/styles/pages/_analyze.scss
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5314e6d048320828d2adf31a29930