### PR TITLE
Normalize trailing slashes in allowed origins

### DIFF
--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,19 @@
+"""Tests for application configuration settings."""
+
+from backend.app.config import Settings
+
+
+def test_allowed_origins_strip_trailing_slash(monkeypatch):
+    """Origins parsed from the environment remove trailing slashes."""
+
+    monkeypatch.setenv(
+        "ALLOWED_ORIGINS",
+        "http://localhost:4200/, https://app.example.com/",
+    )
+
+    settings = Settings()
+
+    assert settings.allowed_origins == [
+        "http://localhost:4200",
+        "https://app.example.com",
+    ]


### PR DESCRIPTION
## Summary
- trim trailing slashes when parsing allowed CORS origins so localhost values still match preflight requests
- cover the ALLOWED_ORIGINS parsing behavior with a regression test

## Testing
- ruff check backend/app/config.py backend/tests/test_config.py
- black --check backend/app/config.py backend/tests/test_config.py
- pytest backend/tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d8cfbe0b9083209d6022e80accd90f