### PR TITLE
Fix comment overflow in board drawer

### DIFF
--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -1127,6 +1127,7 @@
   font-size: 0.88rem;
   line-height: 1.6;
   color: var(--text-primary);
+  overflow-wrap: anywhere;
 }
 
 .board-detail__section {


### PR DESCRIPTION
## Summary
- allow long comment tokens to wrap within the board drawer by enabling overflow wrapping on comment messages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d67982ad8c8320ad772e0f940d9aff