### PR TITLE
Switch recommendation threshold input to percentages

### DIFF
--- a/frontend/src/app/features/settings/page.html
+++ b/frontend/src/app/features/settings/page.html
@@ -263,17 +263,20 @@
         </label>
 
         <label class="form-field">
-          <span class="form-field__label" for="template-threshold">おすすめ度しきい値</span>
+          <span class="form-field__label" for="template-threshold">おすすめ度しきい値 (%)</span>
           <input
             id="template-threshold"
             type="number"
             min="0"
-            max="1"
-            step="0.05"
+            max="100"
+            step="5"
             class="form-control"
-            [value]="templateForm.controls.confidenceThreshold.value()"
+            [value]="templateForm.controls.confidenceThreshold.value() * 100"
             (input)="
-              templateForm.controls.confidenceThreshold.setValue($any($event.target).valueAsNumber)
+              updateConfidenceThreshold(
+                templateForm.controls.confidenceThreshold,
+                $any($event.target).valueAsNumber
+              )
             "
           />
         </label>

--- a/frontend/src/app/features/settings/page.ts
+++ b/frontend/src/app/features/settings/page.ts
@@ -59,6 +59,15 @@ export class SettingsPage {
   });
   public readonly editingTemplateId = signal<string | null>(null);
 
+  public readonly updateConfidenceThreshold = (
+    control: SignalControl<number>,
+    percentValue: number,
+  ): void => {
+    const normalized = Number.isFinite(percentValue) ? percentValue / 100 : control.value();
+    const clamped = Math.min(Math.max(normalized, 0), 1);
+    control.setValue(clamped);
+  };
+
   /**
    * Handles label form submission.
    *


### PR DESCRIPTION
## Summary
- show the template confidence threshold input as a percentage field with an updated label
- convert percent input values back to normalized confidence thresholds before persisting

## Testing
- npx prettier --check src/app/features/settings/page.ts src/app/features/settings/page.html
- npm run lint -- src/app/features/settings/page.ts
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d5d1040ef08320870dbb5731e33779