### PR TITLE
Refine analysis prompt to demand actionable subtasks

### DIFF
--- a/backend/app/services/chatgpt.py
+++ b/backend/app/services/chatgpt.py
@@ -103,7 +103,9 @@ class ChatGPTClient:
         " using the requested JSON schema. Each proposal must contain a concise"
         " title, a summary that elaborates on the goal, optional labels,"
         " priority, due date guidance in days, and subtasks that describe"
-        " concrete steps. Use the same language as the user whenever possible."
+        " concrete, verifiable actions. Each subtask must be a single step that"
+        " starts with a strong verb, specifies the expected outcome, and avoids"
+        " vague phrases. Use the same language as the user whenever possible."
         " When available, tailor goals and subtasks to the engineer profile"
         " metadata provided in the request."
     )


### PR DESCRIPTION
## Summary
- refine the analysis assistant system prompt so generated subtasks must be single actionable steps with clear verbs and outcomes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d68d0cac5c832099afea2091e63f65