### PR TITLE
Retranslate documentation to natural English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,42 @@
 # Verbalize Yourself
 
-Verbalize Yourself は Angular 20 フロントエンドと FastAPI バックエンドを組み合わせた AI ガイド付きリフレクションワークスペースで、カード管理・分析・レポート作成を一体化し、ChatGPT による自動化で内省サイクルを加速します。【F:frontend/src/app/app.routes.ts†L1-L73】【F:backend/app/main.py†L1-L69】
+Verbalize Yourself is an AI-guided reflection workspace that pairs an Angular 20 frontend with a FastAPI backend. The platform centralizes card capture, analysis, and reporting while using ChatGPT to streamline each reflection cycle.【F:frontend/src/app/app.routes.ts†L1-L73】【F:backend/app/main.py†L1-L69】
 
 ## Feature Highlights
-- **Workspace task board** – ラベルやステータスでグルーピングされたカードをドラッグ＆ドロップで並べ替え、クイックフィルターやテンプレートでワークフローを整えます。【F:frontend/src/app/features/board/page.ts†L1-L160】【F:frontend/src/app/core/state/workspace-store.ts†L1-L200】
-- **AI-assisted intake & daily reporting** – 自由入力の振り返りメモを AI が提案カードへ構造化し、日報/週報の送信ではセクションから提案タスクを生成して記録します。【F:backend/app/routers/analysis.py†L1-L27】【F:backend/app/services/chatgpt.py†L43-L190】【F:backend/app/routers/daily_reports.py†L1-L108】【F:frontend/src/app/features/reports/reports-page.component.ts†L1-L157】
-- **Analytics & continuous improvement** – 管理者はスナップショットや Why-Why 分析を作成し、根本原因ノードや改善アクション、イニシアチブの進捗をダッシュボードで追跡できます。【F:backend/app/routers/analytics.py†L1-L200】【F:backend/app/models.py†L301-L439】【F:frontend/src/app/features/analytics/page.ts†L1-L112】【F:frontend/src/app/core/state/continuous-improvement-store.ts†L1-L200】
-- **Appeal narrative generation** – アピール文生成 API が推奨フローと複数フォーマットを提示し、ChatGPT 応答とフォールバックテンプレートを統合して成果ストーリーを保存します。【F:backend/app/routers/appeals.py†L1-L27】【F:backend/app/services/appeals.py†L1-L200】【F:backend/app/services/appeal_prompts.py†L1-L180】
-- **Governance & competency management** – API 資格情報の暗号化管理、評価ルーブリック、クオータ設定などの管理機能で運用ガードレールを構築します。【F:backend/app/routers/admin_settings.py†L1-L140】【F:backend/app/routers/competencies.py†L1-L120】
+- **Workspace task board** – Group cards by label or status, reprioritize them with drag and drop, and rely on quick filters and templates to keep the workflow organized.【F:frontend/src/app/features/board/page.ts†L1-L160】【F:frontend/src/app/core/state/workspace-store.ts†L1-L200】
+- **AI-assisted intake & daily reporting** – Convert free-form reflection notes into structured proposals, generate follow-up tasks from report sections, and send daily or weekly updates automatically.【F:backend/app/routers/analysis.py†L1-L27】【F:backend/app/services/chatgpt.py†L43-L190】【F:backend/app/routers/daily_reports.py†L1-L108】【F:frontend/src/app/features/reports/reports-page.component.ts†L1-L157】
+- **Analytics & continuous improvement** – Administrators create analytics snapshots, run Why-Why investigations, capture root causes, and track initiatives on dashboards that stay connected to workspace data.【F:backend/app/routers/analytics.py†L1-L200】【F:backend/app/models.py†L301-L439】【F:frontend/src/app/features/analytics/page.ts†L1-L112】【F:frontend/src/app/core/state/continuous-improvement-store.ts†L1-L200】
+- **Appeal narrative generation** – Produce suggested flows and multi-format narratives that blend ChatGPT output with fallback templates so appeal stories remain consistent.【F:backend/app/routers/appeals.py†L1-L27】【F:backend/app/services/appeals.py†L1-L200】【F:backend/app/services/appeal_prompts.py†L1-L180】
+- **Governance & competency management** – Encrypt external API credentials, configure evaluation rubrics, and manage quotas to establish operational guardrails.【F:backend/app/routers/admin_settings.py†L1-L140】【F:backend/app/routers/competencies.py†L1-L120】
 
 ## Technology Stack
-- **Frontend** – Angular 20 スタンドアロンコンポーネント、CDK Drag & Drop、Signal ベースの状態管理、ESLint/Prettier を採用しています。【F:frontend/package.json†L1-L60】【F:frontend/src/app/features/board/page.ts†L1-L160】
-- **Backend** – FastAPI + SQLAlchemy が REST ルーターとスキーマを提供し、ChatGPT クライアントが Responses API を JSON スキーマでラップします。【F:backend/app/main.py†L1-L69】【F:backend/app/schemas.py†L1-L1080】【F:backend/app/services/chatgpt.py†L43-L190】
-- **Persistence & Background models** – カード、アナリティクス、Why-Why 分析、提案アクション、日報、アピール生成などを JSON カラム付きのリレーショナルモデルで管理します。【F:backend/app/models.py†L120-L780】
+- **Frontend** – Angular 20 standalone components with CDK Drag & Drop, signal-based state management, and ESLint/Prettier tooling.【F:frontend/package.json†L1-L60】【F:frontend/src/app/features/board/page.ts†L1-L160】
+- **Backend** – FastAPI and SQLAlchemy expose REST routers and schemas, and a ChatGPT client wraps the Responses API with JSON schema validation.【F:backend/app/main.py†L1-L69】【F:backend/app/schemas.py†L1-L1080】【F:backend/app/services/chatgpt.py†L43-L190】
+- **Persistence & background models** – Cards, analytics, Why-Why analyses, suggested actions, daily reports, and appeal content are stored in relational models with JSON columns.【F:backend/app/models.py†L120-L780】
 
 ## Repository Layout
 ```
 .
-├── backend/                # FastAPI アプリケーションと ChatGPT 連携サービス
-├── frontend/               # Angular 20 SPA
-├── docs/                   # アーキテクチャ、開発ルール、機能別要件/詳細設計
-├── scripts/                # 自動化スクリプト
-└── start-localhost.bat     # Windows 用ワンコマンド起動
+├── backend/                # FastAPI application and ChatGPT integration services
+├── frontend/               # Angular 20 single-page application
+├── docs/                   # Architecture, development rules, and feature specifications
+├── scripts/                # Automation scripts
+└── start-localhost.bat     # Windows bootstrap script
 ```
-主なドキュメントは `docs/` にあり、`docs/features/` 配下で機能ごとの要件・詳細設計を管理しています。
+The primary documentation lives under `docs/`, with feature requirements and detailed designs in `docs/features/`.
 
 ## Getting Started
 ### Prerequisites
-- Python 3.11 以上 (FastAPI・Ruff・Black を利用)。【F:pyproject.toml†L1-L28】
-- Node.js / npm (Angular CLI とビルド/テストスクリプト用)。【F:frontend/package.json†L1-L60】
-- OpenAI API キー (管理画面から保存し、ChatGPT クライアントが復号して利用)。【F:backend/app/services/chatgpt.py†L111-L157】【F:backend/app/routers/admin_settings.py†L22-L81】
+- Python 3.11 or later (used with FastAPI, Ruff, and Black).【F:pyproject.toml†L1-L28】
+- Node.js / npm (for the Angular CLI and build/test scripts).【F:frontend/package.json†L1-L60】
+- OpenAI API key (save it from the admin UI so the ChatGPT client can decrypt and use it).【F:backend/app/services/chatgpt.py†L111-L157】【F:backend/app/routers/admin_settings.py†L22-L81】
 
 ### One-click startup on Windows
-リポジトリルートで同梱スクリプトを実行すると仮想環境の作成、依存インストール、バックエンド/フロントエンドの起動まで自動化されます。
+Run the bundled script from the repository root to create a virtual environment, install dependencies, and start both the backend and frontend:
 ```
 start-localhost.bat
 ```
-スクリプトは FastAPI を <http://localhost:8000>、Angular 開発サーバーを <http://localhost:4200> で起動します。【F:start-localhost.bat†L1-L41】
+The script launches FastAPI at <http://localhost:8000> and the Angular dev server at <http://localhost:4200>.【F:start-localhost.bat†L1-L41】
 
 ### Manual startup (macOS/Linux)
 1. **Backend**
@@ -48,21 +48,21 @@ start-localhost.bat
    pip install -r backend/requirements-dev.txt
    uvicorn app.main:app --app-dir backend --reload
    ```
-   依存関係をインストールし、ホットリロード付きで FastAPI アプリを起動します。【F:backend/requirements.txt†L1-L13】【F:backend/app/main.py†L1-L69】
+   Install the dependencies and run the FastAPI app with hot reload enabled.【F:backend/requirements.txt†L1-L13】【F:backend/app/main.py†L1-L69】
 
-2. **Frontend** (別ターミナル)
+2. **Frontend** (run in a separate terminal)
    ```bash
    cd frontend
    npm install
    npm start
    ```
-   `npm start` は Angular の開発サーバーを 4200 番ポートで立ち上げます。【F:frontend/package.json†L4-L12】
+   `npm start` launches the Angular dev server on port 4200.【F:frontend/package.json†L4-L12】
 
 ### Environment variables
-バックエンドは Pydantic Settings で環境変数を読み込みます (例: DB 接続、CORS、ChatGPT 既定値、暗号鍵)。【F:backend/app/config.py†L10-L39】
+The backend loads environment variables with Pydantic Settings (database connections, CORS, ChatGPT defaults, encryption keys, and more).【F:backend/app/config.py†L10-L39】
 
 ## Running Tests & Quality Checks
-Pull Request 前に自動チェックを実行してください。
+Execute the automated checks before opening a pull request.
 ```bash
 # Backend
 pytest backend/tests
@@ -75,13 +75,13 @@ npm test -- --watch=false
 npm run lint
 npm run format:check
 ```
-`npm test` は Angular CLI (Karma) を利用し、ESLint と Prettier でスタイルを検証します。【F:frontend/package.json†L4-L18】
+`npm test` relies on the Angular CLI (Karma), and ESLint plus Prettier enforce consistent formatting.【F:frontend/package.json†L4-L18】
 
 ## Documentation & Architecture
-- `docs/architecture.md` – システムコンテキストと主要コンポーネント。
-- `docs/development-rules.md` – 開発プロセスと品質基準。
-- `docs/features/appeal-generation/requirements.md` – アピール文生成の要件定義。
-- `docs/features/appeal-generation/detail-design.md` – アピール文生成の詳細設計。
-- `docs/features/analytics-insights/requirements.md` – 分析・継続的改善機能の要件。
-- `docs/features/analytics-insights/detail-design.md` – 分析・継続的改善機能の実装設計。
-- `docs/ui-design-system.md` – コンポーネントの UI ガイドライン。
+- `docs/architecture.md` – System context and major components.
+- `docs/development-rules.md` – Development workflow and quality expectations.
+- `docs/features/appeal-generation/requirements.md` – Requirements for appeal narrative generation.
+- `docs/features/appeal-generation/detail-design.md` – Detailed design for appeal narrative generation.
+- `docs/features/analytics-insights/requirements.md` – Requirements for analytics and continuous improvement.
+- `docs/features/analytics-insights/detail-design.md` – Detailed design for analytics and continuous improvement.
+- `docs/ui-design-system.md` – UI guidelines for shared components.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,11 +1,7 @@
 # Architecture Overview
 
 ## System Context
-Verbalize Yourself is an AI-guided reflection workspace (AIガイドのリフレクションワークスペース) that combines an Angular single-page application with a FastAPI backend that exposes
-modular routers for cards, analytics, initiatives, competencies, reporting, and administration while
-sharing a common SQLAlchemy model layer.【F:frontend/package.json†L1-L60】【F:frontend/src/app/app.routes.ts†L9-L66】【F:backend/app/main.py†L1-L69】【F:backend/app/models.py†L120-L439】
-AI assistance is woven into the platform through a dedicated ChatGPT client that structures proposals
-for both ad-hoc analysis and scheduled report generation flows.【F:backend/app/services/chatgpt.py†L43-L190】【F:backend/app/services/daily_reports.py†L23-L199】
+Verbalize Yourself is an AI-guided reflection workspace that combines an Angular single-page application with a FastAPI backend. The backend exposes modular routers for cards, analytics, initiatives, competencies, reporting, and administration, all sharing a common SQLAlchemy model layer.【F:frontend/package.json†L1-L60】【F:frontend/src/app/app.routes.ts†L9-L66】【F:backend/app/main.py†L1-L69】【F:backend/app/models.py†L120-L439】 AI support is delivered through a dedicated ChatGPT client that structures proposals for on-demand analysis and scheduled report workflows.【F:backend/app/services/chatgpt.py†L43-L190】【F:backend/app/services/daily_reports.py†L23-L199】
 
 ## High-level Interaction Diagram
 ```mermaid
