### PR TITLE
Restrict Codex workflow to trusted triggers

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -13,9 +13,24 @@ on:
 
 jobs:
   codex:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      ((github.event_name == 'issues' || github.event_name == 'issue_comment') &&
+       (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) ||
+        (github.event_name == 'issue_comment' &&
+         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check OPENAI_API_KEY availability
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "::error::OPENAI_API_KEY is not available for this workflow run. Maintainers: please re-run via \"Run workflow\" in the Actions tab so repository secrets are accessible."
+            exit 1
+          fi
 
       - name: Install Codex CLI
         run: npm install -g @openai/codex

--- a/docs/development-rules.md
+++ b/docs/development-rules.md
@@ -37,6 +37,11 @@ Follow these rules to keep delivery smooth and maintain quality.
    - Run `git fetch origin main && git merge origin/main` (or rebase) near the end of the task.
    - Resolve any conflicts and rerun builds or tests as necessary.
 
+### Codex workflow limitations
+
+- GitHub workflow runs triggered by issues or comments created by external contributors cannot access repository secrets such as `OPENAI_API_KEY`.
+- When the Codex automation fails for that reason, a maintainer with write access must re-run the workflow manually via **Run workflow** so the job can use the required secrets.
+
 ---
 
 ## Pre-merge Requirements


### PR DESCRIPTION
## Summary
- gate the Codex workflow so it only runs for workflow dispatches or trusted issue/comment authors
- add a guard step that informs maintainers to re-run manually when the OpenAI secret is unavailable
- document the rerun requirement for external issue or comment triggers in the development rules

## Testing
- not run (documentation and workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d7932eefa0832092a9cafc8d67e4c1