### PR TITLE
Ensure report assistant columns share equal height

### DIFF
--- a/frontend/src/styles/pages/_report-assistant.scss
+++ b/frontend/src/styles/pages/_report-assistant.scss
@@ -9,7 +9,7 @@
 }
 
 .report-assistant-page__layout {
-  align-items: start;
+  align-items: stretch;
 }
 
 .report-assistant-page__form,


### PR DESCRIPTION
## Summary
- stretch the report assistant two-column layout so the form and result panels match the taller column

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5677894988320b264ff2dfceeaf69