### PR TITLE
Fix board preference handling and proposal persistence

### DIFF
--- a/frontend/src/app/core/state/workspace-store.ts
+++ b/frontend/src/app/core/state/workspace-store.ts
@@ -2428,11 +2428,11 @@ export class WorkspaceStore {
     userId: string | null,
     settings: WorkspaceSettings,
   ): Promise<void> {
+    const token = ++this.preferencesRequestToken;
     if (!userId) {
       return;
     }
 
-    const token = ++this.preferencesRequestToken;
     const cachedPreferences: BoardPreferences = {
       grouping: this.groupingSignal(),
       filters: cloneFilters(this.filtersSignal()),

--- a/frontend/src/app/core/state/workspace-store.ts
+++ b/frontend/src/app/core/state/workspace-store.ts
@@ -686,6 +686,7 @@ type CardSuggestionPayload = {
   readonly originSuggestionId?: string;
   readonly initiativeId?: string;
   readonly confidence?: number;
+  readonly confidenceDisplay?: number;
   readonly storyPoints?: number;
   readonly subtasks?: readonly Subtask[];
 };
@@ -747,19 +748,20 @@ export class WorkspaceStore {
   private configRequest: Promise<WorkspaceSettings> | null = null;
   private lastConfigUserId: string | null = null;
   private preferencesRequestToken = 0;
+  private lastAppliedUserId: string | null = null;
 
   public constructor() {
+    const initialUser = this.auth.user();
+    this.applyUserContext(initialUser?.id ?? null);
+
     effect(
       () => {
         const userId = this.activeUserId();
-        const settings = this.loadSettings(userId);
-        const preferences = this.loadPreferences(userId, settings);
-        this.settingsSignal.set(settings);
-        this.groupingSignal.set(preferences.grouping);
-        this.filtersSignal.set(preferences.filters);
-        this.reconcileCardsForSettings(settings);
-        this.reconcileFiltersForSettings(settings);
-        void this.refreshBoardPreferences(userId, settings);
+        if (userId === this.lastAppliedUserId) {
+          return;
+        }
+
+        this.applyUserContext(userId);
       },
       { allowSignalWrites: true },
     );
@@ -1176,6 +1178,10 @@ export class WorkspaceStore {
               : [defaultLabel];
 
         const normalizedConfidence = normalizeProposalConfidence(proposal.confidence);
+        const requestConfidence =
+          typeof proposal.confidence === 'number' && Number.isFinite(proposal.confidence)
+            ? proposal.confidence
+            : undefined;
 
         const card = await this.createCardFromSuggestion({
           title: proposal.title,
@@ -1184,7 +1190,8 @@ export class WorkspaceStore {
           labelIds,
           priority: 'medium',
           assignee: settings.defaultAssignee,
-          confidence: normalizedConfidence,
+          confidence: requestConfidence,
+          confidenceDisplay: normalizedConfidence,
           originSuggestionId: proposal.id,
           subtasks: proposal.subtasks.map((task) => ({
             id: createId(),
@@ -1197,9 +1204,7 @@ export class WorkspaceStore {
       }
     } catch (error) {
       if (createdCardIds.size > 0) {
-        this.cardsSignal.update((cards) =>
-          cards.filter((card) => !createdCardIds.has(card.id)),
-        );
+        this.cardsSignal.update((cards) => cards.filter((card) => !createdCardIds.has(card.id)));
       }
 
       throw error;
@@ -1658,8 +1663,14 @@ export class WorkspaceStore {
 
     try {
       const response = await firstValueFrom(this.cardsApi.createCard(request));
+      const mapped = mapCardFromResponse(response, fallbackStatusId);
+      const confidence =
+        payload.confidenceDisplay !== undefined
+          ? payload.confidenceDisplay
+          : normalizeProposalConfidence(mapped.confidence ?? 0);
       const card = {
-        ...mapCardFromResponse(response, fallbackStatusId),
+        ...mapped,
+        confidence,
         originSuggestionId: payload.originSuggestionId,
       } satisfies Card;
 
@@ -2359,6 +2370,19 @@ export class WorkspaceStore {
     this.reconcileFiltersForSettings(updatedSettings);
   }
 
+  private applyUserContext(userId: string | null): void {
+    this.lastAppliedUserId = userId;
+    const settings = this.loadSettings(userId);
+    const preferences = this.loadPreferences(userId, settings);
+
+    this.settingsSignal.set(settings);
+    this.groupingSignal.set(preferences.grouping);
+    this.filtersSignal.set(preferences.filters);
+    this.reconcileCardsForSettings(settings);
+    this.reconcileFiltersForSettings(settings);
+    void this.refreshBoardPreferences(userId, settings);
+  }
+
   private reconcileCardsForSettings(settings: WorkspaceSettings): void {
     const allowedStatusIds = new Set(settings.statuses.map((status) => status.id));
     const allowedLabelIds = new Set(settings.labels.map((label) => label.id));
@@ -2404,10 +2428,15 @@ export class WorkspaceStore {
     userId: string | null,
     settings: WorkspaceSettings,
   ): Promise<void> {
-    const token = ++this.preferencesRequestToken;
     if (!userId) {
       return;
     }
+
+    const token = ++this.preferencesRequestToken;
+    const cachedPreferences: BoardPreferences = {
+      grouping: this.groupingSignal(),
+      filters: cloneFilters(this.filtersSignal()),
+    };
 
     try {
       const response = await firstValueFrom(this.boardLayoutsApi.getBoardLayout());
@@ -2435,6 +2464,14 @@ export class WorkspaceStore {
       }
 
       this.logger.error('WorkspaceStore', error);
+
+      if (this.groupingSignal() !== cachedPreferences.grouping) {
+        this.groupingSignal.set(cachedPreferences.grouping);
+      }
+
+      if (!filtersEqual(this.filtersSignal(), cachedPreferences.filters)) {
+        this.filtersSignal.set(cloneFilters(cachedPreferences.filters));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- apply user-specific context updates when authentication changes and reuse cached preferences when remote loads fail
- refresh board preferences with cached fallbacks and error logging without mutating state
- ensure proposal imports persist original confidence values while normalizing UI display confidence

## Testing
- npm run lint
- CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless --include src/app/core/state/workspace-store.spec.ts *(fails: Chrome binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8eb81818483209d56f6da51df374d