### PR TITLE
Update persistence documentation and translate remaining notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Verbalize Yourself
 
-Verbalize Yourself is an AI-assisted operations workspace that converts free-form shift notes into structured tasks, analytics, and competency insights. An Angular 17 single-page application collaborates with a FastAPI backend so teams can analyse feedback, triage tickets, and oversee automation quotas from one control plane.
+Verbalize Yourself is an AI-assisted operations workspace that converts free-form shift notes into structured tasks, analytics, and competency insights. An Angular 20 single-page application collaborates with a FastAPI backend so teams can analyse feedback, triage tickets, and oversee automation quotas from one control plane.
 
 ## Highlights
 - **Task operations hub** – Drag cards across custom board columns, apply quick filters for overdue or unassigned work, and manage subtasks, comments, and activity history from a unified drawer backed by the workspace signal store.

--- a/backend/README.md
+++ b/backend/README.md
@@ -58,7 +58,7 @@ Configuration is managed through environment variables (see `app/config.py`). Ke
 - `CHATGPT_MODEL`: Logical name for the ChatGPT model (default: `gpt-4o-mini`).
 - `ALLOWED_ORIGINS`: Comma-separated list of origins allowed to call the API with browser credentials (default: `http://localhost:4200`).
 - `SECRET_ENCRYPTION_KEY`: Optional key used to encrypt stored API credentials (defaults to an internal fallback; configure in production).
-- **AI API トークン**: Manage the actual ChatGPT API key from the admin settings screen. The backend reads the encrypted value from the database.
+- **AI API token**: Manage the ChatGPT API key from the admin settings screen. The backend reads the encrypted value from the database.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- translate and expand the backend persistence guide so each workflow points to the FastAPI routers that store data
- refresh the backend README configuration section to use English wording for the AI API token entry
- update the project README to reflect the current Angular 20 frontend version

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6af8c09748320976ec01c7711ae11