### PR TITLE
Reduce shell workspace side padding

### DIFF
--- a/frontend/src/app/core/layout/shell/shell.scss
+++ b/frontend/src/app/core/layout/shell/shell.scss
@@ -1,6 +1,6 @@
 :host {
   display: block;
-  --shell-inline-padding: clamp(1rem, 3vw, 2.5rem);
+  --shell-inline-padding: clamp(0.75rem, 1.75vw, 2rem);
   --shell-max-width: min(100%, 120rem);
 }
 


### PR DESCRIPTION
## Summary
- decrease the workspace shell inline padding clamp to reduce unused side spacing on all pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d53653752c83208c010dd1803491a5