### PR TITLE
Fix board detail padding

### DIFF
--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -556,15 +556,16 @@
 
 .board-detail {
   margin-block-start: var(--page-content-gap);
-  display: block;
-  padding: var(--panel-padding);
+  display: flex;
+  flex-direction: column;
+  gap: var(--panel-gap);
+  padding: clamp(var(--space-xl), 3vw, var(--space-xxl));
   border-radius: var(--radius-xl);
   border: 1px solid var(--border-card);
   background: var(--surface-card);
 }
 
 .board-detail.surface-panel {
-  --panel-padding: clamp(var(--space-xl), 3vw, var(--space-xxl));
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- add internal spacing and gap to the board detail panel so text no longer touches the border

## Testing
- not run (style-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7fc1af8cc8320a5506c84257ebce9