### PR TITLE
feat: toggle login and register views

### DIFF
--- a/frontend/src/app/features/auth/login/page.html
+++ b/frontend/src/app/features/auth/login/page.html
@@ -8,203 +8,227 @@
 >
   <div class="auth-page__container">
     <div class="auth-page__grid">
-      <section
-        class="surface-panel page-panel auth-card auth-card--login"
-        aria-labelledby="login-heading"
-      >
-        <div class="auth-card__header">
-          <span class="auth-card__badge">ログイン</span>
-          <h2 id="login-heading" class="auth-card__title">登録済みの方はこちら</h2>
-        </div>
-        <p class="auth-card__subtitle">
-          既にワークスペースへ招待されている場合は、メールアドレスとパスワードを入力してサインインしてください。
-        </p>
-
-        @if (loginNotice(); as notice) {
-          <div class="app-alert app-alert--error" role="alert" aria-live="polite">{{ notice }}</div>
-        }
-
-        <form class="auth-form" (submit)="onLoginSubmit($event)">
-          <div class="form-field">
-            <label class="form-field__label" for="login-email">メールアドレス</label>
-            <input
-              id="login-email"
-              name="email"
-              type="email"
-              autocomplete="email"
-              class="form-control"
-              [class.form-control--invalid]="loginEmailError()"
-              [value]="loginForm.controls.email.value()"
-              (input)="onLoginEmailInput($event)"
-              [attr.aria-invalid]="loginEmailError() ? 'true' : null"
-              [attr.aria-describedby]="loginEmailError() ? 'login-email-error' : null"
-              placeholder="you@example.com"
-            />
-            @if (loginEmailError(); as emailError) {
-              <p
-                id="login-email-error"
-                class="form-feedback form-feedback--error"
-                aria-live="polite"
-              >
-                {{ emailError }}
-              </p>
-            }
-          </div>
-
-          <div class="form-field">
-            <label class="form-field__label" for="login-password">パスワード</label>
-            <input
-              id="login-password"
-              name="password"
-              type="password"
-              autocomplete="current-password"
-              autocapitalize="off"
-              spellcheck="false"
-              class="form-control"
-              [class.form-control--invalid]="loginPasswordError()"
-              [value]="loginForm.controls.password.value()"
-              (input)="onLoginPasswordInput($event)"
-              [attr.aria-invalid]="loginPasswordError() ? 'true' : null"
-              [attr.aria-describedby]="loginPasswordError() ? 'login-password-error' : null"
-              placeholder="パスワード"
-            />
-            @if (loginPasswordError(); as passwordError) {
-              <p
-                id="login-password-error"
-                class="form-feedback form-feedback--error"
-                aria-live="polite"
-              >
-                {{ passwordError }}
-              </p>
-            }
-          </div>
-
-          <button
-            type="submit"
-            class="auth-button focus-ring bg-accent px-5 py-3 text-sm font-semibold text-white hover:bg-accent-strong disabled:cursor-not-allowed disabled:bg-slate-400"
-            [disabled]="!canSubmitLogin()"
+      @if (isLoginView()) {
+        <div class="auth-page__panel">
+          <section
+            class="surface-panel page-panel auth-card auth-card--login"
+            aria-labelledby="login-heading"
           >
-            サインイン
-          </button>
-        </form>
-      </section>
+            <div class="auth-card__header">
+              <span class="auth-card__badge">ログイン</span>
+              <h2 id="login-heading" class="auth-card__title">登録済みの方はこちら</h2>
+            </div>
+            <p class="auth-card__subtitle">
+              既にワークスペースへ招待されている場合は、メールアドレスとパスワードを入力してサインインしてください。
+            </p>
 
-      <section
-        class="surface-panel page-panel auth-card auth-card--register"
-        aria-labelledby="register-heading"
-      >
-        <div class="auth-card__header">
-          <span class="auth-card__badge auth-card__badge--accent">新規登録</span>
-          <h3 id="register-heading" class="auth-card__title">アカウントを作成</h3>
-        </div>
-        <p class="auth-card__subtitle">
-          初めて利用する方は、メールアドレスと希望のパスワードを入力してアカウントを作成してください。登録後は自動的にホーム画面へ移動します。
-        </p>
-        <ul class="auth-card__hints">
-          <li>パスワードは8文字以上で設定してください。</li>
-          <li>確認用パスワードも同じ内容を入力してください。</li>
-        </ul>
-
-        @if (registerNotice(); as registerMessage) {
-          <div class="app-alert app-alert--error" role="alert" aria-live="polite">
-            {{ registerMessage }}
-          </div>
-        }
-
-        <form class="auth-form" (submit)="onRegisterSubmit($event)">
-          <div class="form-field">
-            <label class="form-field__label" for="register-email">メールアドレス</label>
-            <input
-              id="register-email"
-              name="register-email"
-              type="email"
-              autocomplete="email"
-              class="form-control"
-              [class.form-control--invalid]="registerEmailError()"
-              [value]="registerForm.controls.email.value()"
-              (input)="onRegisterEmailInput($event)"
-              [attr.aria-invalid]="registerEmailError() ? 'true' : null"
-              [attr.aria-describedby]="registerEmailError() ? 'register-email-error' : null"
-              placeholder="you@example.com"
-            />
-            @if (registerEmailError(); as emailError) {
-              <p
-                id="register-email-error"
-                class="form-feedback form-feedback--error"
-                aria-live="polite"
-              >
-                {{ emailError }}
-              </p>
+            @if (loginNotice(); as notice) {
+              <div class="app-alert app-alert--error" role="alert" aria-live="polite">
+                {{ notice }}
+              </div>
             }
-          </div>
 
-          <div class="form-field">
-            <label class="form-field__label" for="register-password">パスワード</label>
-            <input
-              id="register-password"
-              name="new-password"
-              type="password"
-              autocomplete="new-password"
-              autocapitalize="off"
-              spellcheck="false"
-              class="form-control"
-              [class.form-control--invalid]="registerPasswordError()"
-              [value]="registerForm.controls.password.value()"
-              (input)="onRegisterPasswordInput($event)"
-              [attr.aria-invalid]="registerPasswordError() ? 'true' : null"
-              [attr.aria-describedby]="registerPasswordError() ? 'register-password-error' : null"
-              placeholder="8文字以上で入力"
-            />
-            @if (registerPasswordError(); as passwordError) {
-              <p
-                id="register-password-error"
-                class="form-feedback form-feedback--error"
-                aria-live="polite"
+            <form class="auth-form" (submit)="onLoginSubmit($event)">
+              <div class="form-field">
+                <label class="form-field__label" for="login-email">メールアドレス</label>
+                <input
+                  id="login-email"
+                  name="email"
+                  type="email"
+                  autocomplete="email"
+                  class="form-control"
+                  [class.form-control--invalid]="loginEmailError()"
+                  [value]="loginForm.controls.email.value()"
+                  (input)="onLoginEmailInput($event)"
+                  [attr.aria-invalid]="loginEmailError() ? 'true' : null"
+                  [attr.aria-describedby]="loginEmailError() ? 'login-email-error' : null"
+                  placeholder="you@example.com"
+                />
+                @if (loginEmailError(); as emailError) {
+                  <p
+                    id="login-email-error"
+                    class="form-feedback form-feedback--error"
+                    aria-live="polite"
+                  >
+                    {{ emailError }}
+                  </p>
+                }
+              </div>
+
+              <div class="form-field">
+                <label class="form-field__label" for="login-password">パスワード</label>
+                <input
+                  id="login-password"
+                  name="password"
+                  type="password"
+                  autocomplete="current-password"
+                  autocapitalize="off"
+                  spellcheck="false"
+                  class="form-control"
+                  [class.form-control--invalid]="loginPasswordError()"
+                  [value]="loginForm.controls.password.value()"
+                  (input)="onLoginPasswordInput($event)"
+                  [attr.aria-invalid]="loginPasswordError() ? 'true' : null"
+                  [attr.aria-describedby]="loginPasswordError() ? 'login-password-error' : null"
+                  placeholder="パスワード"
+                />
+                @if (loginPasswordError(); as passwordError) {
+                  <p
+                    id="login-password-error"
+                    class="form-feedback form-feedback--error"
+                    aria-live="polite"
+                  >
+                    {{ passwordError }}
+                  </p>
+                }
+              </div>
+
+              <button
+                type="submit"
+                class="auth-button focus-ring bg-accent px-5 py-3 text-sm font-semibold text-white hover:bg-accent-strong disabled:cursor-not-allowed disabled:bg-slate-400"
+                [disabled]="!canSubmitLogin()"
               >
-                {{ passwordError }}
-              </p>
-            }
-          </div>
-
-          <div class="form-field">
-            <label class="form-field__label" for="register-confirm-password"
-              >パスワード（確認）</label
-            >
-            <input
-              id="register-confirm-password"
-              name="confirm-password"
-              type="password"
-              autocomplete="new-password"
-              autocapitalize="off"
-              spellcheck="false"
-              class="form-control"
-              [class.form-control--invalid]="registerConfirmError()"
-              [value]="registerForm.controls.confirmPassword.value()"
-              (input)="onRegisterConfirmInput($event)"
-              [attr.aria-invalid]="registerConfirmError() ? 'true' : null"
-              [attr.aria-describedby]="registerConfirmError() ? 'register-confirm-error' : null"
-              placeholder="確認のため再入力"
-            />
-            @if (registerConfirmError(); as confirmError) {
-              <p
-                id="register-confirm-error"
-                class="form-feedback form-feedback--error"
-                aria-live="polite"
-              >
-                {{ confirmError }}
-              </p>
-            }
-          </div>
-
+                サインイン
+              </button>
+            </form>
+          </section>
           <button
-            type="submit"
-            class="auth-button focus-ring bg-emerald-500 px-5 py-3 text-sm font-semibold text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:bg-slate-400"
-            [disabled]="!canSubmitRegistration()"
+            type="button"
+            class="auth-toggle-button focus-ring text-sm font-semibold text-accent hover:text-accent-strong"
+            (click)="showRegisterView()"
           >
-            アカウントを作成
+            新規登録はこちら
           </button>
-        </form>
-      </section>
+        </div>
+      } @else {
+        <div class="auth-page__panel">
+          <section
+            class="surface-panel page-panel auth-card auth-card--register"
+            aria-labelledby="register-heading"
+          >
+            <div class="auth-card__header">
+              <span class="auth-card__badge auth-card__badge--accent">新規登録</span>
+              <h3 id="register-heading" class="auth-card__title">アカウントを作成</h3>
+            </div>
+            <p class="auth-card__subtitle">
+              初めて利用する方は、メールアドレスと希望のパスワードを入力してアカウントを作成してください。登録後は自動的にホーム画面へ移動します。
+            </p>
+            <ul class="auth-card__hints">
+              <li>パスワードは8文字以上で設定してください。</li>
+              <li>確認用パスワードも同じ内容を入力してください。</li>
+            </ul>
+
+            @if (registerNotice(); as registerMessage) {
+              <div class="app-alert app-alert--error" role="alert" aria-live="polite">
+                {{ registerMessage }}
+              </div>
+            }
+
+            <form class="auth-form" (submit)="onRegisterSubmit($event)">
+              <div class="form-field">
+                <label class="form-field__label" for="register-email">メールアドレス</label>
+                <input
+                  id="register-email"
+                  name="register-email"
+                  type="email"
+                  autocomplete="email"
+                  class="form-control"
+                  [class.form-control--invalid]="registerEmailError()"
+                  [value]="registerForm.controls.email.value()"
+                  (input)="onRegisterEmailInput($event)"
+                  [attr.aria-invalid]="registerEmailError() ? 'true' : null"
+                  [attr.aria-describedby]="registerEmailError() ? 'register-email-error' : null"
+                  placeholder="you@example.com"
+                />
+                @if (registerEmailError(); as emailError) {
+                  <p
+                    id="register-email-error"
+                    class="form-feedback form-feedback--error"
+                    aria-live="polite"
+                  >
+                    {{ emailError }}
+                  </p>
+                }
+              </div>
+
+              <div class="form-field">
+                <label class="form-field__label" for="register-password">パスワード</label>
+                <input
+                  id="register-password"
+                  name="new-password"
+                  type="password"
+                  autocomplete="new-password"
+                  autocapitalize="off"
+                  spellcheck="false"
+                  class="form-control"
+                  [class.form-control--invalid]="registerPasswordError()"
+                  [value]="registerForm.controls.password.value()"
+                  (input)="onRegisterPasswordInput($event)"
+                  [attr.aria-invalid]="registerPasswordError() ? 'true' : null"
+                  [attr.aria-describedby]="
+                    registerPasswordError() ? 'register-password-error' : null
+                  "
+                  placeholder="8文字以上で入力"
+                />
+                @if (registerPasswordError(); as passwordError) {
+                  <p
+                    id="register-password-error"
+                    class="form-feedback form-feedback--error"
+                    aria-live="polite"
+                  >
+                    {{ passwordError }}
+                  </p>
+                }
+              </div>
+
+              <div class="form-field">
+                <label class="form-field__label" for="register-confirm-password"
+                  >パスワード（確認）</label
+                >
+                <input
+                  id="register-confirm-password"
+                  name="confirm-password"
+                  type="password"
+                  autocomplete="new-password"
+                  autocapitalize="off"
+                  spellcheck="false"
+                  class="form-control"
+                  [class.form-control--invalid]="registerConfirmError()"
+                  [value]="registerForm.controls.confirmPassword.value()"
+                  (input)="onRegisterConfirmInput($event)"
+                  [attr.aria-invalid]="registerConfirmError() ? 'true' : null"
+                  [attr.aria-describedby]="registerConfirmError() ? 'register-confirm-error' : null"
+                  placeholder="確認のため再入力"
+                />
+                @if (registerConfirmError(); as confirmError) {
+                  <p
+                    id="register-confirm-error"
+                    class="form-feedback form-feedback--error"
+                    aria-live="polite"
+                  >
+                    {{ confirmError }}
+                  </p>
+                }
+              </div>
+
+              <button
+                type="submit"
+                class="auth-button focus-ring bg-emerald-500 px-5 py-3 text-sm font-semibold text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:bg-slate-400"
+                [disabled]="!canSubmitRegistration()"
+              >
+                アカウントを作成
+              </button>
+            </form>
+          </section>
+          <button
+            type="button"
+            class="auth-toggle-button focus-ring text-sm font-semibold text-accent hover:text-accent-strong"
+            (click)="showLoginView()"
+          >
+            ログインはこちら
+          </button>
+        </div>
+      }
     </div>
   </div>
 </app-page-layout>

--- a/frontend/src/app/features/auth/login/page.spec.ts
+++ b/frontend/src/app/features/auth/login/page.spec.ts
@@ -247,4 +247,22 @@ describe('LoginPage', () => {
     expect(component.registerConfirmError()).toBeNull();
     expect(component.isRegisterFormValid()).toBeTrue();
   });
+
+  it('toggles between login and registration views', () => {
+    const fixture = TestBed.createComponent(LoginPage);
+    const component = fixture.componentInstance;
+
+    expect(component.isLoginView()).toBeTrue();
+    expect(component.isRegisterView()).toBeFalse();
+
+    component.showRegisterView();
+
+    expect(component.isLoginView()).toBeFalse();
+    expect(component.isRegisterView()).toBeTrue();
+
+    component.showLoginView();
+
+    expect(component.isLoginView()).toBeTrue();
+    expect(component.isRegisterView()).toBeFalse();
+  });
 });

