### PR TITLE
Enable board subtask comment editing

### DIFF
--- a/backend/app/routers/comments.py
+++ b/backend/app/routers/comments.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Sequence, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import asc
@@ -14,23 +14,45 @@ from ..utils.activity import record_activity
 router = APIRouter(prefix="/comments", tags=["comments"])
 
 
+def _serialize_comment(
+    comment: models.Comment,
+    author_nickname: Optional[str],
+    author_email: Optional[str] = None,
+) -> schemas.CommentRead:
+    display_name = author_nickname or author_email
+    return schemas.CommentRead(
+        id=comment.id,
+        card_id=comment.card_id,
+        subtask_id=comment.subtask_id,
+        content=comment.content,
+        author_id=comment.author_id,
+        author_nickname=display_name,
+        created_at=comment.created_at,
+        updated_at=comment.updated_at,
+    )
+
+
 @router.get("/", response_model=List[schemas.CommentRead])
 def list_comments(
     card_id: Optional[str] = Query(default=None),
     subtask_id: Optional[str] = Query(default=None),
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
-) -> List[models.Comment]:
+) -> List[schemas.CommentRead]:
     query = (
-        db.query(models.Comment)
+        db.query(models.Comment, models.User.nickname, models.User.email)
         .join(models.Card, models.Comment.card_id == models.Card.id)
+        .outerjoin(models.User, models.Comment.author_id == models.User.id)
         .filter(models.Card.owner_id == current_user.id)
     )
     if card_id:
         query = query.filter(models.Comment.card_id == card_id)
     if subtask_id:
         query = query.filter(models.Comment.subtask_id == subtask_id)
-    return query.order_by(asc(models.Comment.created_at)).all()
+    rows: Sequence[Tuple[models.Comment, Optional[str], Optional[str]]] = query.order_by(
+        asc(models.Comment.created_at)
+    ).all()
+    return [_serialize_comment(comment, nickname, email) for comment, nickname, email in rows]
 
 
 @router.post("/", response_model=schemas.CommentRead, status_code=status.HTTP_201_CREATED)
@@ -68,7 +90,59 @@ def create_comment(
     )
     db.commit()
     db.refresh(comment)
