### PR TITLE
Add proposal import feedback toast

### DIFF
--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -157,6 +157,40 @@
       </div>
     </header>
 
+    @if (proposalPublishFeedback(); as feedback) {
+      <div
+        class="analyze-page__toast analyze-page__toast--inline"
+        role="status"
+        aria-live="polite"
+        [attr.data-state]="feedback.status"
+      >
+        @if (feedback.status === 'success') {
+          <svg
+            class="analyze-page__toast-icon"
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            focusable="false"
+          >
+            <path
+              d="M9.5 16.2 5.3 12a1 1 0 0 1 1.4-1.4l2.8 2.79 7.09-7.09a1 1 0 1 1 1.42 1.42l-7.8 7.8a1 1 0 0 1-1.41 0Z"
+            />
+          </svg>
+        } @else {
+          <svg
+            class="analyze-page__toast-icon analyze-page__toast-icon--error"
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            focusable="false"
+          >
+            <path
+              d="M13.41 12 18.7 6.71a1 1 0 1 0-1.41-1.41L12 10.59 6.71 5.3a1 1 0 0 0-1.41 1.41L10.59 12l-5.3 5.29a1 1 0 1 0 1.41 1.41L12 13.41l5.29 5.29a1 1 0 0 0 1.41-1.41Z"
+            />
+          </svg>
+        }
+        <span class="analyze-page__toast-message">{{ feedback.message }}</span>
+      </div>
+    }
+
     @if (analysisResource.status() === 'loading') {
       <div class="page-state analyze-page__state analyze-page__state--loading" role="status">
         <span class="analyze-page__loader" aria-hidden="true"></span>

--- a/frontend/src/styles/pages/_analyze.scss
+++ b/frontend/src/styles/pages/_analyze.scss
@@ -182,6 +182,19 @@
   box-shadow: 0 20px 40px color-mix(in srgb, var(--success) 24%, transparent);
 }
 
+.analyze-page__toast[data-state='error'] {
+  border-color: color-mix(in srgb, var(--danger) 48%, transparent);
+  box-shadow: 0 20px 40px color-mix(in srgb, var(--danger) 24%, transparent);
+}
+
+.analyze-page__toast--inline {
+  position: static;
+  top: auto;
+  right: auto;
+  margin: 0 0 1rem auto;
+  z-index: auto;
+}
+
 .analyze-page__toast-spinner {
   width: 1.1rem;
   height: 1.1rem;
@@ -196,6 +209,11 @@
   height: 1.1rem;
   fill: var(--success-strong);
   filter: drop-shadow(0 2px 4px color-mix(in srgb, var(--success) 32%, transparent));
+}
+
+.analyze-page__toast-icon--error {
+  fill: var(--danger-strong);
+  filter: drop-shadow(0 2px 4px color-mix(in srgb, var(--danger) 32%, transparent));
 }
 
 .analyze-page__toast-message {


### PR DESCRIPTION
## Summary
- add a proposal import feedback signal with timed success and error handling
- surface inline toast messaging in the analyze page template and reuse icons for success/error
- extend analyze page styles for inline toasts and error variants

## Testing
- npm run format:check *(fails: existing formatting issues in untouched files)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d68d287ff08320a1c5723ebf72afbf