### PR TITLE
Fix Gemini schema minItems incompatibility

### DIFF
--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -120,7 +120,7 @@ class GeminiClient:
         " Respond strictly using the provided JSON schema."
     )
 
-    _UNSUPPORTED_SCHEMA_KEYS: ClassVar[set[str]] = {"additionalProperties"}
+    _UNSUPPORTED_SCHEMA_KEYS: ClassVar[set[str]] = {"additionalProperties", "minItems"}
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- extend the Gemini schema sanitiser to strip the unsupported `minItems` keyword
- prevent response schema generation from including fields rejected by the Google generative AI client

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68db47a25a5883208031b85a536ba7ef