### PR TITLE
feat: redesign competency next actions grid

### DIFF
--- a/frontend/src/app/features/profile/evaluations/page.html
+++ b/frontend/src/app/features/profile/evaluations/page.html
@@ -158,39 +158,32 @@
                   </section>
                 }
 
-                <section class="evaluations-page__latest-actions-grid">
-                  <article class="evaluations-page__latest-action">
-                    <header>
-                      <h3>姿勢・意識面でのアクション</h3>
-                      <p>モチベーションやコミュニケーションの観点で意識したいポイントです。</p>
-                    </header>
-                    @if (hasActions(evaluation.attitude_actions)) {
-                      <ul>
-                        @for (action of evaluation.attitude_actions; track action) {
-                          <li>{{ action }}</li>
-                        }
-                      </ul>
-                    } @else {
-                      <p class="evaluations-page__latest-empty">推奨事項は特にありません。</p>
-                    }
-                  </article>
-                  <article class="evaluations-page__latest-action">
-                    <header>
-                      <h3>具体的な行動プラン</h3>
-                      <p>すぐに実行できるタスクや振り返りポイントをまとめています。</p>
-                    </header>
-                    @if (hasActions(evaluation.behavior_actions)) {
-                      <ul>
-                        @for (action of evaluation.behavior_actions; track action) {
-                          <li>{{ action }}</li>
-                        }
-                      </ul>
-                    } @else {
-                      <p class="evaluations-page__latest-empty">
-                        特筆すべきアクションはありません。
-                      </p>
-                    }
-                  </article>
+                <section class="evaluations-page__latest-section evaluations-page__next-actions">
+                  <header class="evaluations-page__next-actions-header">
+                    <h3>ネクストアクション</h3>
+                    <p>
+                      モチベーションやコミュニケーションで意識したいポイントと、すぐに実行できる行動プランを
+                      まとめています。
+                    </p>
+                  </header>
+
+                  @if (latestNextActions().length > 0) {
+                    <ul class="evaluations-page__next-actions-grid" role="list">
+                      @for (action of latestNextActions(); track action.id) {
+                        <li class="evaluations-page__next-action-card">
+                          <span
+                            class="evaluations-page__next-action-category"
+                            [attr.title]="action.description"
+                          >
+                            {{ action.categoryLabel }}
+                          </span>
+                          <p class="evaluations-page__next-action-text">{{ action.text }}</p>
+                        </li>
+                      }
+                    </ul>
+                  } @else {
+                    <p class="evaluations-page__latest-empty">推奨事項は特にありません。</p>
+                  }
                 </section>
 
                 @if (evaluation.items.length > 0) {

--- a/frontend/src/styles/pages/_profile-evaluations.scss
+++ b/frontend/src/styles/pages/_profile-evaluations.scss
@@ -235,53 +235,80 @@
   line-height: 1.7;
 }
 
-.evaluations-page__latest-actions-grid {
-  display: grid;
-  gap: 1rem;
-}
-
-@media (min-width: 50rem) {
-  .evaluations-page__latest-actions-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-.evaluations-page__latest-action {
+.evaluations-page__next-actions {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  border-radius: 1.25rem;
-  border: 1px solid var(--border-subtle);
-  background: color-mix(in srgb, var(--surface-card) 86%, transparent);
-  padding: 1rem 1.2rem;
 }
 
-.evaluations-page__latest-action header {
+.evaluations-page__next-actions-header {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.4rem;
 }
 
-.evaluations-page__latest-action header h3 {
+.evaluations-page__next-actions-header h3 {
   margin: 0;
-  font-size: 1rem;
+  font-size: 1.05rem;
   font-weight: 600;
   color: var(--text-primary);
 }
 
-.evaluations-page__latest-action header p {
+.evaluations-page__next-actions-header p {
   margin: 0;
   font-size: 0.85rem;
   color: var(--text-muted);
   line-height: 1.6;
 }
 
-.evaluations-page__latest-action ul {
-  margin: 0;
-  padding-left: 1.1rem;
+.evaluations-page__next-actions-grid {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (min-width: 40rem) {
+  .evaluations-page__next-actions-grid {
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  }
+}
+
+@media (min-width: 64rem) {
+  .evaluations-page__next-actions-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.evaluations-page__next-action-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-card) 88%, transparent);
+  padding: 1rem 1.2rem;
+  min-height: 100%;
+}
+
+.evaluations-page__next-action-category {
+  align-self: flex-start;
+  padding: 0.25rem 0.65rem;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: color-mix(in srgb, var(--accent) 90%, transparent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.evaluations-page__next-action-text {
+  margin: 0;
+  font-size: 0.9rem;
   color: var(--text-secondary);
+  line-height: 1.6;
 }
 
 .evaluations-page__latest-empty {


### PR DESCRIPTION
## Summary
- rename the competency "Next Actions" section to "ネクストアクション" and surface a unified list of action cards
- derive a combined next-action dataset from evaluation results so attitude/behavior guidance renders together
- refresh page styles so the cards align in a responsive grid that fits four items across on wide displays

## Testing
- `npm run lint`
- `npm run build`
- `npx prettier --check src/app/features/profile/evaluations/page.html src/app/features/profile/evaluations/page.ts src/styles/pages/_profile-evaluations.scss`


------
https://chatgpt.com/codex/tasks/task_e_68d5354eeaf48320a9d5cb4b1e646204