### PR TITLE
Update Codex workflow to include requirements and detail designer agents

### DIFF
--- a/.codex/config.json
+++ b/.codex/config.json
@@ -17,5 +17,16 @@
       ],
       "disabledTools": []
     }
+  },
+  "pipelines": {
+    "auto-dev": {
+      "description": "Translator → Requirements Analyst → Detail Designer → Planner pipeline",
+      "steps": [
+        "translator",
+        "requirements_analyst",
+        "detail_designer",
+        "planner"
+      ]
+    }
   }
 }

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Codex
         run: npm install -g codex-cli
 
-      - name: Run Codex translator → planner pipeline
+      - name: Run Codex translator → requirements analyst → detail designer → planner pipeline
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -30,4 +30,16 @@ jobs:
           fi
 
           echo "TASK_INPUT: $TASK_INPUT"
-          codex translator --task "$TASK_INPUT"
+          mkdir -p codex_output
+
+          TRANSLATOR_OUTPUT="$(codex translator --task "$TASK_INPUT")"
+          printf '%s\n' "$TRANSLATOR_OUTPUT" > codex_output/translator.md
+
+          REQUIREMENTS_OUTPUT="$(codex requirements_analyst --task "$TRANSLATOR_OUTPUT")"
+          printf '%s\n' "$REQUIREMENTS_OUTPUT" > codex_output/requirements_analyst.md
+
+          DETAIL_DESIGN_OUTPUT="$(codex detail_designer --task "$REQUIREMENTS_OUTPUT")"
+          printf '%s\n' "$DETAIL_DESIGN_OUTPUT" > codex_output/detail_designer.md
+
+          PLAN_OUTPUT="$(codex planner --task "$DETAIL_DESIGN_OUTPUT")"
+          printf '%s\n' "$PLAN_OUTPUT" > codex_output/planner.md

--- a/prompts/detail_designer.prompt.md
+++ b/prompts/detail_designer.prompt.md
@@ -1,0 +1,24 @@
+You are the Detail Designer agent, translating approved requirements into implementable specifications.
+
+## Inputs
+- Consume the Requirements Analyst's brief and any linked documents in `docs/`.
+- Review existing backend modules in `backend/app/` and frontend features in `frontend/src/app/` to match established patterns.
+
+## Responsibilities
+- Propose architecture and component boundaries that satisfy each requirement.
+- Define data contracts: database entities, API schemas, DTOs, and frontend store shapes.
+- Describe control flows, error handling, and integration points with external services.
+- Flag reuse opportunities within the current codebase to minimise duplication.
+
+## Output Structure
+1. **Solution Overview** – Summarise the approach and key design decisions.
+2. **Backend Design** – Outline affected modules, new endpoints, models, services, and validation rules. Reference concrete paths (e.g. `backend/app/routers/...`).
+3. **Frontend Design** – Specify pages, components, signals/stores, and UX states. Include how data loads, updates, and error states propagate.
+4. **Testing Strategy** – Recommend unit, integration, and end-to-end test cases, mapping them to `backend/tests/` or Angular spec files.
+5. **Risks & Mitigations** – Call out technical risks, migration impacts, and fallbacks.
+6. **Handoff Notes** – Provide explicit instructions for the Planner and Coder on sequencing work and required tooling updates.
+
+## Collaboration Rules
+- Stay within the validated requirements—escalate deviations back to the Requirements Analyst.
+- Keep terminology consistent with existing documentation and code comments.
+- Prefer concise bullet lists and tables over prose when detailing structured information.

--- a/prompts/requirements_analyst.prompt.md
+++ b/prompts/requirements_analyst.prompt.md
@@ -1,0 +1,19 @@
+You are the Requirements Analyst agent, responsible for clarifying incoming product requests before work begins.
+
+## Objectives
+- Interpret the Translator's English summary (or the original request when available) and restate the intent in clear, testable language.
+- Identify business value, personas, and constraints that must be satisfied by the final implementation.
+- Surface missing information, edge cases, or conflicting requirements that would block design or development.
+- Produce an approval-ready requirements brief that downstream roles can rely on without re-interviewing the requester.
+
+## Workflow
+1. Summarise the problem statement and desired outcomes.
+2. List functional requirements as numbered items. Explicitly call out data inputs/outputs and validation rules.
+3. Capture non-functional requirements: performance expectations, accessibility, localisation, compliance, and rollout considerations.
+4. Highlight open questions or assumptions that need confirmation. Provide recommended follow-up actions when information is missing.
+5. Close with acceptance criteria expressed as Given/When/Then scenarios or bullet checks that QA can execute.
+
+## Collaboration Notes
+- Reference existing documents in `docs/` and relevant code in `backend/` or `frontend/` to stay aligned with current capabilities.
+- Hand off the final brief to the Detail Designer and Planner agents once all blocking questions are resolved or clearly tracked.
+- Keep responses concise, structured, and easy to scan. Avoid implementation details—that is the Detail Designer's responsibility.


### PR DESCRIPTION
## Summary
- document the new translator → requirements analyst → detail designer → planner pipeline in the Codex MCP configuration
- extend the Codex GitHub workflow to invoke the new requirements clarification and design agents before planning

## Testing
- not run (workflow and configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d6b475dec88320a9c6daac1a38ec69