### PR TITLE
Set board detail surface panel margin to zero

### DIFF
--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -563,6 +563,10 @@
   background: var(--surface-card);
 }
 
+.surface-panel.board-detail {
+  margin: 0;
+}
+
 .board-detail__grid {
   display: grid;
   gap: var(--panel-gap);


### PR DESCRIPTION
## Summary
- set the board detail surface panel margin to zero to align with surrounding layout

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6636552f48320bc539792dc09d251