### PR TITLE
Rename prompt improvement card

### DIFF
--- a/frontend/src/app/core/state/workspace-store.ts
+++ b/frontend/src/app/core/state/workspace-store.ts
@@ -208,7 +208,7 @@ const buildSubtasks = (titles: readonly string[]): Subtask[] =>
 const INITIAL_CARDS: Card[] = [
   {
     id: createId(),
-    title: 'ChatGPT プロンプトの改善',
+    title: 'カード詳細情報',
     summary: '分析精度向上のための新しいプロンプト設計を検証します。',
     statusId: 'in-progress',
     labelIds: ['ai'],


### PR DESCRIPTION
## Summary
- rename the initial card title from "ChatGPT プロンプトの改善" to "カード詳細情報"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d62847d8c483208eb2f312f6381cd7