### PR TITLE
Fix TypeScript module resolution for Angular build

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,6 +14,7 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "preserve",
+    "moduleResolution": "bundler",
     "baseUrl": "src",
     "paths": {
       "@app/*": ["app/*"],


### PR DESCRIPTION
## Summary
- ensure the Angular frontend uses the bundler module resolution strategy so node_modules (e.g. @angular/core) are discovered during compilation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d533bed2148320af6cf95acd7e80f9