### PR TITLE
Fix imported card confidence scaling

### DIFF
--- a/frontend/src/app/core/state/workspace-store.spec.ts
+++ b/frontend/src/app/core/state/workspace-store.spec.ts
@@ -162,7 +162,7 @@ describe('WorkspaceStore', () => {
           summary: 'Simplify the error messages and add success feedback.',
           status_id: 'status-todo',
           label_ids: ['label-ux'],
-          ai_confidence: 0.82,
+          ai_confidence: 82,
           assignees: [],
         }),
       );
@@ -180,7 +180,7 @@ describe('WorkspaceStore', () => {
         summary: 'Simplify the error messages and add success feedback.',
         status_id: 'status-todo',
         label_ids: ['label-ux'],
-        ai_confidence: 0.82,
+        ai_confidence: 82,
         created_at: '2024-06-01T00:00:00.000Z',
         labels: [],
         subtasks: [],

--- a/frontend/src/app/core/state/workspace-store.ts
+++ b/frontend/src/app/core/state/workspace-store.ts
@@ -1176,7 +1176,6 @@ export class WorkspaceStore {
               : [defaultLabel];
 
         const normalizedConfidence = normalizeProposalConfidence(proposal.confidence);
-        const fractionalConfidence = normalizedConfidence / 100;
 
         const card = await this.createCardFromSuggestion({
           title: proposal.title,
@@ -1185,7 +1184,7 @@ export class WorkspaceStore {
           labelIds,
           priority: 'medium',
           assignee: settings.defaultAssignee,
-          confidence: fractionalConfidence,
+          confidence: normalizedConfidence,
           originSuggestionId: proposal.id,
           subtasks: proposal.subtasks.map((task) => ({
             id: createId(),


### PR DESCRIPTION
## Summary
- keep analyzer proposal confidences as percentages when creating cards so existing board templates render correctly

## Testing
- npm test -- --watch=false *(fails: Chrome browser not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ed518a1083209df06df5094e95d9