### PR TITLE
Ensure shell shell-container sections explicitly remove horizontal padding

### DIFF
--- a/frontend/src/app/core/layout/shell/shell.html
+++ b/frontend/src/app/core/layout/shell/shell.html
@@ -196,7 +196,7 @@
     </div>
   </header>
 
-  <main class="shell-container flex flex-1 flex-col gap-6 py-8">
+  <main class="shell-container flex flex-1 flex-col gap-6 px-0 py-0">
     <section class="flex-1">
       <router-outlet />
     </section>
@@ -204,7 +204,7 @@
 
   <footer class="border-t border-subtle bg-surface-strong">
     <div
-      class="shell-container flex flex-col gap-2 py-5 text-xs text-slate-500 dark:text-slate-400 sm:flex-row sm:items-center sm:justify-between"
+      class="shell-container flex flex-col gap-2 px-0 py-0 text-xs text-slate-500 dark:text-slate-400 sm:flex-row sm:items-center sm:justify-between"
     >
       <p>© {{ year }} Verbalize Yourself</p>
       <p>Angular 20 Signal Architecture / ChatGPT モック統合</p>

--- a/frontend/src/app/core/layout/shell/shell.scss
+++ b/frontend/src/app/core/layout/shell/shell.scss
@@ -8,7 +8,8 @@
   box-sizing: border-box;
   width: var(--shell-max-width);
   margin-inline: auto;
-  padding-inline: var(--shell-inline-padding);
+  padding-inline: 0;
+  padding-block: 0;
 }
 
 .shell-header {

--- a/frontend/src/styles/pages/_admin.scss
+++ b/frontend/src/styles/pages/_admin.scss
@@ -1,7 +1,7 @@
 app-admin-page {
   display: block;
   color: var(--text-primary);
-  padding: var(--page-padding-block-start) 0 var(--page-padding-block-end);
+  padding: 0;
   --panel-padding: clamp(1.5rem, 2.4vw, 2rem);
   --page-content-gap: clamp(1.75rem, 2vw, 2.5rem);
 }

--- a/frontend/src/styles/pages/_settings.scss
+++ b/frontend/src/styles/pages/_settings.scss
@@ -1,7 +1,7 @@
 app-settings-page {
   display: block;
   color: var(--text-primary);
-  padding: var(--page-padding-block-start) 0 var(--page-padding-block-end);
+  padding: 0;
   --panel-padding: clamp(1.6rem, 2.4vw, 2.1rem);
   --page-content-gap: clamp(1.75rem, 2vw, 2.5rem);
 }


### PR DESCRIPTION
## Summary
- ensure the shell layout's main outlet and footer containers explicitly set both horizontal and vertical padding to zero with utility classes

## Testing
- npx prettier --check src/app/core/layout/shell/shell.html

------
https://chatgpt.com/codex/tasks/task_e_68d55aef97c48320824bd2f3b3062ad6