### PR TITLE
refactor: rename daily reports feature

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -32,8 +32,15 @@ export const appRoutes: Routes = [
       },
       {
         path: 'daily-reports',
+        pathMatch: 'full',
+        redirectTo: 'reports',
+      },
+      {
+        path: 'reports',
         loadComponent: () =>
-          import('@features/daily-reports/page').then((mod) => mod.DailyReportsPage),
+          import('@features/reports/reports-page.component').then(
+            (mod) => mod.ReportAssistantPageComponent,
+          ),
       },
       {
         path: 'analytics',

--- a/frontend/src/app/core/api/admin-api.service.ts
+++ b/frontend/src/app/core/api/admin-api.service.ts
@@ -28,10 +28,7 @@ export class AdminApiService {
     return this.http.post<Competency>(buildApiUrl('/admin/competencies'), payload);
   }
 
-  public updateCompetency(
-    id: string,
-    payload: Partial<CompetencyInput>,
-  ): Observable<Competency> {
+  public updateCompetency(id: string, payload: Partial<CompetencyInput>): Observable<Competency> {
     return this.http.patch<Competency>(buildApiUrl(`/admin/competencies/${id}`), payload);
   }
 

--- a/frontend/src/app/core/layout/shell/shell.ts
+++ b/frontend/src/app/core/layout/shell/shell.ts
@@ -103,7 +103,7 @@ export class Shell {
     const links = [
       { path: '/board', label: 'ボード' },
       { path: '/input', label: 'タスク起票' },
-      { path: '/daily-reports', label: '日報・週報解析' },
+      { path: '/reports', label: '日報・週報解析' },
       { path: '/analytics', label: '分析' },
       { path: '/profile/evaluations', label: 'コンピテンシー' },
       { path: '/settings', label: '設定' },

--- a/frontend/src/app/core/profile/profile-dialog.ts
+++ b/frontend/src/app/core/profile/profile-dialog.ts
@@ -140,10 +140,7 @@ const ROLE_TREE_DEFINITION = [
       {
         label: 'フルスタック',
         valuePrefix: 'フルスタック',
-        options: [
-          { label: 'フルスタック開発' },
-          { label: '技術選定・アーキテクチャ' },
-        ],
+        options: [{ label: 'フルスタック開発' }, { label: '技術選定・アーキテクチャ' }],
       },
     ],
   },
@@ -418,12 +415,7 @@ export class ProfileDialogComponent implements AfterViewInit {
   });
 
   public readonly hasValidationErrors = computed(() =>
-    Boolean(
-      this.nicknameError() ||
-        this.experienceError() ||
-        this.bioError() ||
-        this.rolesError(),
-    ),
+    Boolean(this.nicknameError() || this.experienceError() || this.bioError() || this.rolesError()),
   );
 
   public readonly experienceDisplay = computed(() => {

--- a/frontend/src/app/features/admin/page.html
+++ b/frontend/src/app/features/admin/page.html
@@ -5,7 +5,6 @@
   description="コンピテンシー設定・判定・ユーザ権限・API キーをまとめて管理できます。"
   headingLevel="h1"
 >
-
   @if (error(); as message) {
     <div class="app-alert app-alert--error" role="alert">
       <span>{{ message }}</span>

--- a/frontend/src/app/features/admin/page.ts
+++ b/frontend/src/app/features/admin/page.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  DestroyRef,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
@@ -279,10 +273,7 @@ export class AdminPage {
     user.card_daily_limit = Number(value);
   }
 
-  public onEvaluationLimitChange(
-    user: AdminUser,
-    value: string | number | null,
-  ): void {
+  public onEvaluationLimitChange(user: AdminUser, value: string | number | null): void {
     if (value === null || value === '') {
       user.evaluation_daily_limit = null;
       return;

--- a/frontend/src/app/features/analytics/page.html
+++ b/frontend/src/app/features/analytics/page.html
@@ -5,7 +5,6 @@
   description="完了率やポイント配分に加え、指摘の傾向や原因、改善活動の進捗までひと目で確認できます。"
   headingLevel="h1"
 >
-
   <section class="page-section analytics-page__intro">
     <div class="analytics-page__intro-content">
       <p>
@@ -272,9 +271,7 @@
       <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <article class="metric-card">
           <p class="text-xs uppercase tracking-[0.2em] text-slate-400">再発率</p>
-          <p class="metric-card__value">
-            {{ overview.recurrenceRate * 100 | number: '1.0-0' }}%
-          </p>
+          <p class="metric-card__value">{{ overview.recurrenceRate * 100 | number: '1.0-0' }}%</p>
           <p class="text-xs text-slate-500">前期比 {{ formatChange(overview.recurrenceDelta) }}</p>
         </article>
         <article class="metric-card">

--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -5,7 +5,6 @@
   description="作業メモやアイデアを貼り付けると、AI がカード案とサブタスクを提案します。内容を確認し、必要なものだけボードへ追加しましょう。"
   headingLevel="h1"
 >
-
   <form class="surface-panel page-panel analyze-page__form" (submit)="handleSubmit($event)">
     <div class="form-grid form-grid--two analyze-page__composer">
       <label class="form-field analyze-page__notes">

--- a/frontend/src/app/features/reports/reports-page.component.html
+++ b/frontend/src/app/features/reports/reports-page.component.html
@@ -1,5 +1,5 @@
 <app-page-layout
-  class="daily-report-page"
+  class="report-assistant-page"
   eyebrow="AI レポートアシスタント"
   title="日報・週報解析"
   description="タグと本文を入力すると、AI がカード候補と振り返りの観点を提案します。"
@@ -9,12 +9,12 @@
     分析ダッシュボードを見る
   </a>
 
-  <div class="app-alert app-alert--notice daily-report-page__notice" role="status">
+  <div class="app-alert app-alert--notice report-assistant-page__notice" role="status">
     解析に使用した本文はカード作成後に破棄され、ワークスペースに保存されません。
   </div>
 
-  <div class="page-grid page-grid--two daily-report-page__layout">
-    <section class="surface-panel page-panel daily-report-page__form">
+  <div class="page-grid page-grid--two report-assistant-page__layout">
+    <section class="surface-panel page-panel report-assistant-page__form">
       <header class="page-section__header">
         <h2 class="page-section__title">解析に送る内容を整理する</h2>
         <p class="page-section__subtitle">
@@ -37,7 +37,7 @@
           </div>
         </div>
 
-        <div class="form-collection daily-report-page__sections" formArrayName="sections">
+        <div class="form-collection report-assistant-page__sections" formArrayName="sections">
           <header class="page-section__header">
             <h3 class="page-section__title">日報・週報セクション</h3>
             <p class="page-section__subtitle">
@@ -62,7 +62,7 @@
               </button>
             </div>
 
-            <div class="form-grid form-grid--two daily-report-page__section-grid">
+            <div class="form-grid form-grid--two report-assistant-page__section-grid">
               <div class="form-field">
                 <label class="form-field__label">タイトル</label>
                 <input
@@ -109,9 +109,9 @@
       </form>
     </section>
 
-    <aside class="daily-report-page__insights">
+    <aside class="report-assistant-page__insights">
       <section
-        class="surface-panel page-panel daily-report-page__results"
+        class="surface-panel page-panel report-assistant-page__results"
         *ngIf="detail() as active; else emptyState"
       >
         <header class="page-section__header">
@@ -121,7 +121,7 @@
           </p>
         </header>
 
-        <div class="daily-report-page__status-group">
+        <div class="report-assistant-page__status-group">
           <span class="page-badge page-badge--accent">ステータス {{ active.status }}</span>
           <span class="page-badge">カード {{ active.cards.length }} 件</span>
           <span class="page-badge">提案 {{ active.pending_proposals.length }} 件</span>
@@ -131,8 +131,8 @@
           失敗理由: {{ active.failure_reason }}
         </div>
 
-        <section class="daily-report-page__group">
-          <header class="daily-report-page__group-header">
+        <section class="report-assistant-page__group">
+          <header class="report-assistant-page__group-header">
             <h3 class="page-section__title">日報・週報本文</h3>
           </header>
           <ul class="page-list" aria-label="送信した日報の内容">
@@ -147,8 +147,8 @@
           </ul>
         </section>
 
-        <section class="daily-report-page__group" *ngIf="active.cards.length > 0">
-          <header class="daily-report-page__group-header">
+        <section class="report-assistant-page__group" *ngIf="active.cards.length > 0">
+          <header class="report-assistant-page__group-header">
             <h3 class="page-section__title">生成されたタスク</h3>
           </header>
           <ul class="page-list" aria-label="生成されたタスク">
@@ -160,7 +160,7 @@
                 </span>
               </div>
               <p class="page-list__description">{{ card.summary }}</p>
-              <div class="daily-report-page__subtasks" *ngIf="card.subtasks.length > 0">
+              <div class="report-assistant-page__subtasks" *ngIf="card.subtasks.length > 0">
                 <span class="surface-pill px-3 py-1" *ngFor="let subtask of card.subtasks">
                   {{ subtask.title }}
                 </span>
@@ -170,10 +170,10 @@
         </section>
 
         <section
-          class="daily-report-page__group"
+          class="report-assistant-page__group"
           *ngIf="active.cards.length === 0 && active.pending_proposals.length > 0"
         >
-          <header class="daily-report-page__group-header">
+          <header class="report-assistant-page__group-header">
             <h3 class="page-section__title">提案中のタスク</h3>
           </header>
           <ul class="page-list" aria-label="提案中のタスク">
@@ -182,7 +182,7 @@
                 <p class="page-list__title">{{ proposal.title }}</p>
               </div>
               <p class="page-list__description">{{ proposal.summary }}</p>
-              <div class="daily-report-page__subtasks" *ngIf="proposal.subtasks.length > 0">
+              <div class="report-assistant-page__subtasks" *ngIf="proposal.subtasks.length > 0">
                 <span class="surface-pill px-3 py-1" *ngFor="let sub of proposal.subtasks">
                   {{ sub.title }}
                 </span>
@@ -191,8 +191,8 @@
           </ul>
         </section>
 
-        <section class="daily-report-page__group">
-          <header class="daily-report-page__group-header">
+        <section class="report-assistant-page__group">
+          <header class="report-assistant-page__group-header">
             <h3 class="page-section__title">イベント履歴</h3>
           </header>
           <ul class="page-list" aria-label="イベント履歴">
@@ -209,7 +209,7 @@
       </section>
 
       <ng-template #emptyState>
-        <section class="surface-panel page-panel daily-report-page__results">
+        <section class="surface-panel page-panel report-assistant-page__results">
           <header class="page-section__header">
             <h2 class="page-section__title">解析結果</h2>
             <p class="page-section__subtitle">

--- a/frontend/src/app/features/reports/reports-page.component.ts
+++ b/frontend/src/app/features/reports/reports-page.component.ts
@@ -10,13 +10,13 @@ import { DailyReportDetail, DailyReportCreateRequest } from '@core/models';
 import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 
 @Component({
-  selector: 'app-daily-reports-page',
+  selector: 'app-report-assistant-page',
   standalone: true,
   imports: [CommonModule, ReactiveFormsModule, RouterLink, PageLayoutComponent],
-  templateUrl: './page.html',
+  templateUrl: './reports-page.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DailyReportsPage {
+export class ReportAssistantPageComponent {
   private readonly gateway = inject(DailyReportsGateway);
   private readonly fb = inject(FormBuilder);
 

--- a/frontend/src/app/features/settings/page.html
+++ b/frontend/src/app/features/settings/page.html
@@ -5,7 +5,6 @@
   description="ステータスやラベル、テンプレートを更新してチームの運用に合わせましょう。"
   headingLevel="h1"
 >
-
   <div class="page-grid page-grid--two settings-page__grid">
     <section class="page-section settings-panel">
       <header class="page-section__header">

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -3,7 +3,7 @@
 @use './styles/pages/board';
 @use './styles/pages/analytics';
 @use './styles/pages/analyze';
-@use './styles/pages/daily-reports';
+@use './styles/pages/report-assistant';
 @use './styles/pages/auth';
 @use './styles/pages/admin';
 @use './styles/pages/settings';

--- a/frontend/src/styles/pages/_report-assistant.scss
+++ b/frontend/src/styles/pages/_report-assistant.scss
@@ -1,69 +1,69 @@
-.daily-report-page {
+.report-assistant-page {
   display: flex;
   flex-direction: column;
   gap: var(--page-content-gap);
 }
 
-.daily-report-page__notice {
+.report-assistant-page__notice {
   margin: 0;
 }
 
-.daily-report-page__layout {
+.report-assistant-page__layout {
   align-items: start;
 }
 
-.daily-report-page__form,
-.daily-report-page__results {
+.report-assistant-page__form,
+.report-assistant-page__results {
   display: flex;
   flex-direction: column;
   gap: var(--panel-gap);
 }
 
-.daily-report-page__sections {
+.report-assistant-page__sections {
   gap: clamp(1rem, 1.4vw, 1.5rem);
 }
 
-.daily-report-page__section-grid {
+.report-assistant-page__section-grid {
   align-items: start;
 }
 
-.daily-report-page__insights {
+.report-assistant-page__insights {
   display: flex;
   flex-direction: column;
   gap: var(--page-content-gap);
 }
 
-.daily-report-page__status-group {
+.report-assistant-page__status-group {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
 }
 
-.daily-report-page__group {
+.report-assistant-page__group {
   display: flex;
   flex-direction: column;
   gap: clamp(0.85rem, 1.4vw, 1.1rem);
 }
 
-.daily-report-page__group-header {
+.report-assistant-page__group-header {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
 }
 
-.daily-report-page__subtasks {
+.report-assistant-page__subtasks {
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
 }
 
-.daily-report-page__subtasks .surface-pill {
+.report-assistant-page__subtasks .surface-pill {
   font-size: 0.8rem;
   padding: 0.35rem 0.75rem;
 }
 
 @media (max-width: 45rem) {
-  .daily-report-page__status-group {
+  .report-assistant-page__status-group {
     gap: 0.35rem;
   }
 }


### PR DESCRIPTION
## Summary
- rename the daily report assistant feature to `reports`, updating the lazy route, navigation link, and providing a redirect from the old path
- rename the standalone page component/template and update markup/styles to use the new `report-assistant` naming
- run prettier to satisfy repository formatting rules across affected frontend files

## Testing
- npm run format:check
- npm test -- --watch=false *(fails: Chrome browser binary is unavailable in the container)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d52edfe078832086c12ff8128d3d51