### PR TITLE
Unify page padding and centralize layout styles

### DIFF
--- a/frontend/src/app/shared/ui/page-layout/page-layout.scss
+++ b/frontend/src/app/shared/ui/page-layout/page-layout.scss
@@ -1,7 +1,5 @@
 :host {
   display: block;
-  padding-inline: clamp(1.5rem, 4vw, 4.5rem);
-  padding-block: var(--page-padding-block-start) var(--page-padding-block-end);
 }
 
 :host(.shell-container) {
@@ -15,7 +13,7 @@
 }
 
 .app-page-layout__body--bleed {
-  margin-inline: calc(clamp(1.5rem, 4vw, 4.5rem) * -1);
+  margin-inline: calc(var(--page-padding-inline) * -1);
 }
 
 :host(.shell-container) .app-page-layout__body--bleed {
@@ -35,12 +33,3 @@
   margin-inline: 0;
 }
 
-@media (min-width: 80rem) {
-  :host {
-    padding-inline: clamp(3rem, 6vw, 6rem);
-  }
-
-  .app-page-layout__body--bleed {
-    margin-inline: calc(clamp(3rem, 6vw, 6rem) * -1);
-  }
-}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -80,6 +80,7 @@
   --page-content-gap: clamp(1.5rem, 3vw, 2.5rem);
   --panel-padding: clamp(1.5rem, 2vw, 2.2rem);
   --panel-gap: clamp(1.25rem, 2vw, 1.75rem);
+  --page-padding-inline: clamp(1.5rem, 4vw, 4.5rem);
   color-scheme: light;
 }
 
@@ -158,6 +159,17 @@ body {
     BlinkMacSystemFont,
     'Segoe UI',
     sans-serif;
+}
+
+.app-page {
+  padding-block: var(--page-padding-block-start) var(--page-padding-block-end);
+  padding-inline: var(--page-padding-inline);
+}
+
+@media (min-width: 80rem) {
+  :root {
+    --page-padding-inline: clamp(3rem, 6vw, 6rem);
+  }
 }
 
 a {

--- a/frontend/src/styles/pages/_base.scss
+++ b/frontend/src/styles/pages/_base.scss
@@ -1,7 +1,3 @@
-.app-page {
-  padding-block: var(--page-padding-block-start) var(--page-padding-block-end);
-}
-
 .page-panel {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a reusable `--page-padding-inline` token and `.app-page` rule so every page receives consistent horizontal and vertical padding from styles.scss
- update the shared page layout component to consume the centralized spacing token and drop duplicate clamp calculations
- clean up the page base partial now that page padding lives alongside the global styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d539284f708320aa1fcdcd858dfa30