### PR TITLE
Adjust competency badge spacing

### DIFF
--- a/frontend/src/styles/pages/_base.scss
+++ b/frontend/src/styles/pages/_base.scss
@@ -377,6 +377,13 @@
   gap: 0.75rem;
 }
 
+.page-list__heading > div {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .page-list__title {
   font-size: 1rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add flex styling to page list headings so competency titles have consistent spacing before their badges and action controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d80dec879c832089c6b33b023ac77b