### PR TITLE
Remove deprecated allowSignalWrites options from effects

### DIFF
--- a/frontend/src/app/core/state/workspace-store.ts
+++ b/frontend/src/app/core/state/workspace-store.ts
@@ -766,9 +766,7 @@ export class WorkspaceStore {
       }
 
       this.applyUserContext(userId);
-    },
-    { allowSignalWrites: true },
-  );
+    });
 
   public constructor() {
     const initialUser = this.auth.user();
@@ -786,9 +784,7 @@ export class WorkspaceStore {
       }
 
       this.fetchCards();
-    },
-    { allowSignalWrites: true },
-  );
+    });
 
   private readonly loadWorkspaceConfigEffect = effect(
     () => {
@@ -799,9 +795,7 @@ export class WorkspaceStore {
 
       this.lastConfigUserId = userId;
       void this.refreshWorkspaceConfig(true);
-    },
-    { allowSignalWrites: true },
-  );
+    });
 
   private readonly syncDefaultAssigneeWithNicknameEffect = effect(
     () => {
@@ -911,9 +905,7 @@ export class WorkspaceStore {
       }
 
       this.lastSyncedAssigneeName = preferredName;
-    },
-    { allowSignalWrites: true },
-  );
+    });
 
   private resolveStorageUserId(userId: string | null): string | null {
     if (!this.storage) {

--- a/frontend/src/app/features/analyze/page.ts
+++ b/frontend/src/app/features/analyze/page.ts
@@ -173,9 +173,7 @@ export class AnalyzePage {
       ) {
         this.triggerResultsHighlight();
       }
-    },
-    { allowSignalWrites: true },
-  );
+    });
 
   private readonly dispatchAnalyze = this.analyzeForm.submit((value) => {
     const payload = this.createRequestPayload(value);

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -241,9 +241,7 @@ export class BoardPage {
       }
 
       this.searchForm.controls.search.setValue(search);
-    },
-    { allowSignalWrites: true },
-  );
+    });
 
   private readonly commentDraftsState = signal<Record<string, string>>({ card: '' });
   private readonly editingCommentState = signal<{ id: string; contextId: string } | null>(null);
@@ -498,9 +496,7 @@ export class BoardPage {
       }
 
       this.lastSelectedCardId = active.id;
-    },
-    { allowSignalWrites: true },
-  );
+    });
 
   public readonly saveCardDetails = (event: Event): void => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- remove the deprecated `allowSignalWrites` option from analyze and board page effects
- drop `allowSignalWrites` usage from workspace store effects to eliminate Angular warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dac92af6988320a7c436d503022ad9