--- a/frontend/src/app/features/auth/login/page.ts
+++ b/frontend/src/app/features/auth/login/page.ts
@@ -48,6 +48,7 @@ export class LoginPage {
   });
   public readonly loginNotice = signal<string | null>(null);
   public readonly registerNotice = signal<string | null>(null);
+  private readonly activeView = signal<'login' | 'register'>('login');
 
   public readonly pending = this.auth.pending;
   private readonly lastLoginSubmission = signal<LoginSubmission | null>(null);
@@ -147,6 +148,8 @@ export class LoginPage {
     () =>
       this.isRegisterFormValid() && (!this.pending() || this.registerFormChangedSinceLastSubmit()),
   );
+  public readonly isLoginView = computed(() => this.activeView() === 'login');
+  public readonly isRegisterView = computed(() => this.activeView() === 'register');
 
   public constructor() {
     effect(() => {
@@ -261,6 +264,26 @@ export class LoginPage {
     const value = (event.target as HTMLInputElement | null)?.value ?? '';
     this.registerConfirmTouched.set(true);
     this.registerForm.controls.confirmPassword.setValue(value);
+  }
+
+  public showLoginView(): void {
+    if (this.activeView() === 'login') {
+      return;
+    }
+
+    this.activeView.set('login');
+    this.resetNotices();
+    this.resetRegisterInteractions();
+  }
+
+  public showRegisterView(): void {
+    if (this.activeView() === 'register') {
+      return;
+    }
+
+    this.activeView.set('register');
+    this.resetNotices();
+    this.resetLoginInteractions();
   }
 
   private resetNotices(): void {

--- a/frontend/src/styles/pages/_auth.scss
+++ b/frontend/src/styles/pages/_auth.scss
@@ -61,6 +61,13 @@
   margin-inline: auto;
 }
 
+.auth-page__panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
 @media (min-width: 62rem) {
   .auth-page__grid {
     flex-direction: row;
@@ -98,6 +105,22 @@
   );
   opacity: 0.5;
   pointer-events: none;
+}
+
+.auth-toggle-button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--accent) 75%, var(--text-primary));
+  cursor: pointer;
+  text-decoration: underline;
+  transition: color 0.2s ease;
+}
+
+.auth-toggle-button:hover {
+  color: color-mix(in srgb, var(--accent-strong) 85%, var(--text-primary));
 }
 
 .auth-card--register::after {


### PR DESCRIPTION
## Summary
- show only the login card by default and add a text toggle for registration
- manage the active auth view within the LoginPage component and reset form state when switching
- style the new layout and add a unit test to cover the view toggling behaviour

## Testing
- npm run build
- npx prettier --check "src/app/features/auth/login/page.html" "src/app/features/auth/login/page.ts" "src/app/features/auth/login/page.spec.ts" "src/styles/pages/_auth.scss"
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: Chrome binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5fa128cf88320a646d2d9f336d572