### PR TITLE
Fix padding for board detail surface panel

### DIFF
--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -563,6 +563,10 @@
   background: var(--surface-card);
 }
 
+.board-detail.surface-panel {
+  --panel-padding: clamp(var(--space-xl), 3vw, var(--space-xxl));
+}
+
 .board-detail__grid {
   display: grid;
   gap: var(--panel-gap);


### PR DESCRIPTION
## Summary
- define a panel padding custom property for the board detail surface panel
- ensure the aside uses the same spacing scale as other surface panels

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d663adffc48320b654607cc1db6e8b