### PR TITLE
Refactor admin forms to signal forms

### DIFF
--- a/frontend/src/app/features/admin/page.html
+++ b/frontend/src/app/features/admin/page.html
@@ -112,7 +112,7 @@
         </p>
       </header>
 
-      <form class="page-form" (submit)="createCompetency($event)">
+      <form class="page-form" [formGroup]="competencyForm" (ngSubmit)="createCompetency()">
         <div class="form-grid form-grid--two">
           <label class="form-field">
             <span class="form-field__label">名称</span>
@@ -120,19 +120,13 @@
               type="text"
               class="form-control"
               name="competency-name"
-              [ngModel]="newCompetency().name"
-              (ngModelChange)="updateNewCompetencyField('name', $event)"
+              formControlName="name"
               required
             />
           </label>
           <label class="form-field">
             <span class="form-field__label">レベル</span>
-            <select
-              class="form-control"
-              name="competency-level"
-              [ngModel]="newCompetency().level"
-              (ngModelChange)="updateNewCompetencyField('level', $event)"
-            >
+            <select class="form-control" name="competency-level" formControlName="level">
               <option value="junior">初級 (3段階)</option>
               <option value="intermediate">中級 (5段階)</option>
             </select>
@@ -143,23 +137,18 @@
               class="form-control form-control--textarea"
               name="competency-description"
               rows="3"
-              [ngModel]="newCompetency().description"
-              (ngModelChange)="updateNewCompetencyField('description', $event)"
+              formControlName="description"
               placeholder="評価の観点や期待する行動を記載できます"
             ></textarea>
           </label>
         </div>
 
         <label class="form-toggle">
-          <input
-            type="checkbox"
-            [checked]="newCompetency().is_active ?? true"
-            (change)="updateNewCompetencyField('is_active', $any($event.target).checked)"
-          />
+          <input type="checkbox" formControlName="is_active" />
           <span>作成後すぐに判定対象として有効にする</span>
         </label>
 
-        <div class="admin-criteria">
+        <div class="admin-criteria" formArrayName="criteria">
           <div class="admin-criteria__header">
             <h3>評価項目</h3>
             <button
@@ -171,16 +160,15 @@
             </button>
           </div>
 
