### PR TITLE
Ensure default board statuses exist for every user

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -14,6 +14,7 @@ from ..auth import (
 )
 from ..database import get_db
 from ..services.profile import build_user_profile
+from ..services.status_defaults import ensure_default_statuses
 from ..services.workspace_template_defaults import ensure_default_workspace_template
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -53,6 +54,7 @@ def register(
     user = models.User(**user_values)
     db.add(user)
     db.flush()
+    ensure_default_statuses(db, owner_id=user.id)
     ensure_default_workspace_template(db, owner_id=user.id)
     token_value = create_session_token(db, user)
     db.commit()

--- a/backend/app/routers/statuses.py
+++ b/backend/app/routers/statuses.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from .. import models, schemas
 from ..auth import get_current_user
 from ..database import get_db
+from ..services.status_defaults import ensure_default_statuses
 from ..utils.repository import (
     apply_updates,
     delete_model,
@@ -21,6 +22,7 @@ def list_statuses(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ) -> list[models.Status]:
+    ensure_default_statuses(db, owner_id=current_user.id)
     return (
         db.query(models.Status)
         .filter(models.Status.owner_id == current_user.id)

--- a/backend/app/routers/statuses.py
+++ b/backend/app/routers/statuses.py
@@ -22,7 +22,9 @@ def list_statuses(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ) -> list[models.Status]:
-    ensure_default_statuses(db, owner_id=current_user.id)
+    _, created_or_updated = ensure_default_statuses(db, owner_id=current_user.id)
+    if created_or_updated:
+        db.commit()
     return (
         db.query(models.Status)
         .filter(models.Status.owner_id == current_user.id)

--- a/backend/app/services/status_defaults.py
+++ b/backend/app/services/status_defaults.py
@@ -45,8 +45,12 @@ def _normalize_status_key(name: str | None) -> str | None:
     return _LEGACY_KEY_ALIASES.get(normalized, normalized)
 
 
-def ensure_default_statuses(db: Session, owner_id: str) -> list[models.Status]:
-    """Ensure that the canonical board statuses exist for the owner."""
+def ensure_default_statuses(db: Session, owner_id: str) -> tuple[list[models.Status], bool]:
+    """Ensure that the canonical board statuses exist for the owner.
+
+    Returns a tuple of the statuses belonging to the owner and a flag indicating
+    whether any records were created or updated.
+    """
 
     statuses = (
         db.query(models.Status)
@@ -108,7 +112,7 @@ def ensure_default_statuses(db: Session, owner_id: str) -> list[models.Status]:
     if created_or_updated:
         db.flush()
 
-    return statuses
+    return statuses, created_or_updated
 
 
 __all__ = ["ensure_default_statuses"]

--- a/backend/app/services/status_defaults.py
+++ b/backend/app/services/status_defaults.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from sqlalchemy.orm import Session
+
+from .. import models
+
+
+@dataclass(frozen=True)
+class _DefaultStatusDefinition:
+    key: str
+    name: str
+    category: str
+    order: int
+    color: str
+
+
+_DEFAULT_STATUS_DEFINITIONS: Final[tuple[_DefaultStatusDefinition, ...]] = (
+    _DefaultStatusDefinition(key="todo", name="To Do", category="todo", order=1, color="#64748b"),
+    _DefaultStatusDefinition(key="doing", name="Doing", category="in-progress", order=2, color="#2563eb"),
+    _DefaultStatusDefinition(key="done", name="Done", category="done", order=3, color="#16a34a"),
+)
+
+# Normalize common legacy variants so they map to the canonical defaults.
+_LEGACY_KEY_ALIASES: Final[dict[str, str]] = {
+    "todo": "todo",
+    "backlog": "todo",
+    "inprogress": "doing",
+    "progress": "doing",
+    "doing": "doing",
+    "wip": "doing",
+    "done": "done",
+    "completed": "done",
+    "complete": "done",
+}
+
+
+def _normalize_status_key(name: str | None) -> str | None:
+    if not name:
+        return None
+
+    normalized = "".join(ch for ch in name.casefold() if ch.isalnum())
+    return _LEGACY_KEY_ALIASES.get(normalized, normalized)
+
+
+def ensure_default_statuses(db: Session, owner_id: str) -> list[models.Status]:
+    """Ensure that the canonical board statuses exist for the owner."""
+
+    statuses = (
+        db.query(models.Status)
+        .filter(models.Status.owner_id == owner_id)
+        .order_by(models.Status.order, models.Status.name)
+        .all()
+    )
+    existing_by_key: dict[str, models.Status] = {}
+
+    for status in statuses:
+        key = _normalize_status_key(status.name)
+        if key is None:
+            continue
+
+        # Prefer already normalized names when multiple variants exist.
+        if key not in existing_by_key:
+            existing_by_key[key] = status
+        else:
+            preferred = existing_by_key[key]
+            target_name = next(
+                (definition.name for definition in _DEFAULT_STATUS_DEFINITIONS if definition.key == key),
+                status.name,
+            )
+            if preferred.name != target_name and status.name == target_name:
+                existing_by_key[key] = status
+
+    created_or_updated = False
+
+    for definition in _DEFAULT_STATUS_DEFINITIONS:
+        status = existing_by_key.get(definition.key)
+        if status is None:
+            status = models.Status(
+                owner_id=owner_id,
+                name=definition.name,
+                category=definition.category,
+                order=definition.order,
+                color=definition.color,
+            )
+            db.add(status)
+            statuses.append(status)
+            created_or_updated = True
+            continue
+
+        updates = {}
+        if status.name != definition.name:
+            updates["name"] = definition.name
+        if status.category != definition.category:
+            updates["category"] = definition.category
+        if status.order != definition.order:
+            updates["order"] = definition.order
+        if status.color != definition.color and definition.color:
+            updates["color"] = definition.color
+
+        if updates:
+            for field, value in updates.items():
+                setattr(status, field, value)
+            created_or_updated = True
+
+    if created_or_updated:
+        db.flush()
+
+    return statuses
+
+
+__all__ = ["ensure_default_statuses"]

--- a/frontend/src/app/features/settings/page.html
+++ b/frontend/src/app/features/settings/page.html
@@ -78,7 +78,7 @@
               class="button button--ghost button--pill"
               (click)="statusForm.controls.category.setValue('in-progress')"
             >
-              IN PROGRESS
+              DOING
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Summary
- add a status seeding service that ensures each account has the default To Do, Doing, and Done columns and upgrades legacy names
- invoke the status seeding when registering new users and when listing statuses so existing accounts pick up the defaults
- adjust tests and UI copy to reflect the Doing terminology

## Testing
- pytest backend/tests
- ruff check backend/app/routers/auth.py backend/app/routers/statuses.py backend/app/services/status_defaults.py backend/tests/test_cards.py
- black --check backend/app/routers/auth.py backend/app/routers/statuses.py backend/app/services/status_defaults.py backend/tests/test_cards.py
- npm run format:check *(fails because unrelated files already violate the formatter)*
- npx prettier --check src/app/features/settings/page.html

------
https://chatgpt.com/codex/tasks/task_e_68d8ec968f788320a9f735239b8a53bb