### PR TITLE
Handle deprecated --task flag in Codex pipeline script

### DIFF
--- a/scripts/run_codex_pipeline.sh
+++ b/scripts/run_codex_pipeline.sh
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TASK_INPUT=${1-}
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 [--task] <task description>" >&2
+  exit 1
+fi
+
+# Historical callers may still pass the task description via a deprecated
+# "--task" flag (for example `codex run auto-dev --task "..."`). The current
+# Codex CLI no longer accepts that option, so we strip it here for
+# compatibility and treat the remaining positional arguments as the actual
+# task description.
+if [ "${1-}" = "--task" ]; then
+  shift
+fi
+
+TASK_INPUT="$*"
 if [ -z "${TASK_INPUT}" ]; then
-  echo "Usage: $0 <task description>" >&2
+  echo "Usage: $0 [--task] <task description>" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- allow the Codex pipeline script to ignore the deprecated `--task` flag before constructing the task description
- accept multi-word task descriptions without relying on only the first argument
- update usage text to document the optional legacy flag

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d73922ce0c8320b14e355e7dd00b5d