### PR TITLE
Add overflow wrapping to board card overview text

### DIFF
--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -673,6 +673,7 @@
   font-size: 0.95rem;
   line-height: 1.6;
   color: color-mix(in srgb, var(--text-secondary) 90%, transparent);
+  overflow-wrap: anywhere;
 }
 
 .card-overview__list {
@@ -702,6 +703,7 @@
   font-size: 0.95rem;
   font-weight: 600;
   color: var(--text-primary);
+  overflow-wrap: anywhere;
 }
 
 .card-overview__status {


### PR DESCRIPTION
## Summary
- allow long card summaries and field values in the board detail drawer to wrap within the panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6798c0ae88320b0d87247da86d7fb