### PR TITLE
Fix Codex pipeline flag conflict

### DIFF
--- a/scripts/run_codex_pipeline.sh
+++ b/scripts/run_codex_pipeline.sh
@@ -117,9 +117,11 @@ for STEP in "${PIPELINE_STEPS[@]}"; do
   # the user-provided task (for example "--task foo") are never interpreted as
   # CLI options by the codex binary. Passing `--` before the positional argument
   # ensures argument parsing stops before the trailing `-` placeholder.
+  # `--full-auto` already implies the necessary sandbox/approval behaviour. Avoid
+  # passing `--dangerously-bypass-approvals-and-sandbox` alongside it because the
+  # Codex CLI rejects the combination.
   printf '%s' "${PROMPT}" | codex exec \
     --full-auto \
-    --dangerously-bypass-approvals-and-sandbox \
     --cd "${GITHUB_WORKSPACE:-$(pwd)}" \
     --output-last-message "${OUTPUT_FILE}" \
     --config approval_policy=never \


### PR DESCRIPTION
## Summary
- remove the incompatible --dangerously-bypass-approvals-and-sandbox flag from the codex pipeline script
- document why the flag was dropped to avoid future regressions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7cd1c6acc8320bc021c721342ed01