### PR TITLE
Remove group labels from profile role summary chips

### DIFF
--- a/frontend/src/app/core/profile/profile-dialog.html
+++ b/frontend/src/app/core/profile/profile-dialog.html
@@ -369,11 +369,6 @@
                   >
                     <span class="profile-dialog__role-summary-text">
                       <span class="profile-dialog__role-summary-name">{{ detail.label }}</span>
-                      @if (detail.groups.length) {
-                        <span class="profile-dialog__role-summary-group">
-                          {{ detail.groups.join(' / ') }}
-                        </span>
-                      }
                     </span>
                     <button
                       type="button"

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1609,16 +1609,6 @@ app-profile-dialog .profile-dialog__role-summary-name {
   line-height: 1.2;
 }
 
-app-profile-dialog .profile-dialog__role-summary-group {
-  font-size: 0.7rem;
-  font-weight: 500;
-  color: color-mix(in srgb, var(--accent) 70%, transparent);
-}
-
-app-profile-dialog .profile-dialog__role-summary-item--custom .profile-dialog__role-summary-group {
-  color: color-mix(in srgb, var(--success-strong) 70%, transparent);
-}
-
 app-profile-dialog .profile-dialog__role-summary-remove {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- stop showing role group lineage in the profile dialog selection summary
- remove the unused styling rules for the group label chips

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: Chrome binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8056d4dfc8320b908670057d5c23c