### PR TITLE
Align page layout spacing with board page

### DIFF
--- a/frontend/src/app/shared/ui/page-layout/page-layout.html
+++ b/frontend/src/app/shared/ui/page-layout/page-layout.html
@@ -1,15 +1,17 @@
-<app-page-header
-  [eyebrow]="eyebrow"
-  [title]="title"
-  [description]="description"
-  [headingLevel]="headingLevel"
->
-  <ng-content select="[pageHeaderMeta]"></ng-content>
-  <ng-content select="[appPageHeaderActions]"></ng-content>
-</app-page-header>
+<div class="app-page-layout__section app-page-layout__section--header">
+  <app-page-header
+    [eyebrow]="eyebrow"
+    [title]="title"
+    [description]="description"
+    [headingLevel]="headingLevel"
+  >
+    <ng-content select="[pageHeaderMeta]"></ng-content>
+    <ng-content select="[appPageHeaderActions]"></ng-content>
+  </app-page-header>
+</div>
 
 <div class="app-page-layout__body" [class.app-page-layout__body--bleed]="bleed">
-  <div class="app-page-layout__content">
+  <div class="app-page-layout__section">
     <ng-content select="[pageTabs]"></ng-content>
     <ng-content></ng-content>
   </div>

--- a/frontend/src/app/shared/ui/page-layout/page-layout.scss
+++ b/frontend/src/app/shared/ui/page-layout/page-layout.scss
@@ -6,6 +6,17 @@
   padding-inline: 0;
 }
 
+.app-page-layout__section {
+  display: grid;
+  gap: var(--page-content-gap);
+  width: 100%;
+}
+
+.app-page-layout__section--header {
+  display: block;
+  gap: 0;
+}
+
 .app-page-layout__body {
   display: grid;
   gap: var(--page-content-gap);
@@ -17,19 +28,6 @@
 }
 
 :host(.shell-container) .app-page-layout__body--bleed {
-  margin-inline: 0;
-}
-
-.app-page-layout__content {
-  display: grid;
-  gap: var(--page-content-gap);
-  max-width: 76rem;
-  width: 100%;
-  margin-inline: auto;
-}
-
-:host(.app-page-layout--wide) .app-page-layout__content {
-  max-width: none;
   margin-inline: 0;
 }
 


### PR DESCRIPTION
## Summary
- update the shared page layout markup so headers and content use a common container matching the board page spacing
- simplify the page layout stylesheet by removing the max-width logic and consolidating the structural rules in one place

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d548c581b48320970b9d453b9e350b