### PR TITLE
Adjust Gemini schemas to omit nullable type lists

### DIFF
--- a/backend/app/services/appeal_prompts.py
+++ b/backend/app/services/appeal_prompts.py
@@ -102,7 +102,7 @@ class AppealPromptBuilder:
                             "additionalProperties": False,
                             "properties": {
                                 "content": {"type": "string", "minLength": 1},
-                                "tokens_used": {"type": ["integer", "null"]},
+                                "tokens_used": {"type": "integer"},
                             },
                             "required": ["content"],
                         }
@@ -111,7 +111,7 @@ class AppealPromptBuilder:
                 "token_usage": {
                     "type": "object",
                     "additionalProperties": {
-                        "type": ["integer", "number", "null"],
+                        "type": "number",
                     },
                 },
             },

--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -67,7 +67,7 @@ class GeminiClient:
                         },
                         "priority": {"type": "string", "default": "medium"},
                         "due_in_days": {
-                            "type": ["integer", "null"],
+                            "type": "integer",
                         },
                         "subtasks": {
                             "type": "array",
@@ -82,7 +82,7 @@ class GeminiClient:
                                         "minLength": 1,
                                     },
                                     "description": {
-                                        "type": ["string", "null"],
+                                        "type": "string",
                                     },
                                     "status": {
                                         "type": "string",
@@ -480,23 +480,29 @@ class GeminiClient:
 
     def _string_list(self, value: Any) -> List[str]:
         if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-            items = [self._clean_string(item) for item in value]
-            return [item for item in items if item]
+            results: List[str] = []
+            for item in value:
+                text = self._clean_string(item)
+                if text:
+                    results.append(text)
+            return results
         return []
 
     def _to_optional_int(self, value: Any) -> Optional[int]:
         if value is None:
+            return None
+        if isinstance(value, str) and not value.strip():
             return None
         try:
             return int(value)
         except (TypeError, ValueError):
             return None
 
-    def _clean_string(self, value: Any) -> str:
+    def _clean_string(self, value: Any) -> Optional[str]:
         if value is None:
-            return ""
+            return None
         text = str(value).strip()
-        return text
+        return text or None
 
 
 def _load_gemini_configuration(db: Session, provider: str = "gemini") -> tuple[str, str]:


### PR DESCRIPTION
## Summary
- update the Gemini analysis response schema to drop nullable type lists and rely on omitted fields
- adjust parsing helpers to treat empty or missing values as None for optional card attributes
- align appeal response schema numeric fields with single-type definitions compatible with the Gemini SDK

## Testing
- ruff check backend/app/services/gemini.py backend/app/services/appeal_prompts.py
- black --check backend/app/services/gemini.py backend/app/services/appeal_prompts.py
- pytest backend/tests/test_gemini_service.py backend/tests/test_analysis.py backend/tests/test_appeals.py

------
https://chatgpt.com/codex/tasks/task_e_68db37817c748320896ecde6b9f45686