### PR TITLE
style: center stacked auth cards

### DIFF
--- a/frontend/src/styles/pages/_auth.scss
+++ b/frontend/src/styles/pages/_auth.scss
@@ -1,9 +1,12 @@
 .auth-page {
   min-height: 100vh;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  padding: clamp(3rem, 6vw, 4.5rem) var(--shell-inline-padding, 1.5rem);
+  justify-content: flex-start;
+  gap: clamp(2.5rem, 6vw, 3.5rem);
+  padding: clamp(3rem, 6vw, 4.5rem) var(--shell-inline-padding, 1.5rem)
+    clamp(3rem, 6vw, 5rem);
   background:
     radial-gradient(
       120% 120% at 0% 0%,
@@ -43,27 +46,42 @@
 
 .auth-page__container {
   width: min(1040px, 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(2rem, 5vw, 3rem);
 }
 
 .auth-page__grid {
-  display: grid;
-  gap: clamp(2.5rem, 6vw, 3.5rem);
-  align-items: stretch;
-  justify-items: center;
-}
-
-@media (min-width: 64rem) {
-  .auth-page__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 3rem);
+  align-items: center;
+  width: min(48rem, 100%);
+  margin-inline: auto;
 }
 
 .auth-card {
   position: relative;
   overflow: hidden;
   backdrop-filter: blur(10px);
-  width: min(36rem, 100%);
-  margin-inline: auto;
+  width: min(40rem, 100%);
+}
+
+.auth-page app-page-header .page-header {
+  justify-items: center;
+  text-align: center;
+}
+
+.auth-page app-page-header .page-header__content {
+  justify-items: center;
+  text-align: center;
+}
+
+@media (min-width: 64rem) {
+  .auth-page app-page-header .page-header {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .auth-card::after {


### PR DESCRIPTION
## Summary
- keep the auth cards stacked in a centered column beneath the header on all breakpoints
- widen each auth card while keeping them grouped and horizontally centered within the page layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d566e90a1083209990c49708f2ee53