### PR TITLE
Adjust card detail column ratio

### DIFF
--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -638,7 +638,7 @@
 
 @media (min-width: 62rem) {
   .board-detail__body {
-    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
     align-items: start;
   }
 }


### PR DESCRIPTION
## Summary
- update the board detail layout so the card overview and comment columns use a 1:3 width ratio on large screens

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6640ca6688320b78ca53768b75409