### PR TITLE
Ensure page layout sections use CSS grid

### DIFF
--- a/docs/ui-layout-requirements.md
+++ b/docs/ui-layout-requirements.md
@@ -75,6 +75,7 @@
 
 ## 6. Component-level Layout Rules
 - **Page Header**: Eyebrow ↔ Title は `space-xs`、Title ↔ Description は `space-sm`、アクション群とは `space-md`。
+- **Page Section Wrapper**: `.app-page-layout__section` は CSS Grid (`display: grid`) を採用し、セクション内のブロック間隔をトークン化されたギャップで制御する。個別に余白を積み重ねず、グリッドのギャップ設定を優先すること。
 - **Card**: 上下左右 `space-lg`、ヘッダー ↔ ボディ `space-md`、ボディ内の段落 `space-md`。
 - **List Item**: 最低高さ 56px、上下 `space-md`、アイコン ↔ テキスト `space-sm`。
 - **Table**: 行高 48px、セル左右 `space-md`、行間 `space-xs` のボーダー。

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -315,6 +315,10 @@ app-page-layout .app-page-layout__body {
   margin-top: var(--page-content-gap);
 }
 
+app-page-layout .app-page-layout__section {
+  display: grid;
+}
+
 app-page-layout .app-page-layout__body--bleed {
   margin-inline: calc(var(--page-padding-inline) * -1);
 }


### PR DESCRIPTION
## Summary
- set `.app-page-layout__section` elements to use CSS Grid so layout sections align with the rest of the page scaffolding
- document the grid requirement for page sections in the UI layout specification

## Testing
- not run (CSS/doc update)


------
https://chatgpt.com/codex/tasks/task_e_68d5f8c524ac832082597917a221427c