### PR TITLE
Add inner padding to board card button

### DIFF
--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -392,7 +392,7 @@
 .board-card__select {
   display: block;
   width: 100%;
-  padding: 0;
+  padding: var(--space-sm);
   border: 0;
   background: transparent;
   color: inherit;


### PR DESCRIPTION
## Summary
- add spacing inside the board card button so its text no longer touches the card border

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d8048f8cc48320afa52f87beefdb80