-          @for (criterion of newCompetency().criteria; track $index) {
-            <div class="admin-criteria__row">
+          @for (criterion of competencyForm.controls.criteria.controls; track $index) {
+            <div class="admin-criteria__row" [formGroupName]="$index">
               <label class="form-field">
                 <span class="form-field__label">項目名</span>
                 <input
                   type="text"
                   class="form-control"
                   [attr.name]="'criterion-' + $index + '-title'"
-                  [ngModel]="criterion.title"
-                  (ngModelChange)="updateCriterionField($index, 'title', $event)"
+                  formControlName="title"
                   placeholder="例: 問題発見力"
                 />
               </label>
@@ -190,8 +178,7 @@
                   rows="2"
                   class="form-control form-control--textarea"
                   [attr.name]="'criterion-' + $index + '-description'"
-                  [ngModel]="criterion.description"
-                  (ngModelChange)="updateCriterionField($index, 'description', $event)"
+                  formControlName="description"
                   placeholder="評価基準や期待値を記載します"
                 ></textarea>
               </label>
@@ -199,7 +186,7 @@
                 type="button"
                 class="button button--ghost button--pill"
                 (click)="removeCriterion($index)"
-                [disabled]="newCompetency().criteria.length === 1"
+                [disabled]="competencyForm.controls.criteria.length === 1"
                 aria-label="評価項目を削除"
               >
                 削除
@@ -224,16 +211,11 @@
         </p>
       </header>
 
-      <form class="page-form" (submit)="triggerEvaluation($event)">
+      <form class="page-form" [formGroup]="evaluationForm" (ngSubmit)="triggerEvaluation()">
         <div class="form-grid form-grid--two">
           <label class="form-field">
             <span class="form-field__label">対象ユーザ</span>
-            <select
-              class="form-control"
-              [(ngModel)]="evaluationUserId"
-              name="evaluation-user"
-              required
-            >
+            <select class="form-control" formControlName="userId" name="evaluation-user" required>
               <option value="">選択してください</option>
               @for (user of users(); track user.id) {
                 <option [value]="user.id">{{ user.email }}</option>
@@ -244,7 +226,7 @@
             <span class="form-field__label">コンピテンシー</span>
             <select
               class="form-control"
-              [(ngModel)]="evaluationCompetencyId"
+              formControlName="competencyId"
               name="evaluation-competency"
               required
             >
@@ -259,7 +241,7 @@
             <input
               type="date"
               class="form-control"
-              [(ngModel)]="evaluationPeriodStart"
+              formControlName="periodStart"
               name="evaluation-period-start"
             />
           </label>
@@ -268,7 +250,7 @@
             <input
               type="date"
               class="form-control"
-              [(ngModel)]="evaluationPeriodEnd"
+              formControlName="periodEnd"
               name="evaluation-period-end"
             />
           </label>
@@ -368,28 +350,30 @@
                     />
                   </td>
                   <td>
-                    <input
-                      type="number"
-                      min="0"
-                      class="form-control"
-                      [attr.name]="'card-limit-' + user.id"
-                      [ngModel]="user.card_daily_limit ?? ''"
-                      (ngModelChange)="onCardLimitChange(user, $event)"
-                      (blur)="saveUserQuota(user)"
-                      placeholder="デフォルト"
-                    />
+                    @if (quotaForm(user.id); as quota) {
+                      <input
+                        type="number"
+                        min="0"
+                        class="form-control"
+                        [attr.name]="'card-limit-' + user.id"
+                        [formControl]="quota.controls.cardDailyLimit"
+                        (blur)="saveUserQuota(user)"
+                        placeholder="デフォルト"
+                      />
+                    }
                   </td>
                   <td>
-                    <input
-                      type="number"
-                      min="0"
-                      class="form-control"
-                      [attr.name]="'evaluation-limit-' + user.id"
-                      [ngModel]="user.evaluation_daily_limit ?? ''"
-                      (ngModelChange)="onEvaluationLimitChange(user, $event)"
-                      (blur)="saveUserQuota(user)"
-                      placeholder="デフォルト"
-                    />
+                    @if (quotaForm(user.id); as quota) {
+                      <input
+                        type="number"
+                        min="0"
+                        class="form-control"
+                        [attr.name]="'evaluation-limit-' + user.id"
+                        [formControl]="quota.controls.evaluationDailyLimit"
+                        (blur)="saveUserQuota(user)"
+                        placeholder="デフォルト"
+                      />
+                    }
                   </td>
                   <td class="page-table__cell--center">
                     <button
@@ -430,12 +414,14 @@
         <p class="page-empty">登録済みの API トークンはありません。</p>
       }
 
-      <form class="page-form" (submit)="updateApiCredential($event)">
+      <form class="page-form" [formGroup]="apiForm" (submit)="updateApiCredential($event)">
         <label class="form-field">
           <span class="form-field__label">利用モデル</span>
-          <select class="form-control" name="api-model" [(ngModel)]="apiModel">
-            @if (!isKnownModel(apiModel)) {
-              <option [value]="apiModel">{{ apiModel }} (保存済み)</option>
+          <select class="form-control" name="api-model" formControlName="model">
+            @if (!isKnownModel(apiForm.controls.model.value)) {
+              <option [value]="apiForm.controls.model.value">
+                {{ apiForm.controls.model.value }} (保存済み)
+              </option>
             }
             @for (option of geminiModelOptions; track option.value) {
               <option [value]="option.value">{{ option.label }}</option>
@@ -450,13 +436,14 @@
             class="form-control"
             name="api-secret"
             autocomplete="off"
-            [(ngModel)]="apiSecret"
+            formControlName="secret"
             placeholder="例: AIzaSy..."
             [required]="!apiCredential()"
           />
         </label>
         <p class="form-note">
-          モデルの変更は次回の AI 実行から適用されます。高精度モデルは消費トークンが増えるため、チームの運用方針に合わせて選択してください。
+          モデルの変更は次回の AI
+          実行から適用されます。高精度モデルは消費トークンが増えるため、チームの運用方針に合わせて選択してください。
         </p>
         <button type="submit" class="button button--primary" [disabled]="loading()">保存</button>
       </form>
@@ -470,7 +457,11 @@
         </p>
       </header>
 
-      <form class="page-form" (submit)="updateQuotaDefaults($event)">
+      <form
+        class="page-form"
+        [formGroup]="quotaDefaultsForm"
+        (submit)="updateQuotaDefaults($event)"
+      >
         <div class="form-grid form-grid--two">
           <label class="form-field">
             <span class="form-field__label">カード起票数</span>
@@ -479,7 +470,7 @@
               min="0"
               class="form-control"
               name="default-card-limit"
-              [(ngModel)]="defaultCardLimit"
+              formControlName="cardDailyLimit"
               required
             />
           </label>
@@ -490,7 +481,7 @@
               min="0"
               class="form-control"
               name="default-evaluation-limit"
-              [(ngModel)]="defaultEvaluationLimit"
+              formControlName="evaluationDailyLimit"
               required
             />
           </label>

--- a/frontend/src/app/shared/utils/signal-forms.ts
+++ b/frontend/src/app/shared/utils/signal-forms.ts
@@ -1,0 +1,21 @@
+import { AbstractControl } from '@angular/forms';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { Signal } from '@angular/core';
+import { Observable } from 'rxjs';
+
+export interface SignalFormState<TValue> {
+  readonly value: Signal<TValue>;
+  readonly status: Signal<AbstractControl['status']>;
+}
+
+export function signalForms<TValue>(control: AbstractControl<TValue>): SignalFormState<TValue> {
+  const valueChanges = control.valueChanges as unknown as Observable<TValue>;
+  const value = toSignal(valueChanges, {
+    initialValue: control.value as TValue,
+  });
+  const status = toSignal(control.statusChanges, {
+    initialValue: control.status,
+  });
+
+  return { value, status };
+}


### PR DESCRIPTION
## Summary
- replace the admin page component state with typed reactive forms and supporting signal wiring
- introduce a shared `signalForms` helper to expose control values and statuses as Angular signals
- update the admin page template to use `formGroup`, `formArrayName`, and per-user quota controls instead of `ngModel`

## Testing
- npm run format:check *(fails: existing Prettier warnings in untouched files)*
- npm run lint
- npm test -- --watch=false --code-coverage=false --progress=false *(fails: ChromeHeadless missing libatk-1.0.so.0 on container)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68dac8c64b60832094957bb8fb0decf6