### PR TITLE
Add spacing between stacked board containers

### DIFF
--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -260,6 +260,10 @@
   gap: clamp(1rem, 1.6vw, 1.5rem);
 }
 
+.board-page__task-board + .board-page__subtask-board {
+  margin-block-start: clamp(1.5rem, 2.5vw, 2.5rem);
+}
+
 .board-page__task-header {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a margin between the task and subtask boards so the stacked containers regain their vertical spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55dd373ec8320894fbe3b6e3a1492