### PR TITLE
Add debug instrumentation to recommendation scoring

### DIFF
--- a/backend/tests/test_recommendation_scoring.py
+++ b/backend/tests/test_recommendation_scoring.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.recommendation_scoring import RecommendationScoringService
+
+
+def test_score_card_emits_debug_log(caplog: pytest.LogCaptureFixture) -> None:
+    service = RecommendationScoringService(label_weight=2.0, profile_weight=1.0)
+    profile = SimpleNamespace(roles=["backend engineer"], bio="Build APIs", nickname=None)
+
+    with caplog.at_level(logging.DEBUG, logger="app.services.recommendation_scoring"):
+        result = service.score_card(
+            title="Backend API alignment",
+            summary="Ensure services stay consistent",
+            description="",
+            labels=["backend"],
+            profile=profile,
+        )
+
+    record = next(
+        log for log in caplog.records if log.levelno == logging.DEBUG and log.msg == "Recommendation scoring completed"
+    )
+
+    assert record.elapsed_ms >= 0
+    assert record.label_weight == pytest.approx(service._label_weight)
+    assert record.profile_weight == pytest.approx(service._profile_weight)
+    assert record.label_score == pytest.approx(result.label_correlation)
+    assert record.profile_score == pytest.approx(result.profile_alignment)
+    assert record.score == result.score
+
+
+def test_score_card_logs_debug_on_failure(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    service = RecommendationScoringService()
+    profile = SimpleNamespace(roles=[], bio=None, nickname=None)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(service, "_compose_text", boom)
+
+    with caplog.at_level(logging.DEBUG, logger="app.services.recommendation_scoring"):
+        result = service.score_card(
+            title="Any title",
+            summary=None,
+            description=None,
+            labels=[],
+            profile=profile,
+        )
+
+    assert result.failure_reason == "scoring_error"
+
+    record = next(
+        log
+        for log in caplog.records
+        if log.levelno == logging.DEBUG and log.msg == "Recommendation scoring failed; returning fallback"
+    )
+
+    assert record.elapsed_ms >= 0
+    assert record.label_weight == pytest.approx(service._label_weight)
+    assert record.profile_weight == pytest.approx(service._profile_weight)
+    assert record.label_score is None
+    assert record.profile_score is None
+    assert record.score == 0


### PR DESCRIPTION
## Summary
- capture perf counter timing within `RecommendationScoringService.score_card`
- emit structured debug logging for successful scoring and fallback paths
- add unit coverage to assert the debug payloads via `caplog`

## Testing
- pytest backend/tests/test_recommendation_scoring.py
- black --check backend/app/services/recommendation_scoring.py backend/tests/test_recommendation_scoring.py
- ruff check backend/app/services/recommendation_scoring.py backend/tests/test_recommendation_scoring.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ebafd7088320a6ec942a74cfc8f5