### PR TITLE
Add gap token to app page layout sections

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -318,6 +318,7 @@ app-page-layout .app-page-layout__body {
 
 app-page-layout .app-page-layout__section {
   display: grid;
+  gap: var(--page-content-gap);
 }
 
 app-page-layout .app-page-layout__body--bleed {


### PR DESCRIPTION
## Summary
- add the shared page content gap token to app-page-layout sections so they honor global spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5ff452f4483209e2ef3372c948828