### PR TITLE
Enforce secret encryption key configuration

### DIFF
--- a/backend/app/services/chatgpt.py
+++ b/backend/app/services/chatgpt.py
@@ -27,7 +27,7 @@ from ..schemas import (
     AnalysisSubtask,
     UserProfile,
 )
-from ..utils.secrets import get_secret_cipher
+from ..utils.secrets import SecretEncryptionKeyError, get_secret_cipher
 
 logger = logging.getLogger(__name__)
 
@@ -481,7 +481,10 @@ def _load_chatgpt_configuration(db: Session, provider: str = "openai") -> tuple[
 
         raise ChatGPTConfigurationError("ChatGPT API key is not configured. Update it from the admin settings.")
 
-    cipher = get_secret_cipher()
+    try:
+        cipher = get_secret_cipher()
+    except SecretEncryptionKeyError as exc:
+        raise ChatGPTConfigurationError(str(exc)) from exc
     try:
         secret = cipher.decrypt(credential.encrypted_secret)
     except Exception as exc:  # pragma: no cover - defensive path

--- a/backend/app/utils/secrets.py
+++ b/backend/app/utils/secrets.py
@@ -9,11 +9,26 @@ _DEFAULT_MASK_CHAR = "*"
 _VISIBLE_SEGMENT_LENGTH = 4
 
 
+class SecretEncryptionKeyError(RuntimeError):
+    """Raised when the secret encryption key configuration is invalid."""
+
+
 def get_secret_cipher() -> SecretCipher:
     """Return a cipher configured for encrypting stored secrets."""
 
-    key = settings.secret_encryption_key or "verbalize-yourself"
-    return SecretCipher(key)
+    key = settings.secret_encryption_key
+    if key is None:
+        raise SecretEncryptionKeyError(
+            "Secret encryption key is not configured. Set the SECRET_ENCRYPTION_KEY environment variable.",
+        )
+
+    normalized_key = key.strip()
+    if not normalized_key:
+        raise SecretEncryptionKeyError(
+            "Secret encryption key must not be empty. Update the SECRET_ENCRYPTION_KEY environment variable.",
+        )
+
+    return SecretCipher(normalized_key)
 
 
 def build_secret_hint(secret: str, *, mask_char: str = _DEFAULT_MASK_CHAR) -> str:
@@ -44,4 +59,4 @@ def build_secret_hint(secret: str, *, mask_char: str = _DEFAULT_MASK_CHAR) -> st
     return prefix + (mask_char * masked_length) + suffix
 
 
-__all__ = ["build_secret_hint", "get_secret_cipher"]
+__all__ = ["SecretEncryptionKeyError", "build_secret_hint", "get_secret_cipher"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,6 +12,7 @@ BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
+from app.config import settings
 from app.database import Base, get_db
 from app.main import app
 
@@ -20,19 +21,11 @@ engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
 
 
-@pytest.fixture()
-def email_factory() -> Callable[[], str]:
-    counter = itertools.count()
+@pytest.fixture(autouse=True)
+def configure_secret_encryption_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure a deterministic encryption key for tests that access secrets."""
 
-    def _factory() -> str:
-        return f"user-{next(counter)}@example.com"
-
-    return _factory
-
-
-@pytest.fixture()
-def email(email_factory: Callable[[], str]) -> str:
-    return email_factory()
+    monkeypatch.setattr(settings, "secret_encryption_key", "unit-test-secret-encryption-key")
 
 
 @pytest.fixture()

--- a/backend/tests/utils/test_secrets.py
+++ b/backend/tests/utils/test_secrets.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app.utils.crypto import SecretCipher
-from app.utils.secrets import build_secret_hint, get_secret_cipher
+from app.utils.secrets import SecretEncryptionKeyError, build_secret_hint, get_secret_cipher
 
 
 @pytest.mark.parametrize(
@@ -32,3 +32,11 @@ def test_get_secret_cipher_uses_application_settings(monkeypatch: pytest.MonkeyP
     encrypted = cipher.encrypt("sensitive value")
     assert encrypted
     assert cipher.decrypt(encrypted) == "sensitive value"
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_get_secret_cipher_requires_secret_key(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    monkeypatch.setattr("app.config.settings.secret_encryption_key", value)
+
+    with pytest.raises(SecretEncryptionKeyError):
+        get_secret_cipher()


### PR DESCRIPTION
## Summary
- require a configured SECRET_ENCRYPTION_KEY before encrypting stored API credentials and surface friendly HTTP errors when missing
- guard ChatGPT configuration loading against missing encryption keys and add regression tests for the new behaviour
- stabilize the test suite by forcing a deterministic secret encryption key during tests

## Testing
- pytest backend/tests
- ruff check backend/app/routers/admin_settings.py backend/app/services/chatgpt.py backend/app/utils/secrets.py backend/tests/conftest.py backend/tests/utils/test_secrets.py
- black --check backend/app/routers/admin_settings.py backend/app/services/chatgpt.py backend/app/utils/secrets.py backend/tests/conftest.py backend/tests/utils/test_secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d8dcc38a88832088f81f23bc30c684