### PR TITLE
Fix register card height clipping on login page

### DIFF
--- a/frontend/src/styles/pages/_auth.scss
+++ b/frontend/src/styles/pages/_auth.scss
@@ -87,7 +87,7 @@
 
 @media (min-width: 62rem) {
   .auth-card {
-    flex: 0 1 clamp(30rem, 42vw, 38rem);
+    max-width: clamp(30rem, 42vw, 38rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent the auth register card from using a fixed flex-basis on wide viewports so the full content stays visible
- cap the card width with a max-width clamp to preserve the intended layout proportions

## Testing
- npx prettier --check src/styles/pages/_auth.scss
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5fe080a948320b4ab82d5ea6ec7d9