### PR TITLE
Ensure status report card links default to primary relationship

### DIFF
--- a/backend/app/services/status_reports.py
+++ b/backend/app/services/status_reports.py
@@ -181,9 +181,7 @@ class StatusReportService:
         error_message: str | None = None
 
         try:
-            response = self.analyzer.analyze(
-                schemas.AnalysisRequest(text=analysis_text, max_cards=max_cards)
-            )
+            response = self.analyzer.analyze(schemas.AnalysisRequest(text=analysis_text, max_cards=max_cards))
         except GeminiError as exc:
             error_message = str(exc)
         else:
@@ -296,9 +294,7 @@ class StatusReportService:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-    def _normalize_sections(
-        self, sections: Sequence[schemas.StatusReportSection]
-    ) -> list[schemas.StatusReportSection]:
+    def _normalize_sections(self, sections: Sequence[schemas.StatusReportSection]) -> list[schemas.StatusReportSection]:
         normalized: list[schemas.StatusReportSection] = []
         for section in sections:
             body = section.body.strip()
@@ -387,6 +383,8 @@ class StatusReportService:
 
     def _serialize_card_link(self, link: models.StatusReportCardLink) -> schemas.StatusReportCardSummary:
         card = link.card
+        relationship = getattr(link, "link_role", None) or "primary"
+
         if not card:
             return schemas.StatusReportCardSummary(
                 id=link.card_id,
@@ -398,7 +396,7 @@ class StatusReportService:
                 due_date=None,
                 assignees=[],
                 subtasks=[],
-                relationship=getattr(link, "link_role", "primary"),
+                relationship=relationship,
                 confidence=link.confidence,
             )
 
@@ -413,7 +411,7 @@ class StatusReportService:
             due_date=card.due_date,
             assignees=list(card.assignees or []),
             subtasks=[schemas.SubtaskRead.model_validate(sub) for sub in card.subtasks],
-            relationship=getattr(link, "link_role", "primary"),
+            relationship=relationship,
             confidence=link.confidence,
         )
 
@@ -429,7 +427,7 @@ class StatusReportService:
                 continue
             try:
                 results.append(schemas.AnalysisCard.model_validate(item))
-            except Exception:  # pragma: no cover - defensive parsing
+            except Exception:  # pragma: no cover - defensive parsing  # noqa: S112
                 continue
         return results
 
@@ -445,4 +443,3 @@ class StatusReportService:
         if value.tzinfo is None:
             return value.replace(tzinfo=timezone.utc)
         return value
-


### PR DESCRIPTION
## Summary
- ensure status report card link serialization falls back to the primary relationship when the stored link role is missing or blank
- extend status report tests to cover deleted card links and existing cards without an explicit link role, exercising the relationship default logic

## Testing
- pytest tests
- pytest tests/test_status_reports.py
- black app/services/status_reports.py tests/test_status_reports.py
- ruff check app/services/status_reports.py tests/test_status_reports.py

------
https://chatgpt.com/codex/tasks/task_e_68db0a82c3f0832093411dbe25dfac5a