### PR TITLE
Float shell error toast above header controls

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -675,25 +675,31 @@ app-shell .shell-user__email {
 }
 
 app-shell .shell-toast {
-  position: absolute;
-  top: 0.75rem;
-  right: clamp(1rem, 3vw, 2rem);
+  position: fixed;
+  top: clamp(76px, 10vh, 120px);
+  right: clamp(12px, 5vw, 48px);
   display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.6rem 1.1rem;
-  border-radius: 0.85rem;
-  border: 1px solid color-mix(in srgb, var(--success) 42%, transparent);
-  background: color-mix(in srgb, var(--success) 20%, var(--surface-layer-1));
-  color: color-mix(in srgb, var(--success-strong) 92%, var(--text-primary));
+  gap: 0.75rem;
+  padding: 0.85rem 1.2rem;
+  border-radius: 9999px;
+  border: 1px solid color-mix(in srgb, var(--accent) 46%, transparent);
+  background: color-mix(in srgb, var(--surface-overlay) 96%, transparent);
+  box-shadow: 0 18px 36px color-mix(in srgb, var(--accent) 22%, transparent);
+  color: var(--text-secondary);
   font-size: 0.82rem;
   font-weight: 600;
+  backdrop-filter: blur(16px);
+  z-index: 70;
+  max-inline-size: min(92vw, 420px);
   pointer-events: none;
+  animation: shell-toast-in 220ms ease forwards;
 }
 
 app-shell .shell-toast--error {
   border-color: color-mix(in srgb, var(--danger) 46%, transparent);
-  background: color-mix(in srgb, var(--danger) 16%, var(--surface-layer-1));
+  background: color-mix(in srgb, var(--surface-overlay) 94%, transparent);
+  box-shadow: 0 20px 40px color-mix(in srgb, var(--danger) 26%, transparent);
   color: color-mix(in srgb, var(--danger-strong) 88%, var(--text-primary));
   pointer-events: auto;
 }
@@ -719,6 +725,18 @@ app-shell .shell-toast__dismiss {
 
 app-shell .shell-toast__dismiss:hover {
   background: color-mix(in srgb, currentColor 12%, transparent);
+}
+
+@keyframes shell-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (min-width: 40rem) {


### PR DESCRIPTION
## Summary
- restyle the shell-level toast to use a fixed, floating position so it no longer hides beneath header buttons
- refresh the error styling with overlay colors, shadow, and animation to match the floating task creation toast
- add a dedicated animation keyframe to support the new toast presentation

## Testing
- Not run (UI-only styling change)


------
https://chatgpt.com/codex/tasks/task_e_68db47528a0c8320af2ca118be80536e