### PR TITLE
Ensure theme preference defaults to system when absent

### DIFF
--- a/frontend/src/app/core/layout/shell/shell.ts
+++ b/frontend/src/app/core/layout/shell/shell.ts
@@ -173,6 +173,16 @@ export class Shell {
       if (legacy) {
         return legacy;
       }
+
+      if (stored !== null) {
+        try {
+          storage.removeItem(this.themeStorageKey);
+        } catch {
+          // If removal fails, we still fallback to the system preference in-memory.
+        }
+      }
+
+      this.persistThemePreference(storage, 'system');
     } catch {
       // Ignore storage access issues and fallback to system preference.
     }
@@ -180,14 +190,18 @@ export class Shell {
     return 'system';
   }
 
+  private persistThemePreference(storage: Storage, preference: ThemePreference): void {
+    try {
+      storage.setItem(this.themeStorageKey, preference);
+    } catch {
+      // Ignore storage persistence failures.
+    }
+  }
+
   private migrateLegacyThemePreference(storage: Storage): ThemePreference | null {
     const legacy = storage.getItem(this.legacyThemeStorageKey);
     if (this.isThemePreference(legacy)) {
-      try {
-        storage.setItem(this.themeStorageKey, legacy);
-      } catch {
-        // Ignore storage errors and continue using the legacy value in-memory.
-      }
+      this.persistThemePreference(storage, legacy);
 
       try {
         storage.removeItem(this.legacyThemeStorageKey);


### PR DESCRIPTION
## Summary
- ensure the shell falls back to the system theme when the `verbalize-yourself` preference is missing by persisting the default value
- centralize theme preference persistence and clean up invalid stored values during initialization

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5fa14f3f08320b7c7bf7935b4f290