@@ -20,57 +16,29 @@ flowchart LR
 
 ## Component Responsibilities
 ### Frontend (Angular SPA)
-The Angular client lazy-loads feature areas—analysis intake, kanban board, analytics dashboards,
-daily reports, profile evaluations, settings, and admin tooling—behind authentication guards so only
-signed-in users reach workspace experiences and administrators access protected areas.【F:frontend/src/app/app.routes.ts†L9-L66】【F:frontend/src/app/core/auth/auth.guard.ts†L1-L21】【F:frontend/src/app/core/auth/admin.guard.ts†L1-L23】
-Feature modules coordinate complex UI workflows: the analyzer submits notes for AI review and filters
-the resulting proposals, the board renders grouped cards with drag-and-drop interactions, and the
-daily report page captures shift notes then immediately submits them for AI processing.【F:frontend/src/app/features/analyze/page.ts†L1-L76】【F:frontend/src/app/features/board/page.ts†L1-L199】【F:frontend/src/app/features/reports/reports-page.component.ts†L1-L157】
+The Angular client lazy-loads feature areas—analysis intake, the kanban board, analytics dashboards, daily reports, profile evaluations, workspace settings, and admin tooling—behind authentication guards so only signed-in users can reach workspace experiences and administrators can enter protected areas.【F:frontend/src/app/app.routes.ts†L9-L66】【F:frontend/src/app/core/auth/auth.guard.ts†L1-L21】【F:frontend/src/app/core/auth/admin.guard.ts†L1-L23】 Feature modules coordinate the complex workflows: the analyzer submits notes for AI review and filters the resulting proposals, the board renders grouped cards with drag-and-drop interactions, and the daily report page captures shift notes before sending them for AI processing.【F:frontend/src/app/features/analyze/page.ts†L1-L76】【F:frontend/src/app/features/board/page.ts†L1-L199】【F:frontend/src/app/features/reports/reports-page.component.ts†L1-L157】
 
 ### Backend (FastAPI Services)
-FastAPI mounts routers for analysis, cards, analytics, daily reports, initiatives, saved filters,
-competency management, user preferences, admin controls, and more, giving the client a broad REST
-surface area with consistent authentication requirements.【F:backend/app/main.py†L1-L69】 Daily report
-endpoints orchestrate CRUD operations and status transitions while invoking AI analysis, and analytics
-endpoints manage snapshots, root-cause investigations, and suggested actions for admins.【F:backend/app/routers/daily_reports.py†L1-L117】【F:backend/app/routers/analytics.py†L1-L200】 Competency routers let
-administrators curate rubrics and trigger evaluations tied to quotas.【F:backend/app/routers/competencies.py†L1-L120】
+FastAPI mounts routers for analysis, cards, analytics, daily reports, initiatives, saved filters, competency management, user preferences, admin controls, and more, giving the client a broad REST surface area with consistent authentication requirements.【F:backend/app/main.py†L1-L69】 Daily report endpoints orchestrate CRUD operations and status transitions while invoking AI analysis, and analytics endpoints manage snapshots, root-cause investigations, and suggested actions for administrators.【F:backend/app/routers/daily_reports.py†L1-L117】【F:backend/app/routers/analytics.py†L1-L200】 Competency routers let administrators curate rubrics and trigger evaluations tied to quotas.【F:backend/app/routers/competencies.py†L1-L120】
 
 ### AI & Automation Services
-`ChatGPTClient` enforces a strict JSON schema when calling OpenAI's Responses API so proposals arrive
-with titles, summaries, priorities, labels, subtasks, and due-date hints, while also validating
-configuration and error paths.【F:backend/app/services/chatgpt.py†L43-L190】 Daily report processing
-wraps the client to compose prompt text from shift sections, persist status events, and capture
-returned proposals for potential card creation.【F:backend/app/services/daily_reports.py†L23-L199】
+`ChatGPTClient` enforces a strict JSON schema when calling OpenAI's Responses API so proposals arrive with titles, summaries, priorities, labels, subtasks, and due-date hints, while also validating configuration and error paths.【F:backend/app/services/chatgpt.py†L43-L190】 Daily report processing wraps the client to compose prompts from shift sections, persist status events, and capture returned proposals for potential card creation.【F:backend/app/services/daily_reports.py†L23-L199】
 
 ### Persistence & Domain Model
-A comprehensive SQLAlchemy model layer captures cards, subtasks, labels, statuses, initiatives,
-analytics artefacts, suggested actions, daily reports, quota tracking, and competency evaluations with
-relationships that support joined queries for workspace dashboards.【F:backend/app/models.py†L120-L439】
+A comprehensive SQLAlchemy model layer captures cards, subtasks, labels, statuses, initiatives, analytics artefacts, suggested actions, daily reports, quota tracking, and competency evaluations with relationships that power workspace dashboards.【F:backend/app/models.py†L120-L439】
 
 ## Key Flows
 ### Authentication & Session Management
-The backend issues hashed, expiring session tokens and verifies them on each request, while the
-frontend AuthService persists tokens, restores sessions, and gates route access through guards for
-regular users and administrators.【F:backend/app/auth.py†L1-L123】【F:frontend/src/app/core/auth/auth.service.ts†L1-L146】【F:frontend/src/app/core/auth/auth.guard.ts†L1-L21】【F:frontend/src/app/core/auth/admin.guard.ts†L1-L23】
+The backend issues hashed, expiring session tokens and verifies them on each request. On the frontend, `AuthService` persists tokens, restores sessions, and gates route access through guards for regular users and administrators.【F:backend/app/auth.py†L1-L123】【F:frontend/src/app/core/auth/auth.service.ts†L1-L146】【F:frontend/src/app/core/auth/auth.guard.ts†L1-L21】【F:frontend/src/app/core/auth/admin.guard.ts†L1-L23】
 
 ### AI-assisted Analysis Intake
-Submitting notes from the analyzer invokes the `/analysis` endpoint, which enriches the request with
-the current user's profile before delegating to the ChatGPT client to generate structured proposals;
-the frontend filters and publishes the approved items into the workspace store.【F:backend/app/routers/analysis.py†L1-L27】【F:backend/app/services/chatgpt.py†L43-L190】【F:frontend/src/app/features/analyze/page.ts†L1-L76】
+Submitting notes from the analyzer invokes the `/analysis` endpoint, which enriches the request with the current user's profile before delegating to the ChatGPT client to generate structured proposals. The frontend filters and publishes the approved items into the workspace store.【F:backend/app/routers/analysis.py†L1-L27】【F:backend/app/services/chatgpt.py†L43-L190】【F:frontend/src/app/features/analyze/page.ts†L1-L76】
 
 ### Daily Reporting & Auto Ticketing
-Users compile shift sections on the daily reports page, create drafts via the API, and optionally
-submit them for immediate AI processing; the backend service validates quotas, records events,
-requests ChatGPT proposals, and links generated cards back to each report for review.【F:frontend/src/app/features/reports/reports-page.component.ts†L1-L157】【F:backend/app/routers/daily_reports.py†L1-L117】【F:backend/app/services/daily_reports.py†L23-L199】
+Users compile shift sections on the daily reports page, create drafts via the API, and optionally submit them for immediate AI processing. The backend validates quotas, records events, requests ChatGPT proposals, and links generated cards back to each report for review.【F:frontend/src/app/features/reports/reports-page.component.ts†L1-L157】【F:backend/app/routers/daily_reports.py†L1-L117】【F:backend/app/services/daily_reports.py†L23-L199】
 
 ### Analytics & Continuous Improvement
-Administrators generate analytics snapshots, run root-cause analyses that create tree-structured
-investigations, and capture suggested actions that can spawn cards or initiatives, all persisted in
-relational tables for cross-linking and historical dashboards.【F:backend/app/routers/analytics.py†L1-L200】【F:backend/app/models.py†L301-L439】 The frontend exposes
-analytics and evaluation pages through dedicated routes to surface these insights alongside the task
-board.【F:frontend/src/app/app.routes.ts†L33-L46】
+Administrators generate analytics snapshots, run root-cause analyses that create tree-structured investigations, and capture suggested actions that can spawn cards or initiatives, all persisted in relational tables for cross-linking and historical dashboards.【F:backend/app/routers/analytics.py†L1-L200】【F:backend/app/models.py†L301-L439】 The frontend exposes analytics and evaluation pages through dedicated routes to surface these insights alongside the task board.【F:frontend/src/app/app.routes.ts†L33-L46】
 
 ### Admin & Governance Controls
-Admin endpoints manage encrypted external API credentials, workspace quotas, and competency
-frameworks, enabling teams to tune automation, enforce limits, and curate evaluation rubrics from a
-single control plane.【F:backend/app/routers/admin_settings.py†L1-L140】【F:backend/app/routers/competencies.py†L1-L120】
+Admin endpoints manage encrypted external API credentials, workspace quotas, and competency frameworks, enabling teams to tune automation, enforce limits, and curate evaluation rubrics from a single control plane.【F:backend/app/routers/admin_settings.py†L1-L140】【F:backend/app/routers/competencies.py†L1-L120】

--- a/docs/development-rules.md
+++ b/docs/development-rules.md
@@ -1,110 +1,109 @@
-# 開発時のルール
+# Development Rules
 
-開発を円滑に進め、品質を担保するために、以下のルールを必ず遵守してください。  
-
----
-
-## 推奨開発フロー
-
-1. **最新の `main` ブランチを取り込んで作業ブランチを準備する**  
-   - 作業開始前や途中で `git pull origin main` を実行し、差分を早めに解消する。  
-
-2. **実装とセルフレビューを進める**  
-   - 仕様やチケット条件を確認しながら小さなコミットを積み上げる。  
-   - レビュー前に差分を読み直し、セルフチェックを行う。  
-
-3. **品質チェックを実行する**  
-   - **実際に修正を加えた領域のみ対象**とし、必要なケースだけテスト・チェックを走らせる。  
-   - 実行対象は以下のとおり。  
-    - バックエンド: `pytest backend/tests`
-    - フロントエンド: `cd frontend && npm test`
-      - Karma は環境変数 `CHROME_BIN=/usr/bin/chromium-browser` に設定された Chromium を利用する。
-     - コードフォーマット: `black --check`（変更ファイルのみを対象とする）  
-     - 静的解析: `ruff check`（変更ファイルのみを対象とする）  
-     - フロントエンドフォーマット: `cd frontend && npm run format:check`（変更ファイルのみを対象とする）  
-     - ビルド: `cd frontend && npm run build`  
-   - コメントやドキュメント修正のみの場合は **テスト・フォーマット・ビルドをスキップ可能**。ただし、コードへ影響の可能性があれば実行する。  
-   - いずれかが失敗した場合は修正し、**再度全ての必要チェックを通過するまで繰り返す**。  
-
-4. **ドキュメントを最新化する**  
-   - `README.md` や `docs/` 配下の仕様・ルールを更新する。  
-   - ドキュメントの矛盾を残さないよう確認する。  
-
-5. **UI 変更時のスクリーンショット取得**  
-   - `cd frontend && npm start` でプレビューを確認し、スクリーンショットを取得。  
-   - マージリクエストに添付し、必要に応じて注釈を追加する。  
-
-6. **タスク完了前に最新の `main` を取り込む**  
-   - `git fetch origin main && git merge origin/main`（またはリベース手順）を実行。  
-   - コンフリクトが発生した場合は解消後、再度必要なビルド・テストを行う。  
+Follow these rules to keep delivery smooth and maintain quality.
 
 ---
 
-## マージ前の必須ルール
+## Recommended Workflow
 
-1. **修正の種類に応じたチェックの完了**  
-   - **コード修正がある場合** → 上記の必要な品質チェックをすべて通過していること。  
-   - **コメント／ドキュメント修正のみの場合** → 品質チェックは不要。内容の妥当性を確認すること。  
+1. **Start from the latest `main` branch**
+   - Run `git pull origin main` before you begin and periodically during development so you resolve differences early.
 
-2. **最新の `main` を取り込むこと**  
-   - コンフリクトが発生した場合は必ず解消する。  
-   - 解消後は必要に応じて再ビルド・再テストを実行する。  
+2. **Implement in small steps and self-review**
+   - Confirm requirements or ticket conditions and commit in small increments.
+   - Read through your diff before requesting review and perform a self-check.
 
-3. **コンフリクト修正ルール**  
-   - 未解消の状態ではマージ不可。  
-   - 修正後は動作確認を行い、チェックが必要な場合は再実行する。  
+3. **Run the necessary quality checks**
+   - Only run checks for the areas you actually changed.
+   - Execute the following as needed:
+     - Backend: `pytest backend/tests`
+     - Frontend: `cd frontend && npm test` (Karma uses Chromium configured with `CHROME_BIN=/usr/bin/chromium-browser`).
+     - Code formatting: `black --check` (limit to the files you modified).
+     - Static analysis: `ruff check` (limit to the files you modified).
+     - Frontend formatting: `cd frontend && npm run format:check` (limit to the files you modified).
+     - Build: `cd frontend && npm run build`
+   - If you only changed comments or documentation, you may skip tests, formatting, and builds—but run them whenever the change might affect code.
+   - When any check fails, fix the issue and rerun the required checks until everything passes.
 