-    return comment
+    nickname = current_user.nickname or current_user.email
+    return _serialize_comment(comment, nickname, current_user.email)
+
+
+@router.put("/{comment_id}", response_model=schemas.CommentRead)
+def update_comment(
+    comment_id: str,
+    payload: schemas.CommentUpdate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.CommentRead:
+    comment = db.get(models.Comment, comment_id)
+    if not comment:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Comment not found")
+
+    card = db.get(models.Card, comment.card_id)
+    if not card or card.owner_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Comment not found")
+
+    if "content" in payload.model_fields_set and payload.content is not None:
+        comment.content = payload.content
+
+    if "subtask_id" in payload.model_fields_set:
+        subtask_identifier = payload.subtask_id
+        if subtask_identifier is None:
+            comment.subtask_id = None
+        else:
+            subtask = db.get(models.Subtask, subtask_identifier)
+            if not subtask or subtask.card_id != card.id:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Subtask not found",
+                )
+            comment.subtask_id = subtask_identifier
+
+    record_activity(
+        db,
+        action="comment_updated",
+        card_id=comment.card_id,
+        actor_id=current_user.id,
+        details={"comment_id": comment.id, "subtask_id": comment.subtask_id},
+    )
+    db.add(comment)
+    db.commit()
+    db.refresh(comment)
+
+    author = db.get(models.User, comment.author_id) if comment.author_id else None
+    nickname = author.nickname if author and author.nickname else None
+    email = author.email if author else current_user.email
+    if not nickname and not email:
+        email = current_user.email
+
+    return _serialize_comment(comment, nickname, email)
 
 
 @router.delete(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -410,16 +410,38 @@ class BoardLayoutUpdate(UserPreferenceBase):
 class CommentBase(BaseModel):
     card_id: str
     content: str
-    author_id: Optional[str] = None
     subtask_id: Optional[str] = None
 
 
 class CommentCreate(CommentBase):
-    pass
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, value: str) -> str:
+        sanitized = value.strip()
+        if not sanitized:
+            raise ValueError("content must not be blank")
+        return sanitized
+
+
+class CommentUpdate(BaseModel):
+    content: Optional[str] = None
+    subtask_id: Optional[str] = None
+
+    @field_validator("content")
+    @classmethod
+    def validate_optional_content(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        sanitized = value.strip()
+        if not sanitized:
+            raise ValueError("content must not be blank")
+        return sanitized
 
 
 class CommentRead(CommentBase):
     id: str
+    author_id: Optional[str] = None
+    author_nickname: Optional[str] = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from .test_cards import create_status, register_and_login
+
+
+def _update_nickname(client: TestClient, headers: dict[str, str], nickname: str) -> None:
+    response = client.put(
+        "/profile/me",
+        data={"nickname": nickname},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+
+
+def _create_card_with_subtask(
+    client: TestClient,
+    headers: dict[str, str],
+    status_id: str,
+) -> tuple[str, str]:
+    response = client.post(
+        "/cards",
+        json={
+            "title": "コメントの検証",
+            "status_id": status_id,
+            "subtasks": [{"title": "仕様確認"}],
+        },
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    payload = response.json()
+    card_id = payload["id"]
+    subtask_id = payload["subtasks"][0]["id"]
+    return card_id, subtask_id
+
+
+def test_subtask_comment_crud_flow(client: TestClient) -> None:
+    headers = register_and_login(client, "commenter@example.com")
+    _update_nickname(client, headers, "ボード担当者")
+
+    status_id = create_status(client, headers)
+    card_id, subtask_id = _create_card_with_subtask(client, headers, status_id)
+
+    create_response = client.post(
+        "/comments",
+        json={
+            "card_id": card_id,
+            "subtask_id": subtask_id,
+            "content": "初回メモ",
+        },
+        headers=headers,
+    )
+    assert create_response.status_code == 201, create_response.text
+    created = create_response.json()
+    assert created["card_id"] == card_id
+    assert created["subtask_id"] == subtask_id
+    assert created["content"] == "初回メモ"
+    assert created["author_id"]
+    assert created["author_nickname"] == "ボード担当者"
+
+    list_response = client.get(
+        "/comments",
+        params={"card_id": card_id, "subtask_id": subtask_id},
+        headers=headers,
+    )
+    assert list_response.status_code == 200, list_response.text
+    listed = list_response.json()
+    assert len(listed) == 1
+    assert listed[0]["author_nickname"] == "ボード担当者"
+
+    update_response = client.put(
+        f"/comments/{created['id']}",
+        json={"content": "更新済みメモ", "subtask_id": subtask_id},
+        headers=headers,
+    )
+    assert update_response.status_code == 200, update_response.text
+    updated = update_response.json()
+    assert updated["content"] == "更新済みメモ"
+    assert updated["author_nickname"] == "ボード担当者"
+    assert updated["updated_at"] != created["updated_at"]
+
+    delete_response = client.delete(
+        f"/comments/{created['id']}",
+        headers=headers,
+    )
+    assert delete_response.status_code == 204, delete_response.text
+
+    empty_response = client.get(
+        "/comments",
+        params={"card_id": card_id, "subtask_id": subtask_id},
+        headers=headers,
+    )
+    assert empty_response.status_code == 200
+    assert empty_response.json() == []

--- a/frontend/src/app/core/models/card.ts
+++ b/frontend/src/app/core/models/card.ts
@@ -3,7 +3,8 @@
  */
 export interface CardComment {
   readonly id: string;
-  readonly author: string;
+  readonly authorId?: string;
+  readonly authorNickname: string;
   readonly message: string;
   readonly createdAt: string;
   readonly updatedAt: string;

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -490,9 +490,8 @@
                   <input
                     type="text"
                     class="comment-editor__input"
-                    placeholder="氏名またはイニシャル"
-                    [value]="commentForm.controls.author.value()"
-                    (input)="commentForm.controls.author.setValue($any($event.target).value)"
+                    [value]="commentAuthorNameSignal()"
+                    readonly
                   />
                 </label>
                 <label class="comment-editor__field">
@@ -525,8 +524,17 @@
                   class="button button--secondary"
                   [disabled]="!isCommentFormValid()"
                 >
-                  コメントを追加
+                  {{ editingCommentId() ? 'コメントを更新' : 'コメントを追加' }}
                 </button>
+                @if (editingCommentId()) {
+                  <button
+                    type="button"
+                    class="button button--ghost"
+                    (click)="cancelCommentEditing()"
+                  >
+                    キャンセル
+                  </button>
+                }
               </div>
             </form>
             <ul class="comment-list">
@@ -537,10 +545,13 @@
                   <li class="comment-list__item">
                     <div class="comment-list__meta">
                       <div class="comment-list__identity">
-                        <span class="comment-list__author">{{ comment.author }}</span>
+                        <span class="comment-list__author">{{ comment.authorNickname }}</span>
                         <span class="comment-list__timestamp"
                           >更新: {{ comment.updatedAt | date: 'yyyy/MM/dd HH:mm' }}</span
                         >
+                        @if (isCommentBeingEdited(comment.id)) {
+                          <span class="comment-list__status">編集中</span>
+                        }
                       </div>
                       @if (comment.subtaskId) {
                         <div class="comment-list__context">
@@ -549,13 +560,22 @@
                           >
                         </div>
                       }
-                      <button
-                        type="button"
-                        class="button button--ghost button--pill comment-list__remove"
-                        (click)="removeComment(active.id, comment.id)"
-                      >
-                        削除
-                      </button>
+                      <div class="comment-list__actions">
+                        <button
+                          type="button"
+                          class="button button--ghost button--pill comment-list__edit"
+                          (click)="startEditingComment(comment)"
+                        >
+                          編集
+                        </button>
+                        <button
+                          type="button"
+                          class="button button--ghost button--pill comment-list__remove"
+                          (click)="removeComment(active.id, comment.id)"
+                        >
+                          削除
+                        </button>
+                      </div>
                     </div>
                     <p class="comment-list__message">{{ comment.message }}</p>
                   </li>


### PR DESCRIPTION
## Summary
- include author nickname metadata and an update endpoint in the comments API so subtask notes can be edited safely
- surface the active user’s nickname in board comments, add inline edit/cancel flows, and track updates for subtask-specific discussions
- exercise the new workflow with an integration test that covers creating, updating, listing, and deleting subtask comments

## Testing
- pytest backend/tests
- black --check backend/app/schemas.py backend/app/routers/comments.py backend/tests/test_comments.py
- ruff check backend/app/schemas.py backend/app/routers/comments.py backend/tests/test_comments.py
- npx prettier --check src/app/features/board/page.ts src/app/features/board/page.html
- npm test -- --watchAll=false --runInBand --testEnvironment=jsdom *(fails: Angular CLI does not recognise these Jest flags)*
- npm test -- --watch=false *(fails: Chrome browser is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d60ad935e88320bea59e11ca7b30ce