### PR TITLE
Document WorkspaceStore regression failures

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -25,3 +25,15 @@
 - After publishing proposals, refresh the board to ensure duplicates are obvious.
 - Before multi-operator shifts, agree on quick filters (for example, 'recently created') so duplicates are spotted early.
 - Future work: add server-side duplicate detection in `cards.py` during analyzer publishes.
+
+## WorkspaceStore regression breaks analyzer imports and board preferences
+**Impact**: The Angular `WorkspaceStore` currently submits analyzer proposal confidence scores in the 0–1 range and discards cached board filters when workspace metadata is still loading. The first regression causes analyzer imports to persist cards with `ai_confidence` values like `0.82`, which fails the CI expectation of 0–100 percentages. The second regression resets stored filters to empty arrays, so cached groupings, search text, and remote layouts never reach the UI. The failures surface in `workspace-store.spec.ts` as five broken tests covering analyzer imports and board preference loading/persistence.
+
+**Root cause**:
+- `buildCardCreateRequest` forwards `sanitizeConfidence(payload.confidence)`, and `sanitizeConfidence` simply clamps numeric values without scaling fractional inputs. Analyzer proposals deliver confidences between 0 and 1, so the generated card requests violate the spec expectation of percentage integers.【F:frontend/src/app/core/state/workspace-store.ts†L1686-L1713】【F:frontend/src/app/core/state/workspace-store.ts†L315-L325】【F:frontend/src/app/core/state/workspace-store.spec.ts†L134-L205】
+- `sanitizeFilterIds` removes every filter identifier that is not present in the current workspace settings. When the store has not fetched statuses and labels yet (the common case during login), the allowed sets are empty, so both cached preferences and remote board layouts are sanitised down to empty lists. Subsequent persistence attempts see no changes, which prevents remote updates from firing and leaves the board toolbar stuck at defaults.【F:frontend/src/app/core/state/workspace-store.ts†L2800-L2833】【F:frontend/src/app/core/state/workspace-store.spec.ts†L235-L411】
+
+**Fix plan**:
+- Extend the confidence normalisation helpers so that proposal confidences at or below 1.0 are multiplied by 100 before clamping. Reuse the same logic for local persistence and API payloads to keep card state and backend requests consistent.
+- Teach `sanitizeFilterIds` to retain string identifiers when the allowed set is empty or metadata has not been fetched yet. Once statuses and labels arrive, the existing `reconcileFiltersForSettings` path will sanitise out truly invalid IDs while preserving cached user intent.
+- Backstop the changes with focused unit specs covering both fractional confidences and preference hydration so that future regressions are caught at the store level.


### PR DESCRIPTION
## Summary
- Document the analyzer confidence scaling regression in `WorkspaceStore`
- Capture the board preference sanitisation issue and proposed remediation steps

## Testing
- Not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d930e1669c8320b963558f38ba0212