-4. **UI 変更時の対応**  
-   - 画面サイズや状態ごとのスクリーンショットを網羅する。  
-   - 新旧比較が可能な場合は並べて提示し、確認者が差分を把握しやすくする。  
+4. **Keep documentation current**
+   - Update `README.md` and the materials under `docs/` to reflect the latest specifications and rules.
+   - Double-check that the documents remain consistent.
+
+5. **Capture screenshots for UI changes**
+   - Preview the UI with `cd frontend && npm start` and take screenshots.
+   - Attach the images to the merge request and add annotations when needed.
+
+6. **Rebase on the latest `main` before completion**
+   - Run `git fetch origin main && git merge origin/main` (or rebase) near the end of the task.
+   - Resolve any conflicts and rerun builds or tests as necessary.
+
+---
+
+## Pre-merge Requirements
+
+1. **Finish the checks appropriate for the change**
+   - **Code changes** → All required quality checks must pass.
+   - **Comment or documentation-only changes** → Quality checks are optional; focus on content accuracy.
+
+2. **Bring in the latest `main`**
+   - Resolve every conflict.
+   - After resolving conflicts, rerun builds and tests when needed.
+
+3. **Conflict resolution rules**
+   - Unresolved conflicts block merging.
+   - After resolving, verify functionality and rerun checks if required.
+
+4. **Expectations for UI updates**
+   - Capture screenshots that cover relevant screen sizes and states.
+   - Provide side-by-side comparisons when possible so reviewers can easily see the differences.
 
 ```json
 {
   "development_rules": {
     "workflow": [
-      "作業開始前や途中で最新の main を取り込み、差分を早めに解消する。",
-      "仕様を確認しながら小さなコミットを積み重ね、セルフレビューを行う。",
-      "レビュー依頼前に差分を読み直しセルフチェックを行う。"
+      "Pull the latest main branch at the start and during development to resolve differences early.",
+      "Confirm requirements, commit in small increments, and perform self-review.",
+      "Re-read your diff before requesting review and complete a self-check."
     ],
     "quality_checks": {
       "normal_changes": {
         "backend_tests": "pytest backend/tests",
         "frontend_tests": "cd frontend && npm test",
         "formatting": [
-          "black --check （変更ファイルのみ）",
-          "cd frontend && npm run format:check （変更ファイルのみ）"
+          "black --check (only changed files)",
+          "cd frontend && npm run format:check (only changed files)"
         ],
-        "lint": "ruff check （変更ファイルのみ）",
+        "lint": "ruff check (only changed files)",
         "build": "cd frontend && npm run build",
         "rules": [
-          "対象領域に応じて必要なケースのみ実行する。",
-          "失敗した場合は修正後、全て通過するまで再実行する。"
+          "Run only the checks required for the affected areas.",
+          "Fix issues and rerun every required check until they pass."
         ]
       },
       "doc_or_comment_changes": {
         "skip_checks": true,
         "rules": [
-          "コメントやドキュメント修正のみの場合はテスト・フォーマット・ビルドをスキップ可能。",
-          "ただしコードに影響の可能性がある場合は通常チェックを実行する。"
+          "You may skip tests, formatting, and builds when only documentation or comments change.",
+          "Run the normal checks if the documentation change might affect code behavior."
         ]
       }
     },
     "documentation_and_ui": [
-      "README.md や docs/ 配下を最新仕様に更新する。",
-      "UI に変更がある場合はプレビューで確認しスクリーンショットを取得、マージリクエストに添付する。",
-      "画面バリエーションがある場合は網羅的にキャプチャし、新旧比較も提示する。"
+      "Keep README.md and docs/ aligned with the latest specifications.",
+      "Preview UI changes, capture screenshots, and attach them to the merge request.",
+      "Capture every relevant screen variation and share before/after comparisons."
     ],
     "pre_merge_requirements": {
       "normal_changes": [
-        "コード修正がある場合は全ての必要チェックを通過していること。"
+        "All required checks must pass for code changes."
       ],
       "doc_or_comment_changes": [
-        "コメントやドキュメント修正のみの場合は品質チェック不要。内容確認に集中すること。"
+        "Documentation-only or comment-only changes do not require automated checks; focus on accuracy."
       ],
       "common": [
-        "最新の main を取り込み、コンフリクトがあれば解消すること。",
-        "解消後は必要に応じて再ビルド・再テストを行うこと。",
-        "UI 変更がある場合はスクリーンショットを必ず掲載すること。"
+        "Sync with the latest main and resolve any conflicts.",
+        "Rerun builds or tests after resolving conflicts when needed.",
+        "Always provide screenshots when UI changes are present."
       ]
     }
   }

--- a/docs/features/analytics-insights/detail-design.md
+++ b/docs/features/analytics-insights/detail-design.md
@@ -1,38 +1,37 @@
-# Analytics & Continuous Improvement 詳細設計
+# Analytics & Continuous Improvement Detailed Design
 
-## 1. 目的
-Analytics & Continuous Improvement は、カードボードの絞り込みから管理者向けの分析・改善ダッシュボードまでを横断的に支える機能群です。保存フィルターやスナップショット、Why-Why 分析、提案アクション、イニシアチブ管理を連携させ、AI が生成するレポート草案まで一貫して提供します。【F:frontend/src/app/features/analytics/page.ts†L1-L112】【F:backend/app/routers/analytics.py†L1-L200】
+## 1. Purpose
+Analytics & Continuous Improvement is the cross-cutting capability that supports everything from board filtering to administrator dashboards. It links saved filters, snapshots, Why-Why analyses, suggested actions, initiative management, and AI-generated report drafts into one consistent experience.【F:frontend/src/app/features/analytics/page.ts†L1-L112】【F:backend/app/routers/analytics.py†L1-L200】
 
-## 2. コンポーネント概要
-- **WorkspaceStore** – カード・ラベル・ステータスを Signal ベースで保持し、フィルターやグルーピングをローカルストレージに同期します。【F:frontend/src/app/core/state/workspace-store.ts†L1-L200】
-- **BoardPage** – クイックフィルター、カードグルーピング、ドラッグ＆ドロップを提供し、WorkspaceStore の状態を UI にマッピングします。【F:frontend/src/app/features/board/page.ts†L1-L160】
-- **ContinuousImprovementStore** – 分析スナップショット、原因ツリー、提案アクション、イニシアチブ、レポート草案を統合的に管理します。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L1-L200】
-- **Analytics Router** – スナップショット CRUD と Why-Why 分析生成、提案アクション展開、イニシアチブ更新を行います。【F:backend/app/routers/analytics.py†L16-L200】
-- **Filters Router** – 保存フィルターの CRUD を提供し、ユーザー単位でアクセス制御します。【F:backend/app/routers/filters.py†L1-L78】
-- **SQLAlchemy モデル** – `AnalyticsSnapshot`、`RootCauseAnalysis`、`RootCauseNode`、`SuggestedAction`、`ImprovementInitiative`、`InitiativeProgressLog` が継続的改善データを保持します。【F:backend/app/models.py†L301-L439】
+## 2. Component Overview
+- **WorkspaceStore** – Maintains cards, labels, and statuses with Signals and syncs filters and grouping preferences to local storage.【F:frontend/src/app/core/state/workspace-store.ts†L1-L200】
+- **BoardPage** – Offers quick filters, card grouping, and drag-and-drop interactions while mapping WorkspaceStore state to the UI.【F:frontend/src/app/features/board/page.ts†L1-L160】
+- **ContinuousImprovementStore** – Manages analytics snapshots, cause trees, suggested actions, initiatives, and report drafts in one place.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L1-L200】
+- **Analytics Router** – Handles snapshot CRUD, Why-Why generation, suggested action expansion, and initiative updates.【F:backend/app/routers/analytics.py†L16-L200】
+- **Filters Router** – Provides saved filter CRUD with per-user access control.【F:backend/app/routers/filters.py†L1-L78】
+- **SQLAlchemy models** – `AnalyticsSnapshot`, `RootCauseAnalysis`, `RootCauseNode`, `SuggestedAction`, `ImprovementInitiative`, and `InitiativeProgressLog` persist continuous improvement data.【F:backend/app/models.py†L301-L439】
 
-## 3. ボードフィルタリング設計
-WorkspaceStore はフィルター・グルーピング・テンプレート設定を `signal` で保持し、変化時にボード列やサマリーメトリクスを再計算します。クイックフィルターは定義済み ID をマップし、選択に応じた説明文を UI に提供します。【F:frontend/src/app/core/state/workspace-store.ts†L83-L160】【F:frontend/src/app/features/board/page.ts†L29-L145】
-保存フィルターは `/filters` API と連携し、作成者以外のアクセスは 404 で遮断されます。【F:backend/app/routers/filters.py†L33-L78】
+## 3. Board Filtering Design
+WorkspaceStore keeps filter, grouping, and template settings in Signals and recomputes board columns and summary metrics whenever they change. Quick filters map predefined IDs to explanations rendered in the UI.【F:frontend/src/app/core/state/workspace-store.ts†L83-L160】【F:frontend/src/app/features/board/page.ts†L29-L145】 Saved filters integrate with the `/filters` API, and any request from a non-owner returns 404.【F:backend/app/routers/filters.py†L33-L78】
 
-## 4. Analytics API フロー
-### 4.1 スナップショット
-管理者は `/analytics/snapshots` に対して期間・メトリクス・ナラティブを送信し、レコードが作成されます。クエリ時には `period_start` / `period_end` で重なり期間をフィルタリングします。【F:backend/app/routers/analytics.py†L16-L64】スナップショットはメトリクス JSON、ナラティブ、生成者情報を保存します。【F:backend/app/models.py†L301-L318】
+## 4. Analytics API Flows
+### 4.1 Snapshots
+Administrators send date ranges, metrics, and narratives to `/analytics/snapshots` to create records. Querying uses `period_start` and `period_end` overlap logic to filter results.【F:backend/app/routers/analytics.py†L16-L64】 Snapshots persist metrics JSON, narratives, and creator information.【F:backend/app/models.py†L301-L318】
 
-### 4.2 Why-Why 分析
-`POST /analytics/{target}/why-why` では対象となるスナップショット/カードを解決し、原因ノードと提案アクションを生成して保存します。【F:backend/app/routers/analytics.py†L65-L200】ノードは深さ・信頼度・証拠・推奨メトリクスを保持し、提案アクションはタイトル・説明・労力・インパクト・担当ロール・期限候補を含みます。【F:backend/app/models.py†L318-L427】提案アクションは追加ヒントから最大 2 件の追加アクションを派生させます。【F:backend/app/routers/analytics.py†L80-L163】
+### 4.2 Why-Why Analyses
+`POST /analytics/{target}/why-why` resolves the snapshot or card target, generates cause nodes and suggested actions, and saves them.【F:backend/app/routers/analytics.py†L65-L200】 Nodes store depth, confidence, evidence, and recommended metrics, while suggested actions capture title, description, effort, impact, owner role, and due-date hints.【F:backend/app/models.py†L318-L427】 Suggested actions can spawn up to two additional actions from follow-up hints.【F:backend/app/routers/analytics.py†L80-L163】
 
-### 4.3 イニシアチブ
-`ImprovementInitiative` は提案アクションと関連し、進捗ログを持ちます。Why-Why 分析からカードを起票すると、進捗にイベントが追加されます。【F:backend/app/models.py†L332-L364】【F:frontend/src/app/core/state/continuous-improvement-store.ts†L148-L200】
+### 4.3 Initiatives
+`ImprovementInitiative` records link to suggested actions and maintain progress logs. When a card is created from a Why-Why analysis, a progress event is appended.【F:backend/app/models.py†L332-L364】【F:frontend/src/app/core/state/continuous-improvement-store.ts†L148-L200】
 
-## 5. フロントエンドダッシュボード
-AnalyticsPage は WorkspaceStore と ContinuousImprovementStore を統合し、ステータス・ラベルの枚数、ストーリーポイント合計、スナップショット情報、原因ツリー、提案アクション、レポート草案を描画します。【F:frontend/src/app/features/analytics/page.ts†L1-L112】提案アクションのカード化やスナップショット切り替えは Store のメソッドを呼び出し、Signals を通じて UI を即時更新します。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L75-L200】
+## 5. Frontend Dashboard
+`AnalyticsPage` combines WorkspaceStore and ContinuousImprovementStore to display counts by status and label, story point totals, snapshot data, cause trees, suggested actions, and report drafts.【F:frontend/src/app/features/analytics/page.ts†L1-L112】 Card conversion and snapshot switching call store methods so Signals immediately update the UI.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L75-L200】
 
-## 6. レポート草案生成
-ContinuousImprovementStore はユーザー入力の指示文を保持し、選択中のスナップショットや原因ノード、提案アクションをテンプレート化して Markdown ベースのレポート草案を生成します。スナップショットを切り替えると自動的に草案を再構築します。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L130-L147】
+## 6. Report Draft Generation
+ContinuousImprovementStore stores user prompts and assembles Markdown-based report drafts from the selected snapshot, cause nodes, and suggested actions. Switching snapshots automatically rebuilds the draft.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L130-L147】
 
-## 7. データモデル
-| モデル | 主要フィールド |
+## 7. Data Model
+| Model | Key Fields |
 | --- | --- |
 | `AnalyticsSnapshot` | `period_start`, `period_end`, `metrics`, `narrative`, `generated_by`【F:backend/app/models.py†L301-L318】 |
 | `RootCauseAnalysis` | `target_type`, `version`, `status`, `summary`, `nodes`, `suggestions`【F:backend/app/models.py†L318-L363】 |
@@ -40,15 +39,15 @@ ContinuousImprovementStore はユーザー入力の指示文を保持し、選�
 | `SuggestedAction` | `title`, `description`, `effort_estimate`, `impact_score`, `owner_role`, `due_date_hint`, `status`, `initiative_id`, `created_card_id`【F:backend/app/models.py†L381-L427】 |
 | `ImprovementInitiative` | `status`, `health`, `progress_logs`, `suggested_actions`【F:backend/app/models.py†L332-L364】 |
 
-## 8. セキュリティとアクセス制御
-Analytics ルーターは管理者専用ガード `require_admin` を依存関係として利用し、一般ユーザーからのアクセスを拒否します。【F:backend/app/routers/analytics.py†L16-L32】保存フィルターは作成者 ID によるチェックで不正アクセスを防ぎます。【F:backend/app/routers/filters.py†L33-L78】
+## 8. Security & Access Control
+The Analytics router requires the `require_admin` dependency so only administrators can access it.【F:backend/app/routers/analytics.py†L16-L32】 Saved filters rely on creator ID checks to block unauthorized access.【F:backend/app/routers/filters.py†L33-L78】
 
-## 9. テレメトリ
-- スナップショット作成・更新はイベントログに記録され、期間別の利用率や失敗率を監視します。
-- 提案アクションのカード化時には `created_card_id` が保存されるため、転換率とリードタイムの算出が可能です。【F:backend/app/models.py†L381-L427】
-- フロントでは Signals の更新を活用し、ユーザー行動を analytics SDK で計測できるようセクション分割しています。【F:frontend/src/app/features/analytics/page.ts†L65-L112】
+## 9. Telemetry
+- Log snapshot creation and updates to monitor usage by period and track failure rates.
+- Persist `created_card_id` when converting suggested actions so we can measure conversion rate and lead time.【F:backend/app/models.py†L381-L427】
+- Segment the frontend with Signals so the analytics SDK can capture user behavior per section.【F:frontend/src/app/features/analytics/page.ts†L65-L112】
 
-## 10. テスト戦略
-- **ユニットテスト** – WorkspaceStore/ContinuousImprovementStore の状態変換、フィルター復元、レポート生成ロジックを検証。
-- **API テスト** – `/filters` と `/analytics` の CRUD、期間フィルタ、Why-Why 生成、提案アクション派生、アクセス制御を網羅。
-- **エンドツーエンドシナリオ** – スナップショット選択から提案アクションカード化、レポート草案更新までを UI 経由で確認。
+## 10. Test Strategy
+- **Unit tests** – Validate WorkspaceStore/ContinuousImprovementStore state transitions, filter restoration, and report generation logic.
+- **API tests** – Cover `/filters` and `/analytics` CRUD, date filtering, Why-Why generation, suggested action branching, and access control.
+- **End-to-end scenarios** – Verify the flow from choosing a snapshot through card conversion and report draft updates via the UI.

--- a/docs/features/analytics-insights/requirements.md
+++ b/docs/features/analytics-insights/requirements.md
@@ -9,78 +9,78 @@
 | Status | Approved |
 
 ## 1. Background & Objectives
-ワークスペースでは日々の改善活動がカードとして蓄積されていますが、従来のボードでは主要課題の俯瞰や因果分析、フォローアップの管理が困難でした。Analytics & Continuous Improvement 機能は、ボードのフィルタリングから根本原因分析、改善施策の追跡、レポート化までを一連の体験として提供します。【F:frontend/src/app/features/board/page.ts†L1-L160】【F:frontend/src/app/features/analytics/page.ts†L1-L112】【F:backend/app/routers/analytics.py†L1-L200】
+Cards that represent daily improvement work already accumulate on the workspace boards, but the legacy board experience makes it hard to understand the biggest issues, analyze causes, and manage follow-up. The Analytics & Continuous Improvement feature delivers a connected flow that covers filtering, root-cause analysis, initiative tracking, and reporting.【F:frontend/src/app/features/board/page.ts†L1-L160】【F:frontend/src/app/features/analytics/page.ts†L1-L112】【F:backend/app/routers/analytics.py†L1-L200】
 
 ### Objectives
-1. カードボードで必要なタスクを素早く絞り込み、ストーリーポイントやステータスの傾向を可視化する。【F:frontend/src/app/core/state/workspace-store.ts†L1-L200】
-2. 管理者が分析スナップショットや Why-Why 分析を作成し、根本原因と提案アクションを体系的に管理できるようにする。【F:backend/app/routers/analytics.py†L16-L200】【F:backend/app/models.py†L301-L439】
-3. 改善施策の進捗やレポート草案をダッシュボードで確認し、AI 生成された要約をチームで再利用できるようにする。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L1-L200】
+1. Allow users to quickly narrow the board to relevant tasks and visualize trends in story points and status.【F:frontend/src/app/core/state/workspace-store.ts†L1-L200】
+2. Let administrators create analytics snapshots and Why-Why analyses so they can manage root causes and suggested actions systematically.【F:backend/app/routers/analytics.py†L16-L200】【F:backend/app/models.py†L301-L439】
+3. Enable teams to monitor initiative progress and report drafts from dashboards, and reuse AI-generated summaries across the team.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L1-L200】
 
 ## 2. Success Metrics
 | Metric | Target | Measurement |
 | --- | --- | --- |
-| 保存済みフィルター再利用率 | アクティブユーザーの 60% が週 1 回以上保存済みフィルターを適用 | `filter_saved` / `filter_applied` イベント |
-| 分析スナップショット活用率 | 管理者の 50% が月 1 回以上スナップショットを作成 | `/analytics/snapshots` POST ログ |
-| 提案アクション転換率 | 提案アクションの 40% がカードに変換 | `SuggestedAction.created_card_id` 比率【F:backend/app/models.py†L381-L427】|
-| レポート生成採用率 | ダッシュボード利用ワークスペースの 30% が月 1 回レポート草案を生成 | `report.generate` イベント |
+| Saved filter reuse rate | 60% of active users apply a saved filter at least once per week | `filter_saved` / `filter_applied` events |
+| Analytics snapshot utilization | 50% of administrators create a snapshot at least once per month | `/analytics/snapshots` POST logs |
+| Suggested action conversion rate | 40% of suggested actions become cards | Ratio of `SuggestedAction.created_card_id` values【F:backend/app/models.py†L381-L427】|
+| Report generation adoption | 30% of workspaces using the dashboard create a draft report each month | `report.generate` events |
 
 ## 3. Scope
 ### In Scope
-- ボードのクイックフィルター、ラベル/ステータス絞り込み、グルーピング切り替え、サマリー統計の表示。【F:frontend/src/app/features/board/page.ts†L1-L160】【F:frontend/src/app/core/state/workspace-store.ts†L1-L200】
-- 保存フィルター CRUD API (`/filters`) とフロントでの保存/適用体験。【F:backend/app/routers/filters.py†L1-L78】
-- Analytics API によるスナップショット作成・取得と Why-Why 分析、提案アクション生成。【F:backend/app/routers/analytics.py†L16-L200】
-- Root cause / Suggested action / Initiative モデルによる継続的改善データの永続化。【F:backend/app/models.py†L301-L427】
-- フロントの ContinuousImprovementStore によるスナップショット選択、原因ツリー、提案アクションのカード化、レポート草案生成。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L1-L200】
+- Quick filters, label/status filtering, grouping switches, and summary statistics on the board.【F:frontend/src/app/features/board/page.ts†L1-L160】【F:frontend/src/app/core/state/workspace-store.ts†L1-L200】
+- Saved filter CRUD API (`/filters`) and the save/apply experience on the frontend.【F:backend/app/routers/filters.py†L1-L78】
+- Analytics API endpoints for creating and retrieving snapshots, running Why-Why analyses, and generating suggested actions.【F:backend/app/routers/analytics.py†L16-L200】
+- Persistence of continuous improvement data through Root Cause / Suggested Action / Initiative models.【F:backend/app/models.py†L301-L427】
+- Frontend `ContinuousImprovementStore` flows for selecting snapshots, browsing cause trees, converting suggested actions to cards, and generating report drafts.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L1-L200】
 
 ### Out of Scope
-- 外部 BI ツールへの自動エクスポート。
-- モバイル専用 UI。
-- AI による完全自動カード作成（承認フローなし）。
+- Automatic export to external BI tools.
+- Mobile-only UI.
+- Fully automated card creation by AI without approval.
 
 ## 4. Personas
 | Persona | Goals | Key Needs |
 | --- | --- | --- |
-| Product Manager | 再発する問題を把握し改善施策を優先したい | ラベル/ステータスごとの傾向と原因ツリー |
-| Engineering Lead | 提案アクションをタスクへ落とし込みたい | ワンクリックのカード化と進捗トラッキング |
-| Executive Sponsor | 定期レポートで改善成果を確認したい | AI がまとめたレポート草案と KPI 変化 |
+| Product Manager | Understand recurring issues and prioritize improvement work | Trend views by label/status and cause trees |
+| Engineering Lead | Turn suggested actions into tasks | One-click card conversion and progress tracking |
+| Executive Sponsor | Review improvement results in regular reports | AI-generated report drafts and KPI deltas |
 
 ## 5. User Stories & Acceptance Criteria
-1. **Board Filtering** – ユーザーはクイックフィルター、ラベル、ステータス、検索テキストでカード一覧を絞り込める。フィルター状態はストアに保持され、ドラッグ＆ドロップ操作でも維持される。【F:frontend/src/app/features/board/page.ts†L1-L160】【F:frontend/src/app/core/state/workspace-store.ts†L83-L160】
-2. **Filter Persistence** – ユーザーはフィルターを保存・更新・削除でき、保存者以外は閲覧できない。`/filters` API は認証ユーザーのレコードのみ返却する。【F:backend/app/routers/filters.py†L1-L78】
-3. **Analytics Snapshots** – 管理者は期間とメトリクスを指定してスナップショットを作成し、API から一覧取得・詳細確認ができる。期間フィルターを指定すると開始/終了日の交差判定で絞り込む。【F:backend/app/routers/analytics.py†L16-L64】
-4. **Why-Why Analyses** – 管理者はスナップショットやカードを対象に Why-Why 分析を作成し、原因ノードと提案アクションが自動生成される。提案にはタイトル・説明・労力・オーナーロールが含まれる。【F:backend/app/routers/analytics.py†L65-L200】【F:backend/app/models.py†L344-L427】
-5. **Suggested Action Conversion** – ユーザーは提案アクションをカードに変換でき、変換後は `status='converted'` とカード ID が保存される。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L148-L189】
-6. **Initiative Tracking** – イニシアチブは進捗ログとサマリーを保持し、ダッシュボードでステータスとヘルスを確認できる。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L108-L198】【F:backend/app/models.py†L332-L364】
-7. **Report Drafting** – 利用者は指示文を入力して AI レポート草案を生成し、スナップショット切り替え時に内容が更新される。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L130-L147】
+1. **Board Filtering** – Users can narrow the card list with quick filters, labels, statuses, and text search. Filter state is stored so drag-and-drop operations keep the active filters.【F:frontend/src/app/features/board/page.ts†L1-L160】【F:frontend/src/app/core/state/workspace-store.ts†L83-L160】
+2. **Filter Persistence** – Users can save, update, and delete filters, and only the creator can view them. The `/filters` API returns records for the authenticated user only.【F:backend/app/routers/filters.py†L1-L78】
+3. **Analytics Snapshots** – Administrators specify a date range and metrics to create snapshots, retrieve the list via the API, and inspect details. Range filtering uses date-overlap logic for start/end values.【F:backend/app/routers/analytics.py†L16-L64】
+4. **Why-Why Analyses** – Administrators can generate Why-Why analyses from snapshots or cards, and the system auto-creates cause nodes and suggested actions with titles, descriptions, effort, and owner roles.【F:backend/app/routers/analytics.py†L65-L200】【F:backend/app/models.py†L344-L427】
+5. **Suggested Action Conversion** – Users can convert suggested actions into cards. After conversion, the action is saved with `status='converted'` and the card ID.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L148-L189】
+6. **Initiative Tracking** – Initiatives store progress logs and summaries so dashboards can show status and health.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L108-L198】【F:backend/app/models.py†L332-L364】
+7. **Report Drafting** – Users enter instructions to generate AI report drafts, and switching snapshots refreshes the draft content.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L130-L147】
 
 ## 6. Functional Requirements
 ### 6.1 Board & Filters
-- クイックフィルターは `myAssignments` `dueSoon` `recentlyCreated` `highPriority` `noAssignee` を提供し、UI 文言をローカライズする。【F:frontend/src/app/features/board/page.ts†L29-L59】
-- 直近で使用したフィルターとグルーピングをローカルストレージに保存し、次回訪問時に復元する。【F:frontend/src/app/core/state/workspace-store.ts†L22-L160】
-- 保存フィルターの定義は任意の JSON を保持し、API は所有者以外のアクセスを 404 で拒否する。【F:backend/app/routers/filters.py†L33-L78】
+- Quick filters include `myAssignments`, `dueSoon`, `recentlyCreated`, `highPriority`, and `noAssignee`, and their labels are localized in the UI.【F:frontend/src/app/features/board/page.ts†L29-L59】
+- Recently used filters and grouping preferences are stored in local storage and restored on the next visit.【F:frontend/src/app/core/state/workspace-store.ts†L22-L160】
+- Saved filter definitions can persist arbitrary JSON, and the API returns 404 when someone other than the owner tries to access a filter.【F:backend/app/routers/filters.py†L33-L78】
 
 ### 6.2 Analytics & Why-Why
-- スナップショットは期間・メトリクス・ナラティブを JSON カラムに保存し、最新順で取得する。【F:backend/app/routers/analytics.py†L16-L64】【F:backend/app/models.py†L301-L318】
-- Why-Why 分析は深さごとのノード、提案アクション、推奨メトリクスを持ち、スナップショットまたはカードと関連付けられる。【F:backend/app/models.py†L318-L427】
-- 提案アクションはタイトル/説明/労力/インパクト/担当ロール/期限候補を格納し、最大 2 件の追加アクションを派生させる。【F:backend/app/routers/analytics.py†L80-L163】
+- Snapshots store date ranges, metrics, and narratives in JSON columns and return results in descending order.【F:backend/app/routers/analytics.py†L16-L64】【F:backend/app/models.py†L301-L318】
+- Why-Why analyses manage depth-based nodes, suggested actions, and recommended metrics linked to snapshots or cards.【F:backend/app/models.py†L318-L427】
+- Suggested actions capture title, description, effort, impact, responsible role, and due-date candidates, and can spawn up to two additional follow-up actions.【F:backend/app/routers/analytics.py†L80-L163】
 
 ### 6.3 Continuous Improvement UI
-- フロントストアはスナップショット・分析・イニシアチブを Signals で保持し、選択変更時にレポート草案を再生成する。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L24-L147】
-- 提案アクションをカード化する際は、カード作成ヘルパーにタイトル・サマリー・推奨ステータス・ラベルを渡し、進捗ログを追加する。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L148-L200】
+- The frontend store keeps snapshots, analyses, and initiatives in Angular Signals and regenerates report drafts whenever the selection changes.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L24-L147】
+- When converting suggested actions to cards, pass the title, summary, recommended status, and labels to the card creation helper and append a progress log entry.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L148-L200】
 
 ## 7. Non-Functional Requirements
-- **Performance** – ボード操作は 50 ms 以内で再描画し、スナップショット API は期間フィルタ付きでも 400 ms 未満で応答する。
-- **Security** – Analytics API は管理者ガードを通過したユーザーのみ利用できる。【F:backend/app/routers/analytics.py†L16-L32】
-- **Reliability** – Why-Why 分析生成中にエラーが発生した場合、生成済みノードをロールバックし再試行可能にする。【F:backend/app/routers/analytics.py†L98-L200】
-- **Observability** – スナップショット作成や提案アクション生成時のイベントをメトリクスに記録し、失敗率 >5% でアラートを発報する。
+- **Performance** – Board interactions re-render within 50 ms, and the snapshot API responds within 400 ms even when filtered by date range.
+- **Security** – The Analytics API is available only to users who pass the administrator guard.【F:backend/app/routers/analytics.py†L16-L32】
+- **Reliability** – If an error occurs while generating a Why-Why analysis, roll back the created nodes so users can retry.【F:backend/app/routers/analytics.py†L98-L200】
+- **Observability** – Record metrics when creating snapshots and suggested actions, and raise an alert when the failure rate exceeds 5%.
 
 ## 8. Risks & Mitigations
 | Risk | Mitigation |
 | --- | --- |
-| フィルター設定が複雑化しユーザーが混乱する | 推奨クイックフィルターと保存済みプリセットを提供し、直近利用設定を自動復元する。【F:frontend/src/app/core/state/workspace-store.ts†L83-L160】 |
-| 提案アクションが放置される | 変換済み状態をダッシュボードで可視化し、進捗ログを自動追記する。【F:frontend/src/app/core/state/continuous-improvement-store.ts†L148-L200】 |
-| 分析データへの権限逸脱 | Analytics ルーターは管理者権限チェックを必須化する。【F:backend/app/routers/analytics.py†L16-L32】 |
+| Users get lost in complex filter settings | Provide recommended quick filters and saved presets, and automatically restore the last-used settings.【F:frontend/src/app/core/state/workspace-store.ts†L83-L160】 |
+| Suggested actions are ignored | Visualize converted status on the dashboard and append progress logs automatically.【F:frontend/src/app/core/state/continuous-improvement-store.ts†L148-L200】 |
+| Unauthorized access to analytics data | Require admin permission checks on all Analytics routes.【F:backend/app/routers/analytics.py†L16-L32】 |
 
 ## 9. Open Questions
-- スナップショットの KPI 定義をワークスペースごとにカスタマイズする要望への対応方針。
-- フィードバックサマリーを自動でイニシアチブに紐付けるためのデータスキーマ拡張。
+- How should we support requests to customize snapshot KPI definitions per workspace?
+- Do we need to extend the data schema so feedback summaries can automatically link to initiatives?

--- a/docs/features/appeal-generation/requirements.md
+++ b/docs/features/appeal-generation/requirements.md
@@ -9,66 +9,66 @@
 | Status | Approved |
 
 ## 1. Background & Objectives
-カードの活動履歴から成果を説明するアピール文の作成は、担当者ごとに構成や語調がばらつき、レビューや社内申請のたびに時間が掛かっていました。Appeal Narrative Generation 機能は、カードに紐づく実績と選択した構成要素をもとに AI が叙述を生成し、成果報告の品質を一定に保つことを目的とします。【F:backend/app/routers/appeals.py†L1-L27】【F:backend/app/services/appeals.py†L1-L200】
+Creating appeal narratives from card activity histories used to take time because every owner applied a different structure and tone when preparing reviews or internal submissions. The Appeal Narrative Generation feature uses card achievements and selected structure elements to generate consistent narratives with AI, keeping report quality aligned.【F:backend/app/routers/appeals.py†L1-L27】【F:backend/app/services/appeals.py†L1-L200】
 
 ### Objectives
-1. ラベルまたは自由入力からアピール対象を選択し、推奨フローを土台に 1～5 ステップの因果構成を調整できること。【F:backend/app/services/appeals.py†L32-L115】
-2. Markdown・箇条書き・CSV テーブルの 3 フォーマットを同時に生成し、各フォーマットが編集/エクスポートしやすい構造になっていること。【F:backend/app/services/appeals.py†L32-L152】
-3. OpenAI 連携に失敗した場合でもフォールバック文章を返し、生成履歴に保存することでレポート作成を継続できること。【F:backend/app/services/appeals.py†L106-L162】【F:backend/app/repositories/appeals.py†L17-L50】
+1. Let users choose the appeal subject from a label or custom text and adjust a 1–5 step causal structure based on recommended flows.【F:backend/app/services/appeals.py†L32-L115】
+2. Generate Markdown, bullet list, and CSV table formats at the same time, with each format easy to edit or export.【F:backend/app/services/appeals.py†L32-L152】
+3. Return fallback copy and save the generation history when OpenAI calls fail so users can keep working on reports.【F:backend/app/services/appeals.py†L106-L162】【F:backend/app/repositories/appeals.py†L17-L50】
 
 ## 2. Success Metrics
 | Metric | Target | Measurement |
 | --- | --- | --- |
-| 生成採用率 | 60% の生成結果が編集後に共有/提出される | `appeal.generate`、`appeal.export` イベント解析 |
-| 生成所要時間 | p95 8 秒以内 | API レイテンシーログ |
-| 再試行率 | 10% 未満 | フォールバック発生とリトライ回数 |
+| Adoption of generated narratives | 60% of outputs are shared or submitted after edits | Analyze `appeal.generate` and `appeal.export` events |
+| Generation time | p95 within 8 seconds | API latency logs |
+| Retry rate | Under 10% | Count of fallbacks and retries |
 
 ## 3. Scope
 ### In Scope
-- `/appeals/config` によるラベル一覧・推奨フロー・対応フォーマットの取得。【F:backend/app/services/appeals.py†L70-L115】
-- `/appeals/generate` でのアピール生成、XSS マスキング、ChatGPT 呼び出し、フォールバック構築、履歴保存。【F:backend/app/services/appeals.py†L78-L155】
-- 生成結果とトークン使用量、警告メッセージを JSON として返却。【F:backend/app/services/appeals.py†L145-L163】
-- `appeal_generations` テーブルでの履歴保管と最新 20 件の取得。【F:backend/app/models.py†L708-L723】【F:backend/app/repositories/appeals.py†L17-L50】
+- Retrieve label lists, recommended flows, and supported formats through `/appeals/config`.【F:backend/app/services/appeals.py†L70-L115】
+- Generate appeals through `/appeals/generate`, including XSS masking, ChatGPT calls, fallback construction, and history storage.【F:backend/app/services/appeals.py†L78-L155】
+- Return JSON that includes generation output, token usage, and warning messages.【F:backend/app/services/appeals.py†L145-L163】
+- Persist generation history in the `appeal_generations` table and retrieve the latest 20 records.【F:backend/app/models.py†L708-L723】【F:backend/app/repositories/appeals.py†L17-L50】
 
 ### Out of Scope
-- UI でのテンプレート編集機能（別ロードマップ扱い）。
-- 生成結果の PDF 変換やワークスペース共有設定。
-- 多言語対応と複数ラベル同時選択のサポート。
+- Template editing in the UI (planned separately).
+- PDF export or workspace-level sharing controls.
+- Multilingual support and selecting multiple labels at once.
 
 ## 4. Personas
 | Persona | Goals | Key Needs |
 | --- | --- | --- |
-| Continuous Improvement Lead | エグゼクティブ向け報告書の品質を揃えたい | 推奨フローとフォーマットの自動構成 |
-| Team Facilitator | レトロスペクティブで成果を共有したい | 達成ハイライトを含む要約生成 |
-| Customer Success Manager | 顧客向けアピール資料を短時間で準備したい | Markdown や CSV で再利用可能な文書 |
+| Continuous Improvement Lead | Keep executive-facing reports consistent | Recommended flows and automatic format assembly |
+| Team Facilitator | Share achievements during retrospectives | Summaries with highlighted wins |
+| Customer Success Manager | Prepare customer appeal materials quickly | Reusable Markdown and CSV documents |
 
 ## 5. User Stories & Acceptance Criteria
-1. **Config 取得** – ユーザーは推奨フローと選択可能フォーマットを確認できる。`GET /appeals/config` はユーザー所有のラベルと推奨フロー `課題→対策→実績→所感` を返し、フォーマットは `markdown` `bullet_list` `table` の 3 種類である。【F:backend/app/services/appeals.py†L70-L115】
-2. **生成リクエスト** – ユーザーは subject/type/flow/formats を指定して生成を実行できる。flow と formats は重複不可で 1～5 ステップに制限され、`label` 指定時は該当ラベルの所有権が検証される。【F:backend/app/schemas.py†L1015-L1059】【F:backend/app/services/appeals.py†L84-L103】
-3. **成果要約の統合** – ラベル経由で紐づく達成実績を取得し、サニタイズした上でプロンプトやフォールバックに利用する。【F:backend/app/services/appeals.py†L101-L135】【F:backend/app/services/appeals.py†L169-L199】
-4. **フォールバック** – ChatGPT 呼び出しに失敗した場合でも、フォーマット別テンプレートで内容を補完し、`generation_status='fallback'` と警告を返す。【F:backend/app/services/appeals.py†L106-L162】【F:backend/app/services/appeal_prompts.py†L96-L173】
-5. **履歴保存** – 生成が完了すると subject/flow/formats/警告/トークン使用量を保存し、レスポンスに生成 ID を含める。【F:backend/app/services/appeals.py†L145-L163】【F:backend/app/repositories/appeals.py†L17-L41】
+1. **Config retrieval** – Users review recommended flows and available formats. `GET /appeals/config` returns the user's labels, the suggested flow `Problem → Action → Result → Reflection`, and the three formats `markdown`, `bullet_list`, and `table`.【F:backend/app/services/appeals.py†L70-L115】
+2. **Generation request** – Users specify subject/type/flow/formats when triggering generation. Flow and format values cannot repeat, are limited to 1–5 steps, and label subjects validate label ownership.【F:backend/app/schemas.py†L1015-L1059】【F:backend/app/services/appeals.py†L84-L103】
+3. **Achievement integration** – For label subjects, fetch linked achievements, sanitize them, and feed them into prompts and fallback content.【F:backend/app/services/appeals.py†L101-L135】【F:backend/app/services/appeals.py†L169-L199】
+4. **Fallback handling** – When the ChatGPT call fails, build format-specific fallback text, return `generation_status='fallback'`, and include warnings.【F:backend/app/services/appeals.py†L106-L162】【F:backend/app/services/appeal_prompts.py†L96-L173】
+5. **History storage** – After generation, save subject, flow, formats, warnings, and token usage, and include the generation ID in the response.【F:backend/app/services/appeals.py†L145-L163】【F:backend/app/repositories/appeals.py†L17-L41】
 
 ## 6. Functional Requirements
-1. **Subject Handling** – `label` タイプは所有者チェックとラベル名取得、`custom` タイプは HTML エスケープと 120 文字制限を行う。【F:backend/app/services/appeals.py†L84-L175】
-2. **Achievements Retrieval** – ラベル指定時はカード実績を時系列で収集し、タイトル・サマリーを個人情報マスキング後に利用する。【F:backend/app/services/appeals.py†L101-L199】
-3. **Prompt Composition** – Jinja テンプレートを使い、フロー説明・フォーマット定義・因果接続詞をプロンプトに含める。テンプレート読み込みに失敗した場合はフォールバックのみ実行する。【F:backend/app/services/appeal_prompts.py†L21-L118】【F:backend/app/services/appeals.py†L54-L144】
-4. **Response Validation** – ChatGPT 応答を JSON スキーマで検証し、各フォーマットの本文とトークン使用量をマージする。【F:backend/app/services/appeal_prompts.py†L120-L156】【F:backend/app/services/appeals.py†L117-L138】
-5. **Warnings** – 因果推奨を外れたフロー選択時は警告配列を付与し、UI に表示可能なテキストを返却する。【F:backend/app/services/appeals.py†L272-L279】
+1. **Subject handling** – For the `label` type, verify ownership and load the label name; for `custom`, escape HTML and limit the text to 120 characters.【F:backend/app/services/appeals.py†L84-L175】
+2. **Achievements retrieval** – When a label is selected, gather card achievements chronologically and mask personal data in titles and summaries before use.【F:backend/app/services/appeals.py†L101-L199】
+3. **Prompt composition** – Use Jinja templates to include flow descriptions, format definitions, and causal connectors in the prompt. If template loading fails, run only the fallback flow.【F:backend/app/services/appeal_prompts.py†L21-L118】【F:backend/app/services/appeals.py†L54-L144】
+4. **Response validation** – Validate ChatGPT responses against a JSON schema and merge body content with token usage per format.【F:backend/app/services/appeal_prompts.py†L120-L156】【F:backend/app/services/appeals.py†L117-L138】
+5. **Warnings** – When users choose flows outside the recommended causal order, append warning entries that the UI can display.【F:backend/app/services/appeals.py†L272-L279】
 
 ## 7. Non-Functional Requirements
-- **Reliability** – ChatGPT 未設定またはタイムアウト時もフォールバックを返却し、HTTP 503 などのエラーは避ける。【F:backend/app/services/appeals.py†L106-L162】
-- **Security** – 件名・実績内のメールや電話番号をマスキングし、HTML をエスケープする。【F:backend/app/services/appeals.py†L169-L199】
-- **Observability** – 生成時間とフォールバック率をログ計測し、8 秒 SLA 超過時にアラート設定できるようメトリクスを出力する。【F:backend/app/services/appeals.py†L117-L145】
-- **Extensibility** – フォーマット定義はクラス変数で管理し、将来の追加に備える。【F:backend/app/services/appeals.py†L32-L75】
+- **Reliability** – Return fallback content when ChatGPT is misconfigured or times out, avoiding HTTP 503 errors.【F:backend/app/services/appeals.py†L106-L162】
+- **Security** – Mask emails and phone numbers in subjects and achievements, and escape HTML.【F:backend/app/services/appeals.py†L169-L199】
+- **Observability** – Log generation time and fallback rate, and emit metrics so we can alert when the 8-second SLA is exceeded.【F:backend/app/services/appeals.py†L117-L145】
+- **Extensibility** – Manage format definitions with class variables to support future additions.【F:backend/app/services/appeals.py†L32-L75】
 
 ## 8. Risks & Mitigations
 | Risk | Mitigation |
 | --- | --- |
-| フォールバック文章が汎用的すぎる | 達成実績やフローをテンプレートに含め、接続詞で因果関係を補強する。【F:backend/app/services/appeal_prompts.py†L96-L173】 |
-| ラベル共有に伴うデータ漏えい | 所有者チェックとマスキング処理で他ワークスペースの情報が混入しないようにする。【F:backend/app/services/appeals.py†L84-L199】 |
-| ChatGPT 設定ミス | プロンプトビルダー初期化に失敗した場合の警告ログとフォールバック動作で影響を局所化する。【F:backend/app/services/appeals.py†L54-L143】 |
+| Fallback text sounds too generic | Include achievements and flow information in the template and reinforce causality with connectors.【F:backend/app/services/appeal_prompts.py†L96-L173】 |
+| Label sharing causes data leaks | Combine ownership checks with masking so other workspace data never appears.【F:backend/app/services/appeals.py†L84-L199】 |
+| ChatGPT configuration mistakes | Log warnings when prompt builder initialization fails and fall back automatically to limit the blast radius.【F:backend/app/services/appeals.py†L54-L143】 |
 
 ## 9. Open Questions
-- 生成履歴の UI 提供タイミングと保持件数の上限はどこまで必要か。
-- ワークスペース単位で推奨フローをカスタマイズする要望をどのように管理するか。
+- When should we surface the generation history UI, and how many records should it display?
+- How will we manage workspace-level requests to customize the recommended flow?

--- a/docs/ui-design-system.md
+++ b/docs/ui-design-system.md
@@ -1,151 +1,137 @@
-# UI デザインシステム（シンプル&モダン版）
+# UI Design System (Simple & Modern)
 
-アプリ全体にミニマルでモダン、そして洗練されたトーンを行き渡らせるため、視覚構造・タイポグラフィ・コンポーネントの仕様を下記の方針で再整理しました。光と影のコントラスト、配色トークン、操作状態の一貫性を軸にライト／ダーク両テーマで同じ質感を保ちます。各画面の改修や新機能追加時は、本ドキュメントを基準に UI を設計してください。
+To deliver a minimal, modern, and polished tone across the app, the visual structure, typography, and component specifications follow the guidelines below. By balancing light and shadow, shared color tokens, and consistent interaction states, both light and dark themes maintain the same texture. Use this document as the reference whenever you redesign screens or ship new features.
 
-## コアデザイン原則
-1. **余白で魅せる** – 情報密度を抑え、広めの余白と明瞭なグリッドで呼吸感のあるレイアウトを構築する。
-2. **コントラストを厳選する** – ベースはニュートラルカラーで構成し、アクセントカラーは重要なアクションや状態のみに限定する。ライト/ダーク双方で背景とテキストのコントラスト比 4.5:1 以上（大きなテキストは 3:1 以上）を確保する。
-3. **操作の迷いを無くす** – ボタンやナビゲーションをシンプルな形状・配色で揃え、どこで操作できるかを即座に判断できるようにする。
-4. **アクセシブルであること** – 十分なコントラスト、明瞭なフォーカス、スクリーンリーダー向けの構造化を標準仕様とする。
+## Core Design Principles
+1. **Let whitespace breathe** – Keep information density low and rely on generous spacing plus a clear grid for layouts that feel calm.
+2. **Be intentional with contrast** – Build on neutral base colors and reserve accent colors for the most important actions or states. Ensure 4.5:1 contrast between text and background (3:1 for large text) in both themes.
+3. **Remove hesitation** – Align buttons and navigation with simple shapes and colors so users instantly see where they can take action.
+4. **Stay accessible** – Treat sufficient contrast, clear focus states, and screen-reader-friendly structure as the default.
 
-## ビジュアルファウンデーション
-### カラーパレット
-- **トークン構成**: すべての色は `--color-{semantic}-{state}-{theme}` の命名で管理し、テーマ（`light` / `dark`）と状態（`default` / `hover` / `active` / `disabled`）を明示する。
-- **ベース**: `--color-surface`、`--color-surface-alt` を主に使用し、段差は 1px のボーダーや背景トーンの差で表現する。ライトテーマはニュートラル 50〜200、ダークテーマはニュートラル 800〜950 を中心にし、シャドウの代わりに `color-mix` で調整した縁取りを活用する。
-- **テキスト**: `--color-text-primary`、`--color-text-secondary` を使い分け、見出しは濃度 90%、補助テキストは 60% を目安にする。ダークテーマでは透過度ではなく明度差で調整し、背景との差を 60 以上（Lab 値換算）確保する。
-- **アクセント**: プライマリアクションは `--color-accent`、肯定/警告/エラーは `--color-success` / `--color-warning` / `--color-danger` を用いる。アクセントの乱用を避けるため、ページごとの固有色はトークンのトーン差（濃淡）で表現する。
-- **サーフェス**: `--surface-layer-{1-4}` を階層化トークンとして定義し、カード/パネル/ステータスピルの背景に使用する。各レイヤーは `--surface-card` と `--surface-card-muted` のグラデーション値から生成し、ライト/ダークテーマともに同じ構造で入れ替わる。
+## Visual Foundation
+### Color Palette
+- **Token structure**: Name every color `--color-{semantic}-{state}-{theme}` to clarify the theme (`light` / `dark`) and interaction state (`default` / `hover` / `active` / `disabled`).
+- **Base surfaces**: Use `--color-surface` and `--color-surface-alt`, expressing elevation with 1px borders or subtle tone shifts. The light theme centers on neutrals 50–200; the dark theme centers on neutrals 800–950 and relies on `color-mix` borders instead of heavy shadows.
+- **Text**: Combine `--color-text-primary` and `--color-text-secondary`. Headings target 90% strength, supporting text about 60%. In the dark theme, change lightness instead of opacity and keep at least a 60-point Lab difference from the background.
+- **Accent**: Use `--color-accent` for primary actions and `--color-success` / `--color-warning` / `--color-danger` for feedback states. To avoid overusing accents, differentiate page-specific colors by token tone rather than introducing new hues.
+- **Surfaces**: Define `--surface-layer-{1-4}` tokens for layered surfaces. Apply them to cards, panels, and status pills. Each layer derives from `--surface-card` and `--surface-card-muted`, swapping values consistently between light and dark themes.
 
-### テーマ & コントラスト指針
-| 対象 | ライトテーマ | ダークテーマ | メモ |
+### Theme & Contrast Guidance
+| Element | Light Theme | Dark Theme | Notes |
 | --- | --- | --- | --- |
-| ページ背景 | `--color-surface-light-default` #F8FAFC | `--color-surface-dark-default` #0F172A | いずれもテキストとのコントラスト 4.5:1 以上を担保する。
-| カード背景 | `--color-surface-alt-light-default` #FFFFFF | `--color-surface-alt-dark-default` #1E293B | 明度差とヘアラインボーダーでコンテナとの差を明示。
-| プライマリテキスト | `--color-text-primary-light` #0F172A | `--color-text-primary-dark` #F8FAFC | 大文字見出しも 3:1 以上を厳守。
-| セカンダリテキスト | `--color-text-secondary-light` rgba(15,23,42,0.65) | `--color-text-secondary-dark` rgba(248,250,252,0.70) | 透明度ではなくコントラスト比を都度計測する。 |
+| Page background | `--color-surface-light-default` #F8FAFC | `--color-surface-dark-default` #0F172A | Maintain ≥4.5:1 contrast with text. |
+| Card background | `--color-surface-alt-light-default` #FFFFFF | `--color-surface-alt-dark-default` #1E293B | Highlight elevation with subtle borders and tone shifts. |
+| Primary text | `--color-text-primary-light` #0F172A | `--color-text-primary-dark` #F8FAFC | Even uppercase headings must meet 3:1. |
+| Secondary text | `--color-text-secondary-light` rgba(15,23,42,0.65) | `--color-text-secondary-dark` rgba(248,250,252,0.70) | Measure contrast rather than relying on opacity. |
 
-> **チェックルール**: 主要コンポーネントの各状態（デフォルト/ホバー/アクティブ/フォーカス/ディスエーブル）は、背景と文字色、背景とボーダー色のコントラスト比を 3:1 以上（可能な限り 4.5:1 以上）に保つ。ダークテーマでは彩度よりも明度差を優先し、アクセントカラーの WCAG AA 適合を確認する。
+> **Check rule**: For every major component state (default/hover/active/focus/disabled), keep background-to-text and background-to-border contrast at 3:1 or higher (aim for 4.5:1). In the dark theme, emphasize lightness differences and verify that accent colors meet WCAG AA.
 
-### サーフェスレイヤー & ボーダー
-| トークン | ライトテーマ | ダークテーマ | 主な用途 |
+### Surface Layers & Borders
+| Token | Light Theme | Dark Theme | Primary Usage |
 | --- | --- | --- | --- |
-| `--surface-layer-1` | `linear-gradient` の上部色。`--surface-card` を 96% ブレンド | `--surface-card` を 94% ブレンド | 基本カード、フォームフィールド、ユーザバッジ |
-| `--surface-layer-2` | `--surface-card` を 88% ブレンド | `--surface-card` を 86% ブレンド | セクション／パネルの下部色、カードのボトムトーン |
-| `--surface-layer-3` | `--surface-card` を 78% ブレンド | `--surface-card` を 76% ブレンド | ピル、トグル、ホバー時のサーフェス |
-| `--surface-layer-4` | `--surface-card` を 68% ブレンド | `--surface-card` を 66% ブレンド | オーバーレイのニュートラルトーン、階層差を強調したい領域 |
-`--border-card` / `--border-card-strong` を境界線の標準とし、`--border-subtle` は背景トーンとの差が小さいテキストや要素に限定する。ページラッパーやサブコンテナは `1px solid color-mix(in srgb, var(--color-surface-inverse) 14%, transparent)` のような淡い実線で囲み、背景にはカードより 4% 暗いトーンを敷いて階層を示す。カード・モジュールは `var(--color-border-strong)` を用いた 1px 実線で縁取り、内側に 1px の `inset` ラインを加えて視認性を補強する。状態変化時（ホバー/フォーカス）はボーダー色を 8〜10% 変化させ、背景トーンのシフトと組み合わせてシャドウ無しでも浮き上がりを感じさせる。カード間の視覚的な段差はレイヤートークンの組み合わせ（例: `layer-1` → `layer-2`、`layer-2` → `layer-3`）で統一する。
-### ボーダー & レイヤリング
-ライト/ダーク双方で統一した階層感を作るため、以下のサーフェスレイヤートークンを軸に背景のブレンド率を管理する。
+| `--surface-layer-1` | Top of the gradient. Blend `--surface-card` to 96%. | Blend `--surface-card` to 94%. | Base cards, form fields, user badges |
+| `--surface-layer-2` | Blend `--surface-card` to 88%. | Blend `--surface-card` to 86%. | Section/panel lower tones, card bottoms |
+| `--surface-layer-3` | Blend `--surface-card` to 78%. | Blend `--surface-card` to 76%. | Pills, toggles, hover surfaces |
+| `--surface-layer-4` | Blend `--surface-card` to 68%. | Blend `--surface-card` to 66%. | Neutral overlays, areas that need emphasis |
 
-| トークン | ライトテーマ | ダークテーマ | 主な用途 |
-| --- | --- | --- | --- |
-| `--surface-layer-1` | `linear-gradient` の上部色。`--surface-card` を 96% ブレンド | `--surface-card` を 94% ブレンド | 基本カード、フォームフィールド、ユーザバッジ |
-| `--surface-layer-2` | `--surface-card` を 88% ブレンド | `--surface-card` を 86% ブレンド | セクション／パネルの下部色、カードのボトムトーン |
-| `--surface-layer-3` | `--surface-card` を 78% ブレンド | `--surface-card` を 76% ブレンド | ピル、トグル、ホバー時のサーフェス |
-| `--surface-layer-4` | `--surface-card` を 68% ブレンド | `--surface-card` を 66% ブレンド | オーバーレイのニュートラルトーン、階層差を強調したい領域 |
+Use `--border-card` / `--border-card-strong` as the default borders and reserve `--border-subtle` for elements that sit on similar backgrounds. Wrap page wrappers or sub-containers with soft 1px lines such as `1px solid color-mix(in srgb, var(--color-surface-inverse) 14%, transparent)` and set their background about 4% darker than cards to show hierarchy. Outline cards and modules with a 1px `var(--color-border-strong)` line and add a 1px inset line for clarity. When states change (hover/focus), shift the border color by 8–10% and adjust the background tone so cards feel elevated without shadows. Keep column depth consistent by pairing layer tokens (e.g., `layer-1` → `layer-2`).
 
-- ページラッパーやサブコンテナは `1px solid color-mix(in srgb, var(--color-surface-inverse) 14%, transparent)` のような淡い実線で囲み、背景にはカードより 4% 暗いトーンを敷いて階層を示す。
-- カード・モジュールは `var(--color-border-strong)` を用いた 1px 実線で縁取り、内側に 1px の `inset` ラインを加えて視認性を補強する。境界線の標準は `--border-card` / `--border-card-strong` を基本とし、`--border-subtle` は背景トーンとの差が小さいテキストや要素に限定する。
-- 状態変化時（ホバー/フォーカス）はボーダー色を 8〜10% 変化させ、背景トーンのシフトとレイヤートークンの段差（例: `layer-1` → `layer-2`）を組み合わせてシャドウ無しでも浮き上がりを感じさせる。
-
-### インタラクション状態マトリクス
-| コンポーネント | 状態 | ライトテーマ | ダークテーマ | コントラスト指標 |
+### Interaction State Matrix
+| Component | State | Light Theme | Dark Theme | Contrast Guidance |
 | --- | --- | --- | --- | --- |
-| ボタン primary | Default / Hover / Active | #2563EB / #1D4ED8 / #1E40AF | #3B82F6 / #2563EB / #1D4ED8 | テキストは常に #FFFFFF（7:1 以上） |
-| ボタン secondary | Default / Hover / Active | #FFFFFF + #CBD5F5 ボーダー / 背景+4% トーン / 背景+8% トーン | #1E293B + #3B4B65 ボーダー / 背景-6% / 背景-10% | テキストは #1E293B or #F8FAFC、最低 4.5:1 |
-| ゴーストボタン | Default / Hover / Active | テキスト #1E293B / 背景 rgba(30,41,59,0.06) / rgba(30,41,59,0.10) | テキスト #E2E8F0 / 背景 rgba(226,232,240,0.12) / rgba(226,232,240,0.18) | 背景との差 3:1 以上 |
-| カード | Default / Hover | #FFFFFF / #F1F5F9 | #1E293B / #243044 | コンテンツテキストは 4.5:1 以上 |
-| ステータスピル | Default / Hover | 背景 #E0F2FE〜#FEE2E2 / テキスト #0369A1 など | 背景 #0F2F49〜#3F1D2B / テキスト #E0F2FE など | 背景と文字差 4.5:1 以上 |
-| Disabled 要素 | 全テーマ | 背景は隣接トーンとの差 12 以上、文字は #94A3B8（ライト）/#475569（ダーク）で 3:1 を担保 | - |
+| Primary button | Default / Hover / Active | #2563EB / #1D4ED8 / #1E40AF | #3B82F6 / #2563EB / #1D4ED8 | Text stays #FFFFFF (≥7:1). |
+| Secondary button | Default / Hover / Active | #FFFFFF with #CBD5F5 border / background +4% tone / background +8% tone | #1E293B with #3B4B65 border / background −6% / background −10% | Text uses #1E293B or #F8FAFC with ≥4.5:1 contrast. |
+| Ghost button | Default / Hover / Active | Text #1E293B / background rgba(30,41,59,0.06) / rgba(30,41,59,0.10) | Text #E2E8F0 / background rgba(226,232,240,0.12) / rgba(226,232,240,0.18) | Maintain ≥3:1 against the page background. |
+| Card | Default / Hover | #FFFFFF / #F1F5F9 | #1E293B / #243044 | Keep content text ≥4.5:1. |
+| Status pill | Default / Hover | Background #E0F2FE–#FEE2E2 / text #0369A1 etc. | Background #0F2F49–#3F1D2B / text #E0F2FE etc. | Ensure ≥4.5:1 text contrast. |
+| Disabled elements | All states | Background differs by ≥12 lightness points; text #94A3B8 (light) / #475569 (dark) for ≥3:1 | – |
 
-### タイポグラフィ
-- ベースフォントは `Inter` + `Noto Sans JP`、本文サイズは 16px（rem 基準）。
-- 見出しは 3 段階のスケールを採用し、`--font-size-heading-lg`（ページタイトル）、`--font-size-heading-md`（セクション）、`--font-size-heading-sm`（カード/リスト）を基準にする。
-- 行間は本文 1.6、見出し 1.3 を目安とし、段落間スペースは `1em` 以上を確保する。
-- ダッシュボードなどの KPI 数値は `.metric-card__value` を使用し、`font-size: clamp(1.5rem, 1.2rem + 1vw, 2.25rem)` / `font-weight: 600` を標準とする。これにより、モバイル時の過剰な拡大を抑えつつデスクトップでは視認性を維持する。
+### Typography
+- Base fonts: `Inter` with `Noto Sans JP`; body size 16px (rem-based).
+- Heading scale: `--font-size-heading-lg` (page title), `--font-size-heading-md` (section), `--font-size-heading-sm` (cards/lists).
+- Line height: 1.6 for body text, 1.3 for headings. Keep ≥1em spacing between paragraphs.
+- KPI values on dashboards use `.metric-card__value` with `font-size: clamp(1.5rem, 1.2rem + 1vw, 2.25rem)` and `font-weight: 600`, preserving readability on both desktop and mobile.
 
-### スペーシング & 角丸
-- ベース余白は 8px グリッド。カードやパネル内は `24px`、コンポーネント間は `16px` を基準とし、セクション間は `32px` を目安にする。
-- 角丸は `--radius-md`（8px）をデフォルト、カードコンテナやモーダルは `--radius-lg`（16px）を使用し、統一感を持たせる。
-- 影での段差表現は禁止し、境界線（1px）と背景トーンのコントラストで階層を示す。親コンテナは透過率 12% 前後のボーダー、子カードはクリアな実線ボーダーで視覚的に分離する。
+### Spacing & Corner Radius
+- Follow an 8px spacing grid. Within cards and panels use 24px padding; keep 16px between components and about 32px between sections.
+- Default corner radius: `--radius-md` (8px); cards and modals use `--radius-lg` (16px).
+- Avoid shadows for elevation. Instead, use 1px borders and background contrast: parent containers get semi-transparent borders (~12%), and child cards use solid borders to separate layers.
 
-### アイコノグラフィ & フォーカス
-- アイコンはストローク 1.5px のラインアイコンで統一し、サイズは 20px / 24px を基準にする。
-- フォーカスリングは `outline: 2px solid var(--color-accent); outline-offset: 2px;` を標準化し、全インタラクティブ要素に適用する。
+### Iconography & Focus
+- Use 1.5px stroke line icons at 20px or 24px sizes.
+- Standardize focus rings with `outline: 2px solid var(--color-accent); outline-offset: 2px;` across all interactive elements.
 
-## レイアウトテンプレート
-### アプリケーションシェル
-- 全ページは `.app-page` をルートに使用し、上下左右の余白は `clamp(40px, 8vw, 72px)` を基準に確保する。
-- シェル内の構造は「固定ヘッダー（ロゴ・主要ナビ）」「コンテンツラッパー」「フッター」で統一。サイドバーが必要な画面もコンテンツラッパー内の 2 カラム構造として定義する。
+## Layout Templates
+### Application Shell
+- Every page uses `.app-page` as the root container with padding `clamp(40px, 8vw, 72px)` on all sides.
+- Structure each shell with a fixed header (logo + primary navigation), content wrapper, and footer. Sidebars live inside the content wrapper as a two-column layout.
 
-### ページタイトル（Page Header）
-- `app-page-header` コンポーネントを全ページで共通利用する。構造は以下の 4 エリアで構成する:
-  - **Eyebrow**: カテゴリ名やパンくずを小さなサンセリフで表示。
-  - **Title**: ページ固有タイトル。28px/700 を基本。
-  - **Description**: 1〜2 行の補足説明。テキスト濃度 60%。
-  - **Actions**: 右側にプライマリ・セカンダリボタン、タブやフィルタが続く場合は下部に整列する。
-- バックグラウンドはフラット（サーフェスと同色）とし、ボーダーで区切らない。
+### Page Header
+- Reuse the `app-page-header` component everywhere. It contains four areas:
+  - **Eyebrow** – Category or breadcrumb in small sans-serif text.
+  - **Title** – Page-specific heading, 28px/700 by default.
+  - **Description** – One or two lines of supporting text at 60% tone.
+  - **Actions** – Primary/secondary buttons on the right; tabs or filters align along the bottom when present.
+- Keep the background flat (same as the page surface) without borders.
 
-### グリッド & コンテナ
-- セクション分割は `.page-section` を使用。ヘッダ（タイトル、説明、アクション）とボディの 2 パートで構成し、セクション間は 32px の余白を置く。
-- 複数列が必要な場合は `.page-grid` を使用し、ブレークポイント 1024px を境に 2 カラム → 1 カラムへ変化させる。
-- サイドバーやフィルタ列も `.page-grid--sidebar` として実装し、カード群と余白を揃える。
+### Grid & Containers
+- Use `.page-section` to divide content into a header (title, description, actions) and body. Leave 32px between sections.
+- When multiple columns are needed, use `.page-grid`, switching from two columns to one at the 1024px breakpoint.
+- Implement sidebars or filter panels with `.page-grid--sidebar` so cards and margins stay aligned.
 
-## コンポーネント仕様
-### シンプルボタン（Button）
-- ベースクラス `.button` は高さ 44px、横幅はコンテンツに合わせる。フォントは 15px/600。パディングは `0 20px`、文字と背景のコントラスト比は常に 4.5:1 以上。
-- バリエーション:
-  - `.button--primary`: 背景 `--color-accent-{state}`, テキストは `--color-text-on-accent-{state}`。ホバー時は 8% 暗く、アクティブ時は 12% 暗くする。ライトテーマでは最小 4.8:1、ダークテーマでは 7:1 のコントラストを確保する。
-  - `.button--secondary`: 背景 `--color-surface-alt`, 枠線 `--color-border`. ホバーで枠線とテキストを 10% 濃くし、アクティブでは背景に 6% のトーンを追加。ディスエーブル時はボーダーを 30% の濃度に落としつつ 3:1 を維持。
-  - `.button--ghost`: 背景透明、テキストはプライマリ。ホバー時は `rgba(surface, 0.08)`、アクティブ時は `rgba(surface, 0.12)` のオーバーレイで必ず 3:1 以上の差を取る。
-  - `.button--pill`: 角丸 `999px`。フィルタやタグ選択に使用し、選択状態はアクセント背景、非選択状態はゴーストを踏襲する。
-- アイコンを含む場合は 8px のギャップを保ち、アイコンは 20px サイズ。
-- フォーカス状態では背景色を変えず、2px のアクセントアウトラインを追加する。
-- ローディングやディスエーブル状態でも文字色の透明度を下げず、背景トーンを調整して 3:1 のコントラストを保持する。
+## Component Specifications
+### Buttons
+- Base class `.button` has 44px height, auto width, 15px/600 typography, and `0 20px` padding. Ensure ≥4.5:1 text contrast.
+- Variants:
+  - `.button--primary`: Background `--color-accent-{state}`, text `--color-text-on-accent-{state}`. Darken by 8% on hover and 12% on active, keeping ≥4.8:1 in light theme and ≥7:1 in dark theme.
+  - `.button--secondary`: Background `--color-surface-alt`, border `--color-border`. Intensify border/text by 10% on hover and add a 6% tone to the background on active. Disabled state drops the border to 30% strength while maintaining 3:1 contrast.
+  - `.button--ghost`: Transparent background with primary text. Apply `rgba(surface, 0.08)` on hover and `rgba(surface, 0.12)` on active; always keep ≥3:1 contrast.
+  - `.button--pill`: Fully rounded (999px). Use for filters or tag chips; selected state adopts the accent background, deselected state follows the ghost pattern.
+- Maintain an 8px gap for icon+text buttons and use 20px icons.
+- For focus, keep the background and add a 2px accent outline.
+- Do not reduce text opacity for loading or disabled states; adjust background tone instead to maintain 3:1 contrast.
 
-### カード（Card）
-- `.surface-card` を基準に高さ可変のカードを定義。背景は `linear-gradient(180deg, var(--surface-layer-1), var(--surface-layer-2))`、外枠は `1px solid var(--color-border-strong)`、角丸内側に `inset 0 0 0 1px color-mix(in srgb, var(--color-surface-alt) 70%, transparent)` の縁取りを追加してレイヤーを強調する。内側余白は 24px、角丸 12px。
-- ヘッダー（タイトル + メタ情報）、ボディ（本文）、フッター（操作）の 3 パートを推奨。ヘッダーは Flex で左右配置し、タイトルは 18px/600。
-- 状態ラベルは右上に `surface-pill` を配置し、背景はアクセントの 12% トーンを使用する。
-- ホバー時は背景トーンを 6% 明るく（ダークでは 6% 暗く）し、アクションの存在を示す。文字色は変えずに 4.5:1 を維持する。
+### Cards
+- Base cards use `.surface-card` with `linear-gradient(180deg, var(--surface-layer-1), var(--surface-layer-2))`, a `1px solid var(--color-border-strong)` outline, and an inset `color-mix(in srgb, var(--color-surface-alt) 70%, transparent)` line. Padding 24px, radius 12px.
+- Recommended structure: header (title + metadata), body, footer (actions). Header uses flex alignment with 18px/600 titles.
+- Place a `surface-pill` status badge at the top-right; background uses a 12% accent tone.
+- On hover, shift the background tone by ±6% (lighter in light theme, darker in dark) without changing text color, keeping ≥4.5:1 contrast.
 
-### カードコンテナ（Card Container）
-- 複数のカードを並べる場合は `.card-collection` を用意し、`display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 24px;` を基本とする。
-- カンバン形式では `.board-columns` を使用し、列ヘッダーもカードと同じスタイルで揃える。列・サブカラムは `linear-gradient(180deg, var(--surface-layer-2), var(--surface-layer-3))` を標準とし、カード（`layer-1` → `layer-2`）とのコントラストで段差を表現する。コンテナ全体にはカードより 4% 暗い（ライトテーマ）/明るい（ダークテーマ）トーンを敷き、`1px` の内向きボーダー（`inset` シャープライン）を追加する。カード外枠とのダブルボーダーで階層を際立たせ、ホバー時はカード背景をトーンシフトさせて境界が滲まないようにする。列間余白は 24px。
-- コンテナ全体にはカードより 4% 暗い（ライトテーマ）/明るい（ダークテーマ）トーンを敷き、`1px` の内向きボーダー（`inset` シャープライン）を追加する。カード外枠とのダブルボーダーで階層を際立たせ、ホバー時はカード背景をトーンシフトさせて境界が滲まないようにする。
+### Card Containers
+- Use `.card-collection` for grids: `display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 24px;`.
+- For kanban layouts, use `.board-columns`. Column headers mirror card styling, and columns apply `linear-gradient(180deg, var(--surface-layer-2), var(--surface-layer-3))`. Lay a surface 4% darker (light theme) or lighter (dark theme) than cards underneath, with a 1px inset border to emphasize hierarchy. Keep 24px gaps between columns.
 
-### リスト & テーブル
-- `.page-list` は縦方向のカード群を軽量に表現するスタイル。`grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr))` で最大 3 列まで展開し、ビューポートに応じて 1 列へ自動的に戻る。各アイテムは 16px の上下余白とボーダーで区切る。
-- テーブルは `.page-table` を基準に、ヘッダ背景を `--color-surface-alt`、セル余白は 16px とする。斜線や濃い罫線は使用せず、ストライプで視認性を確保。
+### Lists & Tables
+- `.page-list` presents stacked cards with `grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr))`, scaling up to three columns and collapsing to one responsively. Each item has 16px vertical padding and dividing borders.
+- Tables use `.page-table` with header backgrounds `--color-surface-alt` and 16px cell padding. Avoid heavy rules or diagonals; use striping for clarity.
 
-### フォーム
-- 各入力は `.form-field`（ラベル、説明、入力）の構造を守る。ラベルは 14px/600、説明文は 12px/60% トーン。
-- 入力コントロールは高さ 44px、角丸 8px、ボーダーは `1px solid var(--color-border)`。フォーカス時はボーダーをアクセントカラーに変更。
-- 複数項目を並べる場合は `.form-grid` を用い、2 カラム時は `minmax(240px, 1fr)` を基本とする。
-- バリデーションメッセージは赤系のテキストで入力直下に表示し、`role="alert"` を付与する。
-- Disabled 状態では `var(--surface-layer-3)` をベースにアクセントトーンを 8% 上乗せし、文字色はセカンダリトーンを維持することで 3:1 を確保する。
+### Forms
+- Structure inputs with `.form-field` (label, description, input). Labels use 14px/600, descriptions 12px at 60% tone.
+- Inputs are 44px tall with 8px radius and `1px solid var(--color-border)` borders. Focus states switch the border to the accent color.
+- Use `.form-grid` for multi-column layouts; default columns use `minmax(240px, 1fr)`.
+- Display validation messages directly under inputs with red-toned text and `role="alert"`.
+- Disabled fields base on `var(--surface-layer-3)` plus 8% accent tint while keeping secondary text color for ≥3:1 contrast.
 
-### ステータスチップ & バッジ
-- `.surface-pill` をベースに、丸み 999px、余白は `8px 12px`。テキストは 13px/600。
-- 状態ごとに `--pill-success`、`--pill-warning`、`--pill-danger` を用意し、背景は 16% トーン、テキストは濃色でコントラストを確保。
-- カード内の補助ラベルは `.page-badge` を使用し、角丸 6px のフラットなラベルとして表示する。
+### Status Chips & Badges
+- `.surface-pill` uses 999px rounding with `8px 12px` padding and 13px/600 text.
+- Provide `--pill-success`, `--pill-warning`, and `--pill-danger`; backgrounds use ~16% tone while text stays dark for contrast.
+- Use `.page-badge` for auxiliary labels inside cards with 6px radius and flat backgrounds.
 
-### タブ & トグル
-- `.page-tabs` は水平方向に配置し、アクティブタブはアクセント色の下線 + テキスト色 100%。非アクティブは 60% トーン。
-- トグルは `.form-toggle` を使用し、チェック時のみアクセント色、未チェック時はボーダーのみのミニマルな見た目とする。
-- 各状態の配色はライト/ダークともに 3:1 以上のコントラストとなるよう、背景トーンとラベル色をセットで定義する。ホバー時は下線を 2px に強調し、アクティブ状態は背景に 8% のトーンを加える。
+### Tabs & Toggles
+- `.page-tabs` align tabs horizontally. Active tabs show an accent underline and full-strength text; inactive tabs use 60% tone.
+- `.form-toggle` keeps toggles minimal: accent color only when checked, border-only when unchecked.
+- Define color sets per state in both themes so background and label combinations always reach ≥3:1 contrast. Increase underline thickness to 2px on hover and add an 8% background tone on active.
 
-### フィードバック & 空状態
-- 成功/警告/エラーのメッセージは `app-alert` を使用し、アイコン + タイトル + 説明文 + アクションの 4 パート構成。
-- 空状態やロード中は `.page-state` を採用し、イラストやアイコンは 64px 程度の単色ラインアイコンで統一する。
+### Feedback & Empty States
+- Use `app-alert` for success/warning/error messages with four parts: icon, title, description, and action.
+- Empty and loading states use `.page-state` with monochrome line icons around 64px.
 
-### ダイアログ / モーダル
-- `.app-dialog` をベースに最大幅 480px、角丸 16px。ヘッダー（タイトル + クローズ）、ボディ（テキスト or フォーム）、フッター（アクション）を明確に分ける。
-- オーバーレイは 40% のブラックで画面全体を覆い、背景スクロールを禁止する。
+### Dialogs / Modals
+- Base on `.app-dialog` with max-width 480px and 16px radius. Separate header (title + close), body (text or form), and footer (actions).
+- Overlays cover the viewport with 40% black and disable background scrolling.
 
-## 運用ルール
-1. 新規 UI を追加する際は上記コンポーネントを優先的に利用し、独自スタイルを定義する場合はデザインチームと合意する。
-2. Figma などのデザインファイルは本ガイドラインと同期し、差異が生じた場合は双方を更新する。
-3. ダークテーマは同じ構造を維持し、色トークンのみの差し替えで成立するようにする。新規トークンを追加する場合はライト/ダーク両テーマと各状態のコントラスト値（WCAG AA 適合）を記録する。
-4. 変更履歴を `docs/ui-design-system.md` に追記し、主要コンポーネントの更新内容を開発チームと共有する。
-
+## Operational Rules
+1. Prioritize these components for new UI; coordinate with design before introducing custom styles.
+2. Keep Figma or other design files in sync with this guide and update both when discrepancies appear.
+3. Maintain the same structure in the dark theme by swapping tokens only. When adding tokens, capture contrast ratios for both themes and every state to ensure WCAG AA compliance.
+4. Append change history to `docs/ui-design-system.md` and share component updates with the development team.


### PR DESCRIPTION
## Summary
- rewrite the README and architecture overview in natural English while preserving feature references and setup guidance
- translate the development workflow guide and feature specs for analytics and appeal generation into consistent English terminology
- refresh the UI design system write-up with clear English rules for colors, layouts, and components

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d5634152d88320b0754e1676e41110