### PR TITLE
Update auto-resolve workflow to load Karma config

### DIFF
--- a/.github/workflows/auto-resolve-pr.yml
+++ b/.github/workflows/auto-resolve-pr.yml
@@ -98,12 +98,12 @@ jobs:
             ran_tests=true
             pushd frontend > /dev/null
             npm ci
-            npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --code-coverage
+            npx ng test --karma-config=karma.conf.cjs --watch=false --browsers=ChromeHeadlessNoSandbox --code-coverage
             popd > /dev/null
           elif [ -f package.json ]; then
             ran_tests=true
             npm ci
-            npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --code-coverage
+            npx ng test --karma-config=karma.conf.cjs --watch=false --browsers=ChromeHeadlessNoSandbox --code-coverage
           fi
 
           if [ -f requirements.txt ]; then


### PR DESCRIPTION
## Summary
- update the auto-resolve CI workflow to pass the frontend Karma configuration when running Angular tests
- ensure the ChromeHeadlessNoSandbox launcher from frontend/karma.conf.cjs is registered during the workflow tests

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68daa232c9f48320bab6dd5febfdb009