### PR TITLE
Align profile dialog width with help dialog

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1026,7 +1026,7 @@ app-profile-dialog .profile-dialog__backdrop {
 app-profile-dialog .profile-dialog__panel {
   position: relative;
   z-index: 1;
-  width: min(48rem, 100%);
+  width: min(960px, 100%);
   max-height: calc(100vh - 3rem);
   overflow-y: auto;
   border-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary
- update the profile dialog panel width to match the help dialog for consistent sizing

## Testing
- Manual verification: launched the Angular dev server, logged in, and opened the profile dialog

------
https://chatgpt.com/codex/tasks/task_e_68d66a37e6ac8320a4ab93a383ec7db3