### PR TITLE
Adopt Gemini defaults in admin page

### DIFF
--- a/frontend/src/app/features/admin/page.html
+++ b/frontend/src/app/features/admin/page.html
@@ -414,9 +414,9 @@
   @if (activeTab() === 'settings') {
     <section class="page-section">
       <header class="page-section__header">
-        <h2 class="page-section__title">AI API トークン</h2>
+        <h2 class="page-section__title">Gemini API キー</h2>
         <p class="page-section__subtitle">
-          OpenAI などの API キーを安全に保管し、判定処理に利用します。
+          Google AI Studio で発行した Gemini API キーを安全に保管し、判定処理に利用します。
         </p>
       </header>
 
@@ -436,27 +436,26 @@
             @if (!isKnownModel(apiModel)) {
               <option [value]="apiModel">{{ apiModel }} (保存済み)</option>
             }
-            @for (option of chatModelOptions; track option.value) {
+            @for (option of geminiModelOptions; track option.value) {
               <option [value]="option.value">{{ option.label }}</option>
             }
           </select>
         </label>
 
         <label class="form-field form-field--full">
-          <span class="form-field__label">新しい API トークン</span>
+          <span class="form-field__label">新しい Gemini API キー</span>
           <input
             type="text"
             class="form-control"
             name="api-secret"
             autocomplete="off"
             [(ngModel)]="apiSecret"
-            placeholder="sk-..."
+            placeholder="例: AIzaSy..."
             [required]="!apiCredential()"
           />
         </label>
         <p class="form-note">
-          モデルの変更は次回の AI
-          実行から適用されます。高精度モデルはトークン消費が増えるため、チームの運用方針に合わせて選択してください。
+          モデルの変更は次回の AI 実行から適用されます。高精度モデルは消費トークンが増えるため、チームの運用方針に合わせて選択してください。
         </p>
         <button type="submit" class="button button--primary" [disabled]="loading()">保存</button>
       </form>

--- a/frontend/src/app/features/admin/page.ts
+++ b/frontend/src/app/features/admin/page.ts
@@ -41,15 +41,16 @@ export class AdminPage {
   public readonly feedback = signal<string | null>(null);
   public readonly error = signal<string | null>(null);
 
-  private readonly defaultChatModel = 'gpt-4o-mini';
-  public readonly chatModelOptions: ReadonlyArray<{ value: string; label: string }> = [
-    { value: 'gpt-4o-mini', label: 'GPT-4o mini (推奨)' },
-    { value: 'gpt-4o', label: 'GPT-4o' },
-    { value: 'gpt-4.1-mini', label: 'GPT-4.1 mini' },
-    { value: 'gpt-4.1', label: 'GPT-4.1' },
+  private readonly defaultGeminiModel = 'gemini-1.5-flash';
+  public readonly geminiModelOptions: ReadonlyArray<{ value: string; label: string }> = [
+    { value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash (推奨)' },
+    { value: 'gemini-1.5-flash-latest', label: 'Gemini 1.5 Flash Latest' },
+    { value: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro' },
+    { value: 'gemini-1.0-pro', label: 'Gemini 1.0 Pro' },
+    { value: 'gemini-1.0-pro-vision', label: 'Gemini 1.0 Pro Vision' },
   ];
-  private readonly knownChatModelValues = new Set(
-    this.chatModelOptions.map((option) => option.value),
+  private readonly knownGeminiModelValues = new Set(
+    this.geminiModelOptions.map((option) => option.value),
   );
 
   public readonly newCompetency = signal<CompetencyInput>({
@@ -65,7 +66,7 @@ export class AdminPage {
   public evaluationPeriodStart = '';
   public evaluationPeriodEnd = '';
   public apiSecret = '';
-  public apiModel = this.defaultChatModel;
+  public apiModel = this.defaultGeminiModel;
   public defaultCardLimit: number | null = null;
   public defaultEvaluationLimit: number | null = null;
 
@@ -420,7 +421,7 @@ export class AdminPage {
         error: (err: unknown) => {
           if (err instanceof HttpErrorResponse && err.status === 404) {
             this.apiCredential.set(null);
-            this.apiModel = this.defaultChatModel;
+            this.apiModel = this.defaultGeminiModel;
             return;
           }
           this.handleError(err, 'API トークンの取得に失敗しました。');
@@ -429,18 +430,18 @@ export class AdminPage {
   }
 
   public isKnownModel(value: string): boolean {
-    return this.knownChatModelValues.has(value);
+    return this.knownGeminiModelValues.has(value);
   }
 
   private resolveChatModel(model: string | null | undefined): string {
     if (!model) {
-      return this.defaultChatModel;
+      return this.defaultGeminiModel;
     }
     const trimmed = model.trim();
     if (!trimmed) {
-      return this.defaultChatModel;
+      return this.defaultGeminiModel;
     }
-    if (this.knownChatModelValues.has(trimmed)) {
+    if (this.knownGeminiModelValues.has(trimmed)) {
       return trimmed;
     }
     return trimmed;


### PR DESCRIPTION
## Summary
- switch the admin settings model defaults to Gemini offerings and keep saved-value handling in sync
- refresh the admin settings copy to reference Google AI Studio keys and updated placeholders

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daa3d1519083208ae17d25068eba7c