### PR TITLE
Handle legacy secret decryption rotation

### DIFF
--- a/backend/tests/test_admin_settings.py
+++ b/backend/tests/test_admin_settings.py
@@ -65,7 +65,9 @@ def test_admin_credentials_use_default_secret_key(client: TestClient) -> None:
         credential = db.query(models.ApiCredential).filter(models.ApiCredential.provider == "gemini").one()
 
     cipher = get_secret_cipher()
-    assert cipher.decrypt(credential.encrypted_secret) == secret
+    decrypted = cipher.decrypt(credential.encrypted_secret)
+    assert decrypted.plaintext == secret
+    assert decrypted.reencrypted_payload is None
 
     fetch = client.get("/admin/api-credentials/gemini", headers=headers)
     assert fetch.status_code == 200, fetch.text


### PR DESCRIPTION
## Summary
- fall back to legacy/plaintext and default key decryption when XOR decoding fails and surface re-encryption details
- rotate persisted Gemini API credentials when an outdated ciphertext is recovered
- cover the migration path with a regression test for legacy payloads

## Testing
- pytest backend/tests
- ruff check backend/app/utils/crypto.py backend/app/services/gemini.py backend/tests/utils/test_secrets.py backend/tests/test_admin_settings.py
- black --check backend/app/utils/crypto.py backend/app/services/gemini.py backend/tests/utils/test_secrets.py backend/tests/test_admin_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68dac8b0fd9c832094782ff8bd20ecfb