### PR TITLE
Remove column identifiers from board card headers

### DIFF
--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -127,7 +127,6 @@
           >
             <header class="board-column__header">
               <div>
-                <p class="board-column__eyebrow">{{ column.id }}</p>
                 <h3 class="board-column__title" [style.color]="columnAccent(column)">
                   {{ column.title }}
                 </h3>
@@ -238,7 +237,6 @@
           >
             <header class="board-column__header">
               <div>
-                <p class="board-column__eyebrow">{{ column.id }}</p>
                 <h3 class="board-column__title" [style.color]="column.accent">
                   {{ column.title }}
                 </h3>

--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -271,14 +271,6 @@
   justify-content: space-between;
 }
 
-.board-column__eyebrow {
-  margin: 0;
-  font-size: 0.72rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-
 .board-summary__metric dt {
   margin: 0;
   font-size: 0.78rem;


### PR DESCRIPTION
## Summary
- stop rendering raw column identifiers above each board column title
- remove the unused board column eyebrow style rule

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7ff187b6c8320a6139945933039ff