### PR TITLE
Simplify header role display

### DIFF
--- a/frontend/src/app/core/layout/shell/shell.html
+++ b/frontend/src/app/core/layout/shell/shell.html
@@ -185,7 +185,7 @@
                     @if (currentUser.roles.length) {
                       <span
                         class="shell-user__roles"
-                        [attr.title]="currentUser.roles.join(' / ')"
+                        [attr.title]="formatRoleTooltip(currentUser.roles)"
                       >
                         {{ formatRolePreview(currentUser.roles) }}
                       </span>

--- a/frontend/src/app/core/layout/shell/shell.ts
+++ b/frontend/src/app/core/layout/shell/shell.ts
@@ -15,6 +15,21 @@ import { ProfileDialogComponent } from '@core/profile/profile-dialog';
 import { UserProfile } from '@core/profile/profile.models';
 import { HelpDialogComponent } from './help-dialog';
 
+function extractRoleLabel(role: string): string {
+  const separator = ' / ';
+  const lastSeparatorIndex = role.lastIndexOf(separator);
+
+  if (lastSeparatorIndex === -1) {
+    return role;
+  }
+
+  return role.slice(lastSeparatorIndex + separator.length).trim();
+}
+
+function formatRoleLabels(roles: readonly string[]): string[] {
+  return roles.map((role) => extractRoleLabel(role)).filter((label) => label.length > 0);
+}
+
 type ThemePreference = 'light' | 'dark' | 'system';
 
 /**
@@ -120,12 +135,18 @@ export class Shell {
   public readonly user = this.auth.user;
 
   public formatRolePreview(roles: readonly string[]): string {
-    if (roles.length === 0) {
+    const labels = formatRoleLabels(roles);
+
+    if (labels.length === 0) {
       return '';
     }
 
-    const preview = roles.slice(0, 2).join(' / ');
-    return roles.length > 2 ? `${preview} / …` : preview;
+    const preview = labels.slice(0, 2).join(' / ');
+    return labels.length > 2 ? `${preview} / …` : preview;
+  }
+
+  public formatRoleTooltip(roles: readonly string[]): string {
+    return formatRoleLabels(roles).join(' / ');
   }
 
   public openProfile(): void {

--- a/frontend/src/app/core/profile/profile-dialog.html
+++ b/frontend/src/app/core/profile/profile-dialog.html
@@ -369,11 +369,6 @@
                   >
                     <span class="profile-dialog__role-summary-text">
                       <span class="profile-dialog__role-summary-name">{{ detail.label }}</span>
-                      @if (detail.groups.length) {
-                        <span class="profile-dialog__role-summary-group">
-                          {{ detail.groups.join(' / ') }}
-                        </span>
-                      }
                     </span>
                     <button
                       type="button"

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1609,16 +1609,6 @@ app-profile-dialog .profile-dialog__role-summary-name {
   line-height: 1.2;
 }
 
-app-profile-dialog .profile-dialog__role-summary-group {
-  font-size: 0.7rem;
-  font-weight: 500;
-  color: color-mix(in srgb, var(--accent) 70%, transparent);
-}
-
-app-profile-dialog .profile-dialog__role-summary-item--custom .profile-dialog__role-summary-group {
-  color: color-mix(in srgb, var(--success-strong) 70%, transparent);
-}
-
 app-profile-dialog .profile-dialog__role-summary-remove {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- strip role group prefixes before rendering the header role preview
- reuse the formatted role labels for the tooltip so it matches the preview text

## Testing
- npm test -- --watchAll=false --runInBand --testEnvironment=jsdom *(fails: Unknown arguments: watchAll, runInBand, testEnvironment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8056d4dfc8320b908670057d5c23c