### PR TITLE
feat: support chatgpt api key from settings

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -21,6 +21,15 @@ class Settings(BaseSettings):
         default="gpt-4o-mini",
         validation_alias=AliasChoices("CHATGPT_MODEL", "chatgpt_model"),
     )
+    chatgpt_api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "CHATGPT_API_KEY",
+            "chatgpt_api_key",
+            "OPENAI_API_KEY",
+            "openai_api_key",
+        ),
+    )
     secret_encryption_key: str | None = Field(
         default=None,
         validation_alias=AliasChoices("SECRET_ENCRYPTION_KEY", "secret_encryption_key"),

--- a/backend/app/services/chatgpt.py
+++ b/backend/app/services/chatgpt.py
@@ -464,12 +464,22 @@ def _load_chatgpt_configuration(db: Session, provider: str = "openai") -> tuple[
         .first()
     )
     if not credential:
+        disabled_credential_exists = (
+            db.query(models.ApiCredential)
+            .filter(
+                models.ApiCredential.provider == provider,
+                models.ApiCredential.is_active.is_(False),
+            )
+            .first()
+            is not None
+        )
+        if disabled_credential_exists:
+            raise ChatGPTConfigurationError("ChatGPT API key is disabled. Update it from the admin settings.")
+
         if settings.chatgpt_api_key:
             return settings.chatgpt_api_key, settings.chatgpt_model
 
-        raise ChatGPTConfigurationError(
-            "ChatGPT API key is not configured. Update it from the admin settings."
-        )
+        raise ChatGPTConfigurationError("ChatGPT API key is not configured. Update it from the admin settings.")
 
     cipher = get_secret_cipher()
     try:

--- a/backend/app/services/chatgpt.py
+++ b/backend/app/services/chatgpt.py
@@ -464,7 +464,12 @@ def _load_chatgpt_configuration(db: Session, provider: str = "openai") -> tuple[
         .first()
     )
     if not credential:
-        raise ChatGPTConfigurationError("ChatGPT API key is not configured. Update it from the admin settings.")
+        if settings.chatgpt_api_key:
+            return settings.chatgpt_api_key, settings.chatgpt_model
+
+        raise ChatGPTConfigurationError(
+            "ChatGPT API key is not configured. Update it from the admin settings."
+        )
 
     cipher = get_secret_cipher()
     try:

--- a/backend/tests/test_chatgpt_service.py
+++ b/backend/tests/test_chatgpt_service.py
@@ -5,7 +5,6 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
-
 from fastapi.testclient import TestClient
 
 from app import models
@@ -14,6 +13,7 @@ from app.database import get_db
 from app.schemas import UserProfile
 from app.services.chatgpt import (
     ChatGPTClient,
+    ChatGPTConfigurationError,
     ChatGPTError,
     _load_chatgpt_configuration,
 )
@@ -141,7 +141,7 @@ def test_load_chatgpt_configuration_uses_stored_model(client: TestClient) -> Non
         credential = models.ApiCredential(
             provider="openai",
             encrypted_secret=cipher.encrypt("sk-live"),
-            secret_hint="sk-****",  # noqa: S105 - test data
+            secret_hint="sk-****",  # noqa: S106 - test data
             is_active=True,
             model="gpt-4o",
         )
@@ -152,7 +152,7 @@ def test_load_chatgpt_configuration_uses_stored_model(client: TestClient) -> Non
     finally:
         db_gen.close()
 
-    assert secret == "sk-live"
+    assert secret == "sk-live"  # noqa: S105 - test data
     assert model == "gpt-4o"
 
 
@@ -175,7 +175,7 @@ def test_load_chatgpt_configuration_defaults_to_settings_model(client: TestClien
     finally:
         db_gen.close()
 
-    assert secret == "sk-default"
+    assert secret == "sk-default"  # noqa: S105 - test data
     assert model == settings.chatgpt_model
 
 
@@ -192,5 +192,32 @@ def test_load_chatgpt_configuration_falls_back_to_settings_api_key(client: TestC
         settings.chatgpt_api_key = original_key
         db_gen.close()
 
-    assert secret == "sk-env"
+    assert secret == "sk-env"  # noqa: S105 - test data
     assert model == settings.chatgpt_model
+
+
+def test_load_chatgpt_configuration_respects_disabled_credential(client: TestClient) -> None:
+    override = client.app.dependency_overrides[get_db]
+    db_gen = override()
+    db = next(db_gen)
+    original_key = settings.chatgpt_api_key
+    try:
+        cipher = get_secret_cipher()
+        credential = models.ApiCredential(
+            provider="openai",
+            encrypted_secret=cipher.encrypt("sk-disabled"),
+            is_active=False,
+        )
+        db.add(credential)
+        db.commit()
+
+        settings.chatgpt_api_key = "sk-env"
+
+        with pytest.raises(ChatGPTConfigurationError):
+            _load_chatgpt_configuration(db)
+
+        db.delete(credential)
+        db.commit()
+    finally:
+        settings.chatgpt_api_key = original_key
+        db_gen.close()

--- a/backend/tests/test_chatgpt_service.py
+++ b/backend/tests/test_chatgpt_service.py
@@ -177,3 +177,20 @@ def test_load_chatgpt_configuration_defaults_to_settings_model(client: TestClien
 
     assert secret == "sk-default"
     assert model == settings.chatgpt_model
+
+
+def test_load_chatgpt_configuration_falls_back_to_settings_api_key(client: TestClient) -> None:
+    override = client.app.dependency_overrides[get_db]
+    db_gen = override()
+    db = next(db_gen)
+    original_key = settings.chatgpt_api_key
+    try:
+        settings.chatgpt_api_key = "sk-env"
+
+        secret, model = _load_chatgpt_configuration(db)
+    finally:
+        settings.chatgpt_api_key = original_key
+        db_gen.close()
+
+    assert secret == "sk-env"
+    assert model == settings.chatgpt_model


### PR DESCRIPTION
## Summary
- allow backend ChatGPT configuration loader to fall back to an API key provided via environment variables
- expose `chatgpt_api_key` / `openai_api_key` settings to populate the fallback path
- cover the new fallback with a regression test to ensure the API client stays available

## Testing
- pytest backend/tests/test_chatgpt_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d811ac6f8c8320a60eee2dbfa6b627