### PR TITLE
Refine dark mode profile dialog backdrop

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -141,8 +141,8 @@
   --neutral-surface-strong: color-mix(in srgb, var(--text-inverse-tertiary) 38%, transparent);
   --neutral-border: color-mix(in srgb, var(--text-inverse-tertiary) 48%, transparent);
   --neutral-border-strong: color-mix(in srgb, var(--text-inverse-tertiary) 58%, transparent);
-  --overlay-backdrop: color-mix(in srgb, var(--surface-inverse) 75%, transparent);
-  --overlay-backdrop-strong: color-mix(in srgb, var(--surface-inverse) 82%, transparent);
+  --overlay-backdrop: color-mix(in srgb, var(--surface-card-muted) 78%, transparent);
+  --overlay-backdrop-strong: color-mix(in srgb, var(--surface-card-muted) 88%, transparent);
   --surface-overlay-strong: color-mix(in srgb, var(--surface-card) 94%, transparent);
   --surface-overlay: color-mix(in srgb, var(--surface-card) 86%, transparent);
   --surface-overlay-muted: color-mix(in srgb, var(--surface-card) 76%, transparent);
@@ -1036,6 +1036,10 @@ app-profile-dialog .profile-dialog__panel {
   display: flex;
   flex-direction: column;
   gap: 2rem;
+}
+
+:root.dark app-profile-dialog .profile-dialog__panel {
+  background: linear-gradient(180deg, var(--surface-layer-1), var(--surface-layer-3));
 }
 
 app-profile-dialog .profile-dialog__header {


### PR DESCRIPTION
## Summary
- darken the profile dialog backdrop overlay in dark mode by reusing the muted surface tone for blur tint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d668ab92bc8320ae974e583a674c11