### PR TITLE
Add admin UI for deleting user accounts

### DIFF
--- a/backend/tests/test_admin_users.py
+++ b/backend/tests/test_admin_users.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def _create_admin(client: TestClient) -> tuple[dict[str, str], str]:
+    email = "owner@example.com"
+    password = "AdminPass123!"  # noqa: S105 - test credential
+
+    register = client.post("/auth/register", json={"email": email, "password": password})
+    assert register.status_code == 201, register.text
+    admin_id = register.json()["user"]["id"]
+
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200, login.text
+    token = login.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}, admin_id
+
+
+def test_admin_can_delete_user(client: TestClient) -> None:
+    headers, _ = _create_admin(client)
+
+    user_register = client.post(
+        "/auth/register",
+        json={"email": "member@example.com", "password": "Password123!"},
+    )
+    assert user_register.status_code == 201, user_register.text
+    user_id = user_register.json()["user"]["id"]
+
+    before = client.get("/admin/users", headers=headers)
+    assert before.status_code == 200, before.text
+    before_ids = {user["id"] for user in before.json()}
+    assert user_id in before_ids
+
+    response = client.delete(f"/admin/users/{user_id}", headers=headers)
+    assert response.status_code == 204, response.text
+
+    after = client.get("/admin/users", headers=headers)
+    assert after.status_code == 200, after.text
+    after_ids = {user["id"] for user in after.json()}
+    assert user_id not in after_ids
+
+
+def test_admin_cannot_delete_self(client: TestClient) -> None:
+    headers, admin_id = _create_admin(client)
+
+    response = client.delete(f"/admin/users/{admin_id}", headers=headers)
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "Cannot delete your own account."

--- a/frontend/src/app/core/api/admin-api.service.ts
+++ b/frontend/src/app/core/api/admin-api.service.ts
@@ -54,6 +54,10 @@ export class AdminApiService {
     return this.http.patch<AdminUser>(buildApiUrl(`/admin/users/${id}`), payload);
   }
 
+  public deleteUser(id: string): Observable<void> {
+    return this.http.delete<void>(buildApiUrl(`/admin/users/${id}`));
+  }
+
   public getApiCredential(provider: string): Observable<ApiCredential> {
     return this.http.get<ApiCredential>(buildApiUrl(`/admin/api-credentials/${provider}`));
   }

--- a/frontend/src/app/features/admin/page.html
+++ b/frontend/src/app/features/admin/page.html
@@ -344,6 +344,7 @@
                 <th scope="col">有効</th>
                 <th scope="col">カード起票/日</th>
                 <th scope="col">判定回数/日</th>
+                <th scope="col">操作</th>
               </tr>
             </thead>
             <tbody>
@@ -390,6 +391,16 @@
                       placeholder="デフォルト"
                     />
                   </td>
+                  <td class="page-table__cell--center">
+                    <button
+                      type="button"
+                      class="button button--danger button--pill"
+                      (click)="deleteUser(user)"
+                      aria-label="{{ user.email }} を削除"
+                    >
+                      削除
+                    </button>
+                  </td>
                 </tr>
               }
             </tbody>
@@ -421,11 +432,7 @@
       <form class="page-form" (submit)="updateApiCredential($event)">
         <label class="form-field">
           <span class="form-field__label">利用モデル</span>
-          <select
-            class="form-control"
-            name="api-model"
-            [(ngModel)]="apiModel"
-          >
+          <select class="form-control" name="api-model" [(ngModel)]="apiModel">
             @if (!isKnownModel(apiModel)) {
               <option [value]="apiModel">{{ apiModel }} (保存済み)</option>
             }
@@ -448,7 +455,8 @@
           />
         </label>
         <p class="form-note">
-          モデルの変更は次回の AI 実行から適用されます。高精度モデルはトークン消費が増えるため、チームの運用方針に合わせて選択してください。
+          モデルの変更は次回の AI
+          実行から適用されます。高精度モデルはトークン消費が増えるため、チームの運用方針に合わせて選択してください。
         </p>
         <button type="submit" class="button button--primary" [disabled]="loading()">保存</button>
       </form>

--- a/frontend/src/app/features/admin/page.ts
+++ b/frontend/src/app/features/admin/page.ts
@@ -48,7 +48,9 @@ export class AdminPage {
     { value: 'gpt-4.1-mini', label: 'GPT-4.1 mini' },
     { value: 'gpt-4.1', label: 'GPT-4.1' },
   ];
-  private readonly knownChatModelValues = new Set(this.chatModelOptions.map((option) => option.value));
+  private readonly knownChatModelValues = new Set(
+    this.chatModelOptions.map((option) => option.value),
+  );
 
   public readonly newCompetency = signal<CompetencyInput>({
     name: '',
@@ -241,6 +243,28 @@ export class AdminPage {
       card_daily_limit: user.card_daily_limit ?? null,
       evaluation_daily_limit: user.evaluation_daily_limit ?? null,
     });
+  }
+
+  public deleteUser(user: AdminUser): void {
+    this.clearError();
+
+    if (typeof window !== 'undefined') {
+      const confirmed = window.confirm(`${user.email} を削除しますか？この操作は取り消せません。`);
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    this.api
+      .deleteUser(user.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.users.update((list) => list.filter((item) => item.id !== user.id));
+          this.notify('ユーザを削除しました。');
+        },
+        error: (err) => this.handleError(err, 'ユーザの削除に失敗しました。'),
+      });
   }
 
   public updateApiCredential(event: SubmitEvent): void {


### PR DESCRIPTION
## Summary
- add an admin API endpoint to delete user accounts while blocking self-deletion
- expose the delete operation through the Angular admin console with confirmation buttons
- cover the new behavior with backend tests for successful deletion and self-deletion rejection

## Testing
- ruff check backend/app/routers/admin_users.py backend/tests/test_admin_users.py
- black --check backend/app/routers/admin_users.py backend/tests/test_admin_users.py
- pytest backend/tests
- npm run lint
- npx prettier --check src/app/features/admin/page.html src/app/features/admin/page.ts
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d8ebf42ec8832087274ebc8248538b