### PR TITLE
Improve feedback cues on analyze page submission

### DIFF
--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -93,14 +93,55 @@
     </div>
 
     <div class="form-actions analyze-page__form-actions">
-      <button type="submit" class="button button--primary">タスク案を作成</button>
+      <button
+        type="submit"
+        class="button button--primary analyze-page__submit"
+        [disabled]="isSubmitDisabled()"
+        [attr.aria-busy]="isAnalyzing()"
+      >
+        <span
+          class="button__spinner"
+          aria-hidden="true"
+          [class.button__spinner--visible]="isAnalyzing()"
+        ></span>
+        <span class="button__label">{{ isAnalyzing() ? '生成中…' : 'タスク案を作成' }}</span>
+      </button>
       <button type="button" class="button button--ghost" (click)="resetForm()">
         入力をリセット
       </button>
     </div>
   </form>
 
-  <section class="page-section analyze-page__results">
+  @if (generationToast(); as toastState) {
+    <div
+      class="analyze-page__toast"
+      role="status"
+      aria-live="polite"
+      [attr.data-state]="toastState"
+    >
+      @if (toastState === 'loading') {
+        <span class="analyze-page__toast-spinner" aria-hidden="true"></span>
+      } @else {
+        <svg
+          class="analyze-page__toast-icon"
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          focusable="false"
+        >
+          <path
+            d="M9.5 16.2 5.3 12a1 1 0 0 1 1.4-1.4l2.8 2.79 7.09-7.09a1 1 0 1 1 1.42 1.42l-7.8 7.8a1 1 0 0 1-1.41 0Z"
+          />
+        </svg>
+      }
+      <span class="analyze-page__toast-message">{{ generationToastMessage() }}</span>
+    </div>
+  }
+
+  <section
+    class="page-section analyze-page__results"
+    [class.analyze-page__results--highlight]="shouldHighlightResults()"
+    aria-live="polite"
+  >
     <header class="page-section__header analyze-page__results-header">
       <div>
         <p class="analyze-page__results-eyebrow">AI Suggestions</p>
@@ -117,9 +158,12 @@
     </header>
 
     @if (analysisResource.status() === 'loading') {
-      <div class="page-state analyze-page__state">
-        <h2>タスク案を生成しています</h2>
-        <p>AI がタスク案を準備しています...</p>
+      <div class="page-state analyze-page__state analyze-page__state--loading" role="status">
+        <span class="analyze-page__loader" aria-hidden="true"></span>
+        <div class="analyze-page__state-body">
+          <h2>タスク案を生成しています</h2>
+          <p>AI がタスク案を準備しています...</p>
+        </div>
       </div>
     }
 
