### PR TITLE
Ensure Codex pipeline receives raw task text

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -21,23 +21,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          # イベント種別で入力を切り替え
+          # イベント種別で入力を切り替え。Codex パイプラインには生のテキストのみを渡す。
           if [ "${{ github.event_name }}" = "issues" ]; then
-            TASK_INPUT="${{ github.event.issue.title }}: ${{ github.event.issue.body }}"
+            RAW_TASK_INPUT="${{ github.event.issue.title }}: ${{ github.event.issue.body }}"
           elif [ "${{ github.event_name }}" = "issue_comment" ]; then
-            TASK_INPUT="Comment on issue #${{ github.event.issue.number }}: ${{ github.event.comment.body }}"
+            RAW_TASK_INPUT="Comment on issue #${{ github.event.issue.number }}: ${{ github.event.comment.body }}"
           else
-            TASK_INPUT="Manual trigger: Please implement the requested feature."
+            RAW_TASK_INPUT="Manual trigger: Please implement the requested feature."
           fi
 
-          echo "TASK_INPUT: $TASK_INPUT"
+          echo "TASK_INPUT: $RAW_TASK_INPUT"
           mkdir -p codex_output
           if ! command -v codex >/dev/null 2>&1; then
             echo "Codex CLI not installed correctly" >&2
             exit 1
           fi
 
-          scripts/run_codex_pipeline.sh "$TASK_INPUT"
+          scripts/run_codex_pipeline.sh "$RAW_TASK_INPUT"
 
       - name: Upload Codex outputs
         uses: actions/upload-artifact@v4

--- a/scripts/run_codex_pipeline.sh
+++ b/scripts/run_codex_pipeline.sh
@@ -16,6 +16,14 @@ if [ "${1-}" = "--task" ]; then
 fi
 
 TASK_INPUT="$*"
+# Guard against historical callers that inlined the deprecated flag into the
+# task description (for example, passing "--task build a feature" as a single
+# argument). We normalise the value so downstream prompts only contain the
+# human-provided request.
+if [[ "${TASK_INPUT}" == --task\ * ]]; then
+  TASK_INPUT="${TASK_INPUT#--task }"
+fi
+
 if [ -z "${TASK_INPUT}" ]; then
   echo "Usage: $0 [--task] <task description>" >&2
   exit 1


### PR DESCRIPTION
## Summary
- ensure the Codex workflow forwards raw issue and comment text without adding the deprecated `--task` flag
- normalize task inputs inside `run_codex_pipeline.sh` by removing any leading `--task ` prefix before prompts are built

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7562506448320b0239b8acf201c84