### PR TITLE
Align card and subtask comment column ratios

### DIFF
--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -638,7 +638,7 @@
 
 @media (min-width: 62rem) {
   .board-detail__body {
-    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
     align-items: start;
   }
 }
@@ -833,7 +833,7 @@
 
 @media (min-width: 62rem) {
   .subtask-editor__layout {
-    grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
+    grid-template-columns: minmax(220px, 1fr) minmax(0, 3fr);
     align-items: start;
   }
 }


### PR DESCRIPTION
## Summary
- update the board detail layout so the card overview and comment columns use a 1:3 width ratio on large screens
- align the subtask editor sidebar and comment pane columns to the same 1:3 ratio for consistent comment widths

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d6640ca6688320b78ca53768b75409