@@ -131,9 +175,16 @@
 
     @if (analysisResource.value()) {
       @if (hasEligibleProposals()) {
-        <ul class="page-list analyze-page__proposal-list">
-          @for (proposal of eligibleProposals(); track proposal.id) {
-            <li class="page-list__item analyze-page__proposal">
+        <ul
+          class="page-list analyze-page__proposal-list"
+          [attr.data-animate]="shouldHighlightResults() ? 'incoming' : null"
+        >
+          @for (proposal of eligibleProposals(); track proposal.id; let index = $index) {
+            <li
+              class="page-list__item analyze-page__proposal"
+              [class.analyze-page__proposal--incoming]="shouldHighlightResults()"
+              [style.--proposal-index]="index"
+            >
               <div class="analyze-page__proposal-header">
                 <h4 class="analyze-page__proposal-title">{{ proposal.title }}</h4>
                 <span class="page-badge page-badge--accent">

--- a/frontend/src/app/features/analyze/page.ts
+++ b/frontend/src/app/features/analyze/page.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { AnalysisGateway } from '@core/api/analysis-gateway';
@@ -20,6 +28,7 @@ import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 export class AnalyzePage {
   private readonly analysisGateway = inject(AnalysisGateway);
   private readonly workspace = inject(WorkspaceStore);
+  private readonly destroyRef = inject(DestroyRef);
 
   public readonly analyzeForm = createSignalForm<AnalysisRequest>({
     notes: '',
@@ -28,6 +37,12 @@ export class AnalyzePage {
   });
 
   private readonly requestSignal = signal<AnalysisRequest | null>(null);
+
+  private readonly toastState = signal<'loading' | 'success' | null>(null);
+  private readonly highlightResults = signal(false);
+  private toastTimer: number | null = null;
+  private highlightTimer: number | null = null;
+  private previousStatus: string | null = null;
 
   public readonly analysisResource = this.analysisGateway.createAnalysisResource(
     this.requestSignal,
@@ -54,6 +69,47 @@ export class AnalyzePage {
     this.generateAutoObjective(this.analyzeForm.controls.notes.value().trim()),
   );
 
+  public readonly isAnalyzing = computed(() => {
+    const status = this.analysisResource.status();
+
+    return status === 'loading' || status === 'reloading';
+  });
+
+  public readonly canSubmit = computed(() => {
+    const value = this.analyzeForm.value();
+    const notes = value.notes.trim();
+    if (notes.length === 0) {
+      return false;
+    }
+
+    if (!value.autoObjective && value.objective.trim().length === 0) {
+      return false;
+    }
+
+    return true;
+  });
+
+  public readonly isSubmitDisabled = computed(() => this.isAnalyzing() || !this.canSubmit());
+
+  public readonly generationToast = computed(() => this.toastState());
+
+  public readonly shouldHighlightResults = computed(() => this.highlightResults());
+
+  public readonly generationToastMessage = computed(() => {
+    const state = this.toastState();
+    if (!state) {
+      return null;
+    }
+
+    if (state === 'loading') {
+      return 'AI がカード案を生成中です…';
+    }
+
+    return this.hasEligibleProposals()
+      ? '提案が更新されました！'
+      : '提案の準備が完了しました。設定を見直してください。';
+  });
+
   private readonly dispatchAnalyze = this.analyzeForm.submit((value) => {
     const payload = this.createRequestPayload(value);
     if (!payload) {
@@ -62,6 +118,40 @@ export class AnalyzePage {
 
     this.requestSignal.set(payload);
   });
+
+  private readonly monitorAnalysisLifecycle = effect(() => {
+    const status = this.analysisResource.status();
+    const previous = this.previousStatus;
+    this.previousStatus = status;
+
+    if (status === 'loading' || status === 'reloading') {
+      this.showLoadingToast();
+      this.highlightResults.set(false);
+      this.clearHighlightTimer();
+
+      return;
+    }
+
+    if (status === 'resolved') {
+      if (previous !== 'resolved') {
+        this.handleAnalysisSuccess();
+      }
+
+      return;
+    }
+
+    if (status === 'error' || status === 'idle' || status === 'local') {
+      this.toastState.set(null);
+      this.highlightResults.set(false);
+      this.clearVisualTimers();
+    }
+  });
+
+  public constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.clearVisualTimers();
+    });
+  }
 
   /**
    * Handles form submission and prevents the default browser behavior.
@@ -112,9 +202,7 @@ export class AnalyzePage {
     return `「${firstMeaningfulLine}」への対応方針を整理する`;
   };
 
-  private readonly createRequestPayload = (
-    value: AnalysisRequest,
-  ): AnalysisRequest | null => {
+  private readonly createRequestPayload = (value: AnalysisRequest): AnalysisRequest | null => {
     const notes = value.notes.trim();
     if (notes.length === 0) {
       return null;
@@ -135,5 +223,87 @@ export class AnalyzePage {
   private readonly resetAnalyzeForm = (): void => {
     this.analyzeForm.reset({ notes: '', objective: '', autoObjective: true });
     this.requestSignal.set(null);
+    this.toastState.set(null);
+    this.highlightResults.set(false);
+    this.clearVisualTimers();
+    this.previousStatus = null;
   };
+
+  private showLoadingToast(): void {
+    this.toastState.set('loading');
+    this.clearToastTimer();
+  }
+
+  private handleAnalysisSuccess(): void {
+    const result = this.analysisResource.value();
+    if (!result) {
+      this.toastState.set(null);
+
+      return;
+    }
+
+    this.toastState.set('success');
+    this.startToastTimer();
+
+    if (this.hasEligibleProposals()) {
+      this.highlightResults.set(true);
+      this.startHighlightTimer();
+    } else {
+      this.highlightResults.set(false);
+      this.clearHighlightTimer();
+    }
+  }
+
+  private startToastTimer(): void {
+    this.clearToastTimer();
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    this.toastTimer = window.setTimeout(() => {
+      this.toastState.set(null);
+      this.toastTimer = null;
+    }, 3800);
+  }
+
+  private startHighlightTimer(): void {
+    this.clearHighlightTimer();
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    this.highlightTimer = window.setTimeout(() => {
+      this.highlightResults.set(false);
+      this.highlightTimer = null;
+    }, 1200);
+  }
+
+  private clearVisualTimers(): void {
+    this.clearToastTimer();
+    this.clearHighlightTimer();
+  }
+
+  private clearToastTimer(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (this.toastTimer !== null) {
+      window.clearTimeout(this.toastTimer);
+      this.toastTimer = null;
+    }
+  }
+
+  private clearHighlightTimer(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (this.highlightTimer !== null) {
+      window.clearTimeout(this.highlightTimer);
+      this.highlightTimer = null;
+    }
+  }
 }

--- a/frontend/src/styles/pages/_analyze.scss
+++ b/frontend/src/styles/pages/_analyze.scss
@@ -141,6 +141,10 @@
   gap: 0.75rem;
 }
 
+.analyze-page__submit {
+  min-width: clamp(11.5rem, 16vw, 13.75rem);
+}
+
 .analyze-page__results-header {
   display: flex;
   flex-direction: column;
@@ -153,6 +157,52 @@
     align-items: flex-end;
     justify-content: space-between;
   }
+}
+
+.analyze-page__toast {
+  position: fixed;
+  top: clamp(84px, 11vh, 120px);
+  right: clamp(12px, 5vw, 48px);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1.15rem;
+  border-radius: 9999px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  background: color-mix(in srgb, var(--surface-overlay) 96%, transparent);
+  box-shadow: 0 18px 36px color-mix(in srgb, var(--accent) 20%, transparent);
+  color: var(--text-secondary);
+  backdrop-filter: blur(16px);
+  z-index: 30;
+  animation: analyze-toast-in 220ms ease forwards;
+}
+
+.analyze-page__toast[data-state='success'] {
+  border-color: color-mix(in srgb, var(--success) 48%, transparent);
+  box-shadow: 0 20px 40px color-mix(in srgb, var(--success) 24%, transparent);
+}
+
+.analyze-page__toast-spinner {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 9999px;
+  border: 2px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  border-top-color: var(--accent);
+  animation: analyze-toast-spin 820ms linear infinite;
+}
+
+.analyze-page__toast-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  fill: var(--success-strong);
+  filter: drop-shadow(0 2px 4px color-mix(in srgb, var(--success) 32%, transparent));
+}
+
+.analyze-page__toast-message {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
 }
 
 .analyze-page__results-eyebrow {
@@ -168,8 +218,31 @@
   margin-top: 1.1rem;
 }
 
+.analyze-page__results {
+  position: relative;
+  margin-top: 1.1rem;
+}
+
+.analyze-page__results--highlight::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: calc(var(--radius-lg) * 1.05);
+  border: 2px solid color-mix(in srgb, var(--accent) 48%, transparent);
+  opacity: 0;
+  pointer-events: none;
+  animation: analyze-results-glow 960ms ease forwards;
+}
+
 .analyze-page__proposal-list {
   margin-top: 1.1rem;
+}
+
+.analyze-page__proposal-list[data-animate='incoming'] .analyze-page__proposal--incoming {
+  opacity: 0;
+  transform: translateY(12px);
+  animation: analyze-proposal-in 420ms cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+  animation-delay: calc(var(--proposal-index, 0) * 70ms);
 }
 
 .analyze-page__proposal {
@@ -202,6 +275,40 @@
   font-size: 0.95rem;
   line-height: 1.65;
   color: var(--text-secondary);
+}
+
+.analyze-page__state--loading {
+  display: flex;
+  align-items: center;
+  gap: 1.1rem;
+  padding: clamp(1.1rem, 1.5vw, 1.5rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  background: color-mix(in srgb, var(--surface-layer-2) 92%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.analyze-page__loader {
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 9999px;
+  border: 3px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  border-top-color: var(--accent);
+  animation: analyze-toast-spin 780ms linear infinite;
+}
+
+.analyze-page__state-body {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.analyze-page__state-body h2 {
+  margin: 0;
+}
+
+.analyze-page__state-body p {
+  margin: 0;
+  color: var(--text-muted);
 }
 
 .analyze-page__proposal-tags {
@@ -247,6 +354,53 @@
   height: 0.5rem;
   border-radius: 9999px;
   background: var(--accent);
+}
+
+@keyframes analyze-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes analyze-toast-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes analyze-results-glow {
+  0% {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(1.04);
+  }
+}
+
+@keyframes analyze-proposal-in {
+  0% {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .analyze-page__proposal-actions {

--- a/frontend/src/styles/pages/_base.scss
+++ b/frontend/src/styles/pages/_base.scss
@@ -500,6 +500,33 @@
   filter: none;
 }
 
+.button__spinner {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  border: 2px solid color-mix(in srgb, var(--text-inverse-secondary) 45%, transparent);
+  border-top-color: var(--text-inverse-primary);
+  opacity: 0;
+  animation: button-spinner-rotate 900ms linear infinite;
+  transition: opacity 150ms ease;
+}
+
+.button__spinner--visible {
+  opacity: 1;
+}
+
+.button__label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@keyframes button-spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .form-grid {
   display: grid;
   gap: clamp(0.75rem, 1vw, 1.25rem);


### PR DESCRIPTION
## Summary
- add reactive submission state handling to show loading status, disable the submit button, and generate contextual toasts on the AI analyze page
- animate proposal results and loading panels with highlight, spinner, and entrance transitions for clearer feedback when new suggestions arrive
- extend shared button styles with a spinner element used by the analyze action button

## Testing
- npm run format:check *(fails: repository has pre-existing formatting warnings outside the changed files)*
- npm test -- --watch=false *(fails: Chrome browser binary is unavailable in the container)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d682db6d7c8320979942abf2ff0305