### PR TITLE
Fix API base URL resolution for status report analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ The backend starts on <http://localhost:8000> (with auto-applied migrations and 
    ```
    The Angular dev server provides hot module replacement at <http://localhost:4200>. Adjust the backend origin, if necessary, in `frontend/src/app/core/api/api.config.ts`.
 
+### Configuring the API base URL for production deployments
+
+The frontend automatically targets the backend origin when it is served from a non-localhost domain. If your deployment proxies the FastAPI server through a different host or path, expose the base URL via a meta tag in `index.html`:
+
+```html
+<meta name="verbalize:api-base-url" content="https://api.example.com" />
+```
+
+When no override is provided and the app is accessed from localhost, the SPA falls back to `http://localhost:8000` so the development servers continue to work out of the box.
+
 ### Running Tests & Quality Checks
 Execute the relevant checks before opening a pull request. Use the focused commands when you only touched documentation.
 

--- a/frontend/src/app/core/api/api.config.ts
+++ b/frontend/src/app/core/api/api.config.ts
@@ -1,10 +1,58 @@
-export const API_BASE_URL = 'http://localhost:8000';
+const DEFAULT_DEV_API_BASE_URL = 'http://localhost:8000';
+
+const ABSOLUTE_URL_PATTERN = /^https?:\/\//i;
+const LOCALHOST_PATTERN = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3})(?::\d+)?$/i;
+
+const resolveMetaApiBaseUrl = (): string | null => {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  try {
+    const element = document.querySelector('meta[name="verbalize:api-base-url"]');
+    const content = element?.getAttribute('content')?.trim();
+    return content?.length ? content.replace(/\/$/, '') : null;
+  } catch (error) {
+    return null;
+  }
+};
+
+const resolveWindowApiBaseUrl = (): string | null => {
+  if (typeof window === 'undefined' || !window.location?.origin) {
+    return null;
+  }
+
+  const origin = window.location.origin.replace(/\/$/, '');
+  if (!origin || LOCALHOST_PATTERN.test(origin)) {
+    return null;
+  }
+
+  return origin;
+};
+
+const resolveApiBaseUrl = (): string => {
+  return resolveMetaApiBaseUrl() || resolveWindowApiBaseUrl() || DEFAULT_DEV_API_BASE_URL;
+};
+
+export const API_BASE_URL = resolveApiBaseUrl();
 
 export const buildApiUrl = (path: string): string => {
-  if (path.startsWith('http://') || path.startsWith('https://')) {
+  if (ABSOLUTE_URL_PATTERN.test(path)) {
     return path;
   }
 
   const normalized = path.startsWith('/') ? path : `/${path}`;
   return `${API_BASE_URL}${normalized}`;
+};
+
+export const isApiRequestUrl = (url: string): boolean => {
+  if (!url) {
+    return false;
+  }
+
+  if (ABSOLUTE_URL_PATTERN.test(url)) {
+    return url.startsWith(API_BASE_URL);
+  }
+
+  return true;
 };

--- a/frontend/src/app/core/api/api.config.ts
+++ b/frontend/src/app/core/api/api.config.ts
@@ -12,7 +12,7 @@ const resolveMetaApiBaseUrl = (): string | null => {
     const element = document.querySelector('meta[name="verbalize:api-base-url"]');
     const content = element?.getAttribute('content')?.trim();
     return content?.length ? content.replace(/\/$/, '') : null;
-  } catch (error) {
+  } catch {
     return null;
   }
 };

--- a/frontend/src/app/core/auth/auth.interceptor.ts
+++ b/frontend/src/app/core/auth/auth.interceptor.ts
@@ -1,7 +1,7 @@
 import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 
-import { API_BASE_URL } from '@core/api/api.config';
+import { isApiRequestUrl } from '@core/api/api.config';
 
 import { AuthService } from './auth.service';
 
@@ -9,7 +9,7 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const auth = inject(AuthService);
   const token = auth.token();
 
-  if (!token || !req.url.startsWith(API_BASE_URL)) {
+  if (!token || !isApiRequestUrl(req.url)) {
     return next(req);
   }
 


### PR DESCRIPTION
## Summary
- resolve the frontend API base URL dynamically, with production overrides via meta tag
- update the auth interceptor to detect API requests using the new helper
- document how to configure the API base URL for deployments serving the SPA remotely

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary is not available in the container)*
- npm run format:check *(fails: existing Prettier issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fcbd07c48320860735869bda343f