### PR TITLE
feat(board): remove progress summary panel

### DIFF
--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -13,40 +13,6 @@
   </app-page-header>
 
   <div class="board-page__overview">
-    @if (summarySignal(); as summary) {
-      <section class="surface-panel page-panel board-summary">
-        <header class="board-summary__header">
-          <p class="board-summary__eyebrow">進捗状況</p>
-        </header>
-        <ul class="board-summary__metrics">
-          <li>
-            <span>完了カード</span>
-            <strong>{{ summary.doneCards }}</strong>
-          </li>
-          <li>
-            <span>総カード数</span>
-            <strong>{{ summary.totalCards }}</strong>
-          </li>
-          <li>
-            <span>アクティブラベル</span>
-            <strong>{{ summary.activeLabels }}</strong>
-          </li>
-        </ul>
-        <a routerLink="/profile/evaluations" class="button button--secondary board-summary__cta">
-          最新のコンピテンシー判定を確認
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 24 24"
-            class="board-summary__link-icon"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.8"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
-        </a>
-      </section>
-    }
     <div class="flex h-full min-w-0 flex-col gap-4">
       <section class="surface-panel page-panel board-filters">
         <div class="board-filters__grid page-grid page-grid--two">

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
-import { RouterLink } from '@angular/router';
 import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
 
 import { WorkspaceStore } from '@core/state/workspace-store';
@@ -110,14 +109,13 @@ const RESOLVED_SUBTASK_STATUSES = new Set<SubtaskStatus>(['done', 'non-issue']);
 @Component({
   selector: 'app-board-page',
   standalone: true,
-  imports: [CommonModule, DragDropModule, RouterLink, PageHeaderComponent],
+  imports: [CommonModule, DragDropModule, PageHeaderComponent],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BoardPage {
   private readonly workspace = inject(WorkspaceStore);
 
-  public readonly summarySignal = this.workspace.summary;
   public readonly groupingSignal = this.workspace.grouping;
   public readonly groupingLabelSignal = computed(() =>
     this.groupingSignal() === 'status' ? 'ステータス別' : 'ラベル別',


### PR DESCRIPTION
## Summary
- remove the progress summary panel from the board overview layout
- drop the unused workspace summary signal and RouterLink import from the board page component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5653ac0f88320be49a2990ad10438