### PR TITLE
Propagate AI scoring failure reasons through cards API

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -133,6 +133,7 @@ class Card(Base, TimestampMixin):
     dependencies: Mapped[list[str]] = mapped_column(JSON, default=list)
     ai_confidence: Mapped[float | None] = mapped_column(Float)
     ai_notes: Mapped[str | None] = mapped_column(Text)
+    ai_failure_reason: Mapped[str | None] = mapped_column(Text)
     custom_fields: Mapped[dict] = mapped_column(JSON, default=dict)
     error_category_id: Mapped[str | None] = mapped_column(
         String, ForeignKey("error_categories.id", ondelete="SET NULL"), nullable=True

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -289,6 +289,7 @@ class CardBase(BaseModel):
     dependencies: List[str] = Field(default_factory=list)
     ai_confidence: Optional[float] = Field(default=None, ge=0, le=100)
     ai_notes: Optional[str] = None
+    ai_failure_reason: Optional[str] = Field(default=None, json_schema_extra={"readOnly": True})
     custom_fields: dict[str, Any] = Field(default_factory=dict)
     label_ids: List[str] = Field(default_factory=list)
     error_category_id: Optional[str] = None
@@ -314,6 +315,7 @@ class CardUpdate(BaseModel):
     dependencies: Optional[List[str]] = None
     ai_confidence: Optional[float] = Field(default=None, ge=0, le=100)
     ai_notes: Optional[str] = None
+    ai_failure_reason: Optional[str] = Field(default=None, json_schema_extra={"readOnly": True})
     custom_fields: Optional[dict[str, Any]] = None
     label_ids: Optional[List[str]] = None
     error_category_id: Optional[str] = None


### PR DESCRIPTION
## Summary
- add an `ai_failure_reason` column to cards via the ORM and startup migration
- expose the field on card schemas while keeping it read-only for create/update payloads
- persist recommendation failure reasons in the card router and cover both success and fallback paths in tests

## Testing
- pytest backend/tests/test_cards.py
- black backend/tests/test_cards.py
- ruff check backend/app/models.py backend/app/migrations.py backend/app/schemas.py backend/app/routers/cards.py backend/tests/test_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ebb2159083209ee77fd18bc4a0ae