### PR TITLE
Center login cards on auth page

### DIFF
--- a/frontend/src/styles/pages/_auth.scss
+++ b/frontend/src/styles/pages/_auth.scss
@@ -49,6 +49,7 @@
   display: grid;
   gap: clamp(2rem, 4vw, 2.5rem);
   align-items: stretch;
+  justify-items: center;
 }
 
 @media (min-width: 64rem) {
@@ -61,6 +62,8 @@
   position: relative;
   overflow: hidden;
   backdrop-filter: blur(10px);
+  width: min(28rem, 100%);
+  margin-inline: auto;
 }
 
 .auth-card::after {


### PR DESCRIPTION
## Summary
- center the auth page cards within the grid for the login screen
- constrain auth card width so the login card stays centered on wide viewports

## Testing
- npm run format:check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d539c003448320b99a65b602873e09