### PR TITLE
Ensure app page layout body margin is reset

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -296,7 +296,8 @@ a:hover {
 
 /* Page layout component */
 app-page-layout {
-  display: block;
+  display: grid;
+  gap: var(--page-content-gap);
   --app-page-layout-max-width: 76rem;
 }
 
@@ -313,7 +314,6 @@ app-page-layout .app-page-layout__header {
 app-page-layout .app-page-layout__body {
   display: grid;
   margin: 0;
-  margin-top: var(--page-content-gap);
 }
 
 app-page-layout .app-page-layout__section {


### PR DESCRIPTION
## Summary
- switch the `app-page-layout` host to a grid layout so sections use the shared `--page-content-gap` spacing
- remove the extra top margin from `.app-page-layout__body` so the class always uses a zero margin

## Testing
- npm start -- --host 0.0.0.0 --port 4200


------
https://chatgpt.com/codex/tasks/task_e_68d5fdeea0b4832085178b6304f42e50