### PR TITLE
Remove unnecessary page layout gap styling

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -320,7 +320,6 @@ app-page-layout .app-page-layout__header {
 
 app-page-layout .app-page-layout__body {
   display: grid;
-  gap: var(--page-content-gap);
   margin-top: var(--page-content-gap);
 }
 
@@ -334,7 +333,6 @@ app-page-layout.shell-container .app-page-layout__body--bleed {
 
 app-page-layout .app-page-layout__content {
   display: grid;
-  gap: var(--page-content-gap);
   max-width: var(--app-page-layout-max-width);
   width: 100%;
   margin-inline: auto;


### PR DESCRIPTION
## Summary
- remove the gap spacing rule from the app-page-layout body and content areas

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d55d2f12848320a2f369b5f4abcd89