### PR TITLE
Add card deletion workflow with confirmation

### DIFF
--- a/frontend/src/app/core/state/workspace-store.ts
+++ b/frontend/src/app/core/state/workspace-store.ts
@@ -697,6 +697,32 @@ export class WorkspaceStore {
     );
   };
 
+  /**
+   * Permanently removes a card from the workspace.
+   *
+   * @param cardId - Identifier of the card to delete.
+   */
+  public readonly removeCard = (cardId: string): void => {
+    let removed = false;
+
+    this.cardsSignal.update((cards) => {
+      const next = cards.filter((card) => {
+        if (card.id === cardId) {
+          removed = true;
+          return false;
+        }
+
+        return true;
+      });
+
+      return removed ? next : cards;
+    });
+
+    if (removed && this.selectedCardIdSignal() === cardId) {
+      this.selectedCardIdSignal.set(null);
+    }
+  };
+
   public readonly updateSubtaskStatus = (
     cardId: string,
     subtaskId: string,

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -353,13 +353,22 @@
               <p class="card-detail-header__eyebrow">カード編集</p>
               <h3 class="card-detail-header__title">{{ active.title }}</h3>
             </div>
-            <button
-              type="button"
-              class="button button--ghost button--pill"
-              (click)="openCard(null)"
-            >
-              閉じる
-            </button>
+            <div class="card-detail-header__actions">
+              <button
+                type="button"
+                class="button button--danger button--pill"
+                (click)="confirmDeleteCard(active)"
+              >
+                カードを削除
+              </button>
+              <button
+                type="button"
+                class="button button--ghost button--pill"
+                (click)="openCard(null)"
+              >
+                閉じる
+              </button>
+            </div>
           </div>
 
           <section class="subtask-editor space-y-4">

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -338,6 +338,18 @@ export class BoardPage {
   };
 
   /**
+   * Requests confirmation before deleting the provided card.
+   *
+   * @param card - Card slated for deletion.
+   */
+  public readonly confirmDeleteCard = (card: Card): void => {
+    const message = `カード「${card.title}」を削除しますか？この操作は取り消せません。`;
+    if (window.confirm(message)) {
+      this.workspace.removeCard(card.id);
+    }
+  };
+
+  /**
    * Updates the status of a card from the inline menu.
    *
    * @param cardId - Card identifier to update.

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1086,7 +1086,6 @@ app-help-dialog .help-dialog__secondary:hover {
   color: var(--text-primary);
 }
 
-
 /* Profile dialog */
 app-profile-dialog .profile-dialog {
   position: fixed;

--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -332,7 +332,6 @@
   color: var(--text-primary);
 }
 
-
 .board-summary__cta {
   align-self: flex-start;
   font-size: 0.85rem;
@@ -986,6 +985,14 @@
   font-size: 1.5rem;
   font-weight: 700;
   color: var(--text-primary);
+}
+
+.card-detail-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
 }
 
 .card-detail-header__subtitle {


### PR DESCRIPTION
## Summary
- add a workspace store helper to remove cards and clear the current selection when the deleted card was open
- surface a "カードを削除" action with confirmation in the board detail pane and group the header actions consistently
- style the new header actions layout and run Prettier on the touched stylesheets

## Testing
- npm run format:check
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: Chrome binary unavailable in container)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5623c206c83208ec76cc96c5413aa