### PR TITLE
Add daily reporting documentation set

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ npm run format:check
 - `docs/development-rules.md` – Development workflow and quality expectations.
 - `docs/features/appeal-generation/requirements.md` – Requirements for appeal narrative generation.
 - `docs/features/appeal-generation/detail-design.md` – Detailed design for appeal narrative generation.
+- `docs/features/daily-reporting/requirements.md` – Requirements for daily reporting and AI analysis.
+- `docs/features/daily-reporting/detail-design.md` – Detailed design for daily reporting services and UI workflow.
 - `docs/features/analytics-insights/requirements.md` – Requirements for analytics and continuous improvement.
 - `docs/features/analytics-insights/detail-design.md` – Detailed design for analytics and continuous improvement.
 - `docs/ui-design-system.md` – UI guidelines for shared components.

--- a/docs/features/daily-reporting/detail-design.md
+++ b/docs/features/daily-reporting/detail-design.md
@@ -1,0 +1,28 @@
+# Daily Reporting Detailed Design
+
+## API Surface
+- `POST /daily-reports` — Creates a draft report for the authenticated user, normalizes sections/tags, records a `DRAFT_CREATED` event, and returns the persisted payload. Validation ensures at least one section body is present.【F:backend/app/routers/daily_reports.py†L16-L37】【F:backend/app/services/daily_reports.py†L31-L82】
+- `GET /daily-reports` — Lists reports owned by the user with optional status filtering, eagerly loading linked cards to surface counts in list responses.【F:backend/app/routers/daily_reports.py†L30-L53】【F:backend/app/services/daily_reports.py†L96-L133】
+- `GET /daily-reports/{report_id}` — Retrieves a single report with detailed events, card summaries, and pending proposals when `include_details` is requested.【F:backend/app/routers/daily_reports.py†L39-L54】【F:backend/app/services/daily_reports.py†L96-L190】
+- `PUT /daily-reports/{report_id}` — Updates draft or failed reports by re-normalizing sections/tags and appending an `UPDATED` event. Requests against other statuses return a 400 error.【F:backend/app/routers/daily_reports.py†L55-L73】【F:backend/app/services/daily_reports.py†L62-L90】
+- `POST /daily-reports/{report_id}/submit` — Transitions the report into `PROCESSING`, records submission/analysis-start events, and orchestrates ChatGPT analysis. Returns the latest detail snapshot and pending proposals without deleting the record yet.【F:backend/app/routers/daily_reports.py†L74-L93】【F:backend/app/services/daily_reports.py†L138-L177】
+- `POST /daily-reports/{report_id}/retry` — Re-runs analysis exclusively for failed reports. The service enforces status validation, reuses the same submission pipeline, and returns the refreshed detail payload.【F:backend/app/routers/daily_reports.py†L94-L109】【F:backend/app/services/daily_reports.py†L138-L205】
+
+## Event Logging & Processing Metadata
+- Every state transition records a `DailyReportEvent` instance, providing an ordered audit log returned via detail responses. Events capture submission, analysis start, proposal persistence, completion, and failures with contextual payloads.【F:backend/app/services/daily_reports.py†L46-L213】
+- Processing metadata tracks pending proposals, created card IDs, confidence scores, and the last error. Helpers ensure the JSON column is always a dictionary and merges incremental updates safely.【F:backend/app/services/daily_reports.py†L182-L217】
+- Events are sorted by normalized timestamps before serialization to ensure deterministic timelines even when timezone metadata is missing.【F:backend/app/services/daily_reports.py†L200-L238】
+
+## ChatGPT Integration
+- The `DailyReportService` accepts an optional `ChatGPTClient`. Submission calls compose a prompt from normalized sections, invoke the `analyze` method with a capped number of proposals, and capture the `model` identifier returned by ChatGPT.【F:backend/app/services/daily_reports.py†L118-L177】
+- Errors from ChatGPT raise a `ChatGPTError`, leading to a failed status, failure reason, and captured error message. Successful analyses store proposals, log completion events, and mark the report `COMPLETED` before the database row is deleted and the detail payload returned.【F:backend/app/services/daily_reports.py†L150-L213】
+
+## Data Model Usage
+- Reports persist normalized sections as JSON content and tags as deduplicated lists, allowing idempotent updates via the update endpoint.【F:backend/app/services/daily_reports.py†L62-L117】
+- Linked cards, subtasks, and card statuses are preloaded when returning details so UI consumers receive complete summaries without additional queries.【F:backend/app/services/daily_reports.py†L108-L190】
+- Processed proposals remain in `processing_meta` until cards are created elsewhere. Destroyed reports still return detail snapshots constructed before deletion, enabling clients to render analysis results for ephemeral runs.【F:backend/app/services/daily_reports.py†L178-L213】
+
+## UI Workflow
+- The Angular `ReportAssistantPageComponent` renders a standalone page with a dynamic sections form, tag entry, and submission button. It blocks duplicate submissions while awaiting backend responses.【F:frontend/src/app/features/reports/reports-page.component.ts†L19-L75】
+- On submit, the component chains report creation and submission, stores the returned detail, shows a localized success message, and resets the form back to a single blank section.【F:frontend/src/app/features/reports/reports-page.component.ts†L63-L108】
+- Errors from the backend or network are parsed into user-friendly Japanese strings, allowing members to correct validation issues or retry later.【F:frontend/src/app/features/reports/reports-page.component.ts†L95-L147】

