### PR TITLE
Use setup-chrome action in auto-resolve workflow

### DIFF
--- a/.github/workflows/auto-resolve-pr.yml
+++ b/.github/workflows/auto-resolve-pr.yml
@@ -34,21 +34,9 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install Chrome and export CHROME_BIN
-        run: |
-          for candidate in google-chrome google-chrome-stable chromium chromium-browser chrome-headless-shell; do
-            if command -v "$candidate" >/dev/null 2>&1; then
-              echo "CHROME_BIN=$(command -v "$candidate")" >> $GITHUB_ENV
-              exit 0
-            fi
-          done
-
-          # fallback: install Chrome manually
-          tmp_dir=$(mktemp -d)
-          curl -fsSL -o "$tmp_dir/google-chrome.deb" https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          sudo apt-get update
-          sudo apt-get install -y "$tmp_dir/google-chrome.deb"
-          echo "CHROME_BIN=$(command -v google-chrome)" >> $GITHUB_ENV
+      - name: Set up Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
 
       - name: Install MCP servers
         run: |
@@ -89,7 +77,7 @@ jobs:
 
       - name: Run Tests
         env:
-          CHROME_BIN: ${{ env.CHROME_BIN }}
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: |
           set -e
           ran_tests=false


### PR DESCRIPTION
## Summary
- replace the manual Chrome installation logic with browser-actions/setup-chrome@v1
- wire the Run Tests step to use the action-provided chrome binary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa232a26083208a24695e49fd2318