### PR TITLE
Trigger workspace config refresh when applying user context

### DIFF
--- a/frontend/src/app/core/state/workspace-store.ts
+++ b/frontend/src/app/core/state/workspace-store.ts
@@ -2439,6 +2439,11 @@ export class WorkspaceStore {
     this.reconcileCardsForSettings(settings);
     this.reconcileFiltersForSettings(settings, false);
     void this.refreshBoardPreferences(userId, settings);
+
+    if (userId !== this.lastConfigUserId) {
+      this.lastConfigUserId = userId;
+      void this.refreshWorkspaceConfig(true);
+    }
   }
 
   private bindAuthSetUserPatch(): void {


### PR DESCRIPTION
## Summary
- ensure the workspace store refreshes configuration data whenever a new user context is applied so status metadata stays current

## Testing
- npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*
- npm run format:check -- src/app/core/state/workspace-store.ts *(fails: Prettier reports existing formatting issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dac9183eac8320805e4840dab749a1