--- a/docs/features/daily-reporting/requirements.md
+++ b/docs/features/daily-reporting/requirements.md
@@ -1,0 +1,31 @@
+# Daily Reporting Requirements
+
+## Background
+- Members compose multi-section daily or weekly reflections that must be normalized into structured content before AI analysis runs. The backend service rejects reports without at least one populated section and cleans titles/tags prior to storage, ensuring the report content remains coherent for downstream processing.【F:backend/app/services/daily_reports.py†L31-L96】
+- Reports are owned by authenticated users and stored with status tracking (draft, processing, failed, completed). Subsequent submissions reuse persisted content and trigger additional processing events when needed.【F:backend/app/routers/daily_reports.py†L16-L109】【F:backend/app/services/daily_reports.py†L104-L205】
+
+## Objectives
+- Allow contributors to draft structured reports, submit them for AI-assisted analysis, and immediately review generated task proposals without manual intervention.【F:frontend/src/app/features/reports/reports-page.component.ts†L19-L96】
+- Provide a repeatable workflow that records lifecycle events, captures ChatGPT analysis outcomes, and gracefully handles transient failures with retry support.【F:backend/app/routers/daily_reports.py†L55-L109】【F:backend/app/services/daily_reports.py†L138-L225】
+
+## Scope
+- **In scope:**
+  - FastAPI endpoints under `/daily-reports` for creating, listing, retrieving, updating, submitting, and retrying report analysis.【F:backend/app/routers/daily_reports.py†L16-L109】
+  - Server-side normalization of report sections, tags, and processing metadata to safeguard consistency before analysis requests are dispatched.【F:backend/app/services/daily_reports.py†L31-L187】
+  - Angular form experience for composing sections, submitting reports, surfacing success or error states, and presenting analysis details once available.【F:frontend/src/app/features/reports/reports-page.component.ts†L19-L128】
+- **Out of scope:**
+  - Automated card creation from analysis proposals (handled elsewhere after the analysis completes).
+  - Administrative analytics or governance controls beyond the report lifecycle described above.
+
+## User Stories
+- As a team member, I can capture multiple sections with optional titles so that only meaningful content is forwarded for AI analysis.【F:frontend/src/app/features/reports/reports-page.component.ts†L31-L83】【F:backend/app/services/daily_reports.py†L31-L90】
+- As a team member, I receive immediate feedback when my report submission succeeds or fails, enabling me to retry if necessary.【F:frontend/src/app/features/reports/reports-page.component.ts†L63-L117】【F:backend/app/routers/daily_reports.py†L74-L109】
+- As a team member, I can view prior reports filtered by status to monitor processing progress and historical outcomes.【F:backend/app/routers/daily_reports.py†L30-L53】
+- As a team member, I can revise draft or failed reports before resubmitting them to address validation or analysis feedback.【F:backend/app/routers/daily_reports.py†L55-L73】
+
+## Acceptance Criteria
+- Report creation must require at least one non-empty section and persist normalized titles, tags, and auto-ticket preferences.【F:backend/app/services/daily_reports.py†L31-L90】
+- Submissions must transition reports into a processing state, log submission and analysis-start events, and attempt ChatGPT analysis with a configurable card cap.【F:backend/app/services/daily_reports.py†L138-L177】
+- On successful analysis, reports are marked completed, proposal metadata is stored, lifecycle events are appended, and the persisted row is removed after returning the detail payload to the client.【F:backend/app/services/daily_reports.py†L178-L213】
+- On analysis failure, the failure reason is recorded, report status becomes failed, processing metadata captures the error, and a retry endpoint is exposed for failed reports only.【F:backend/app/routers/daily_reports.py†L94-L109】【F:backend/app/services/daily_reports.py†L154-L170】
+- The frontend must block duplicate submissions while a request is pending, reset the form after success, and surface localized error messaging when the backend returns validation or transport issues.【F:frontend/src/app/features/reports/reports-page.component.ts†L41-L125】


### PR DESCRIPTION
## Summary
- document daily reporting feature requirements, objectives, scope, user stories, and acceptance criteria
- capture detailed design covering API endpoints, event logging, ChatGPT integration, data model handling, and UI workflow
- link the new documentation from the repository README alongside existing feature specs

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d6072a2e10832084e077bebd99d960