### PR TITLE
Fix help dialog close button alignment

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -763,8 +763,9 @@ app-help-dialog .help-dialog__panel {
 }
 
 app-help-dialog .help-dialog__header {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
   gap: 1.5rem;
 }
 
@@ -794,7 +795,8 @@ app-help-dialog .help-dialog__description {
 }
 
 app-help-dialog .help-dialog__close {
-  align-self: flex-start;
+  align-self: start;
+  justify-self: end;
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- switch the help dialog header layout to a grid so the close control can sit opposite the title block
- justify the close button to the end of the header to render it in the upper-right corner of the dialog

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d61fc32bcc83209a7c87705c3fa763