### PR TITLE
fix: refresh profile dialog role option styling

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1360,13 +1360,15 @@ app-profile-dialog .profile-dialog__role-option {
   gap: 0.55rem;
   padding: 0.55rem 0.75rem;
   border-radius: 0.9rem;
-  border: 1px solid var(--border-overlay);
-  background: var(--surface-overlay-muted);
-  color: var(--text-secondary);
+  border: 1px solid var(--border-card);
+  background: linear-gradient(180deg, var(--surface-layer-1), var(--surface-layer-2));
+  color: color-mix(in srgb, var(--text-secondary) 82%, var(--text-primary) 18%);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--surface-card) 72%, transparent);
   transition:
     border-color 150ms ease,
-    background-color 150ms ease,
-    color 150ms ease;
+    background 150ms ease,
+    color 150ms ease,
+    box-shadow 150ms ease;
 }
 
 app-profile-dialog .profile-dialog__role-option input {
@@ -1374,8 +1376,9 @@ app-profile-dialog .profile-dialog__role-option input {
 }
 
 app-profile-dialog .profile-dialog__role-option:hover {
-  border-color: var(--border-overlay-strong);
-  background: var(--surface-overlay);
+  border-color: var(--border-card-strong);
+  background: linear-gradient(180deg, var(--surface-layer-1), var(--surface-layer-3));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--surface-card) 82%, transparent);
   color: var(--text-primary);
 }
 
@@ -1385,8 +1388,13 @@ app-profile-dialog .profile-dialog__role-option:has(input:focus-visible) {
 }
 
 app-profile-dialog .profile-dialog__role-option:has(input:checked) {
-  border-color: var(--accent);
-  background: var(--accent-muted);
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--border-card-strong) 35%);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent-muted) 65%, var(--surface-layer-1)),
+    color-mix(in srgb, var(--accent-muted) 45%, var(--surface-layer-2))
+  );
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--accent-muted) 55%, transparent);
   color: var(--text-primary);
 }
 
@@ -1395,7 +1403,7 @@ app-profile-dialog .profile-dialog__role-option:has(input:checked) span {
 }
 
 app-profile-dialog .profile-dialog__role-option input:checked + span {
-  color: var(--accent, #2563eb);
+  color: var(--accent-strong);
   font-weight: 600;
 }
 
@@ -1489,18 +1497,21 @@ app-profile-dialog .profile-dialog__custom-role-remove svg {
 }
 
 .dark app-profile-dialog .profile-dialog__role-option {
-  border-color: color-mix(in srgb, var(--text-tertiary) 32%, transparent);
-  background: color-mix(in srgb, var(--surface-inverse) 82%, transparent);
-  color: color-mix(in srgb, var(--text-primary) 90%, transparent);
+  border-color: var(--border-card);
+  background: linear-gradient(180deg, var(--surface-layer-1), var(--surface-layer-2));
+  color: color-mix(in srgb, var(--text-secondary) 90%, var(--text-primary) 10%);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--surface-card) 28%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-option:hover {
-  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
-  background: color-mix(in srgb, var(--accent-strong) 22%, transparent);
+  border-color: var(--border-card-strong);
+  background: linear-gradient(180deg, var(--surface-layer-1), var(--surface-layer-3));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--surface-card) 38%, transparent);
+  color: var(--text-primary);
 }
 
 .dark app-profile-dialog .profile-dialog__role-option input:checked + span {
-  color: color-mix(in srgb, var(--accent) 95%, transparent);
+  color: color-mix(in srgb, var(--accent-strong) 85%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__custom-role-item {
@@ -1518,7 +1529,7 @@ app-profile-dialog .profile-dialog__custom-role-remove svg {
 }
 
 app-profile-dialog .profile-dialog__role-option input:checked + span {
-  color: var(--accent, #2563eb);
+  color: var(--accent-strong);
   font-weight: 600;
 }
 
@@ -1661,18 +1672,21 @@ app-profile-dialog
 }
 
 .dark app-profile-dialog .profile-dialog__role-option {
-  border-color: color-mix(in srgb, var(--text-tertiary) 32%, transparent);
-  background: color-mix(in srgb, var(--surface-inverse) 82%, transparent);
-  color: color-mix(in srgb, var(--text-primary) 90%, transparent);
+  border-color: var(--border-card);
+  background: linear-gradient(180deg, var(--surface-layer-1), var(--surface-layer-2));
+  color: color-mix(in srgb, var(--text-secondary) 90%, var(--text-primary) 10%);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--surface-card) 28%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-option:hover {
-  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
-  background: color-mix(in srgb, var(--accent-strong) 22%, transparent);
+  border-color: var(--border-card-strong);
+  background: linear-gradient(180deg, var(--surface-layer-1), var(--surface-layer-3));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--surface-card) 38%, transparent);
+  color: var(--text-primary);
 }
 
 .dark app-profile-dialog .profile-dialog__role-option input:checked + span {
-  color: color-mix(in srgb, var(--accent) 95%, transparent);
+  color: color-mix(in srgb, var(--accent-strong) 85%, transparent);
 }
 
 .dark app-profile-dialog .profile-dialog__role-summary-item {


### PR DESCRIPTION
## Summary
- restyle the profile dialog role option cards to follow the design-system gradients, borders, and accent states
- align hover and selected treatments for the role options across light and dark themes for consistent contrast

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d66a91e9b88320bffdf094887c90c5