### PR TITLE
Improve analytics action conversion feedback

### DIFF
--- a/frontend/src/app/features/analytics/page.html
+++ b/frontend/src/app/features/analytics/page.html
@@ -252,13 +252,37 @@
             <button
               type="button"
               class="button button--primary"
-              [disabled]="action.status === 'converted'"
+              [disabled]="action.status === 'converted' || isActionPending(action.id)"
               (click)="convertAction(action.id)"
             >
-              {{ action.status === 'converted' ? '作成済み' : 'ワンクリックでタスク化' }}
+              <span
+                class="button__spinner"
+                [class.button__spinner--visible]="isActionPending(action.id)"
+                aria-hidden="true"
+              ></span>
+              <span class="button__label">
+                {{
+                  action.status === 'converted'
+                    ? '作成済み'
+                    : isActionPending(action.id)
+                      ? '作成中…'
+                      : 'ワンクリックでタスク化'
+                }}
+              </span>
             </button>
             @if (action.createdCardId) {
               <span class="text-xs text-slate-500">カードID: {{ action.createdCardId }}</span>
+            }
+            @if (actionStatus(action.id); as status) {
+              <p
+                class="text-xs font-medium"
+                [class.text-emerald-600]="status.status === 'success'"
+                [class.text-rose-600]="status.status === 'error'"
+                [attr.role]="status.status === 'error' ? 'alert' : 'status'"
+                [attr.aria-live]="status.status === 'error' ? 'assertive' : 'polite'"
+              >
+                {{ status.message }}
+              </p>
             }
           </div>
         </li>


### PR DESCRIPTION
## Summary
- return explicit success/error results when converting suggested actions so callers can react to failures
- add per-action pending/status tracking in the analytics page and clear transient messages with timers
- show inline feedback and spinner states in the analytics action list for better accessibility

## Testing
- npx prettier --check "src/app/core/state/continuous-improvement-store.ts" "src/app/features/analytics/page.ts" "src/app/features/analytics/page.html"
- npx eslint src/app/core/state/continuous-improvement-store.ts src/app/features/analytics/page.ts
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d68d26f62483208f73280306af2644