### PR TITLE
Prevent shell toasts from overlapping

### DIFF
--- a/frontend/src/app/core/layout/shell/shell.html
+++ b/frontend/src/app/core/layout/shell/shell.html
@@ -1,55 +1,61 @@
 <div class="flex min-h-screen flex-col bg-surface">
   <header class="shell-header">
-    @if (globalErrorMessage(); as errorMessage) {
-      <div class="shell-toast shell-toast--error" role="alert" aria-live="assertive">
-        <svg
-          aria-hidden="true"
-          viewBox="0 0 24 24"
-          class="h-4 w-4"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.8"
-        >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01" />
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-          />
-        </svg>
-        <span class="shell-toast__message">{{ errorMessage }}</span>
-        <button
-          type="button"
-          class="shell-toast__dismiss focus-ring"
-          (click)="dismissGlobalError()"
-          aria-label="エラー通知を閉じる"
-        >
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 24 24"
-            class="h-4 w-4"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.8"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" d="m16 8-8 8m0-8 8 8" />
-          </svg>
-        </button>
-      </div>
-    }
-    @if (profileToastMessage(); as toast) {
-      <div class="shell-toast" role="status" aria-live="polite">
-        <svg
-          aria-hidden="true"
-          viewBox="0 0 24 24"
-          class="h-4 w-4"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.8"
-        >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M5 12.5 10 17l9-10" />
-        </svg>
-        <span>{{ toast }}</span>
+    @let errorMessage = globalErrorMessage();
+    @let profileToast = profileToastMessage();
+    @if (errorMessage || profileToast) {
+      <div class="shell-toast-stack">
+        @if (errorMessage) {
+          <div class="shell-toast shell-toast--error" role="alert" aria-live="assertive">
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+              class="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01" />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+              />
+            </svg>
+            <span class="shell-toast__message">{{ errorMessage }}</span>
+            <button
+              type="button"
+              class="shell-toast__dismiss focus-ring"
+              (click)="dismissGlobalError()"
+              aria-label="エラー通知を閉じる"
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                class="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="m16 8-8 8m0-8 8 8" />
+              </svg>
+            </button>
+          </div>
+        }
+        @if (profileToast) {
+          <div class="shell-toast" role="status" aria-live="polite">
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+              class="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 12.5 10 17l9-10" />
+            </svg>
+            <span>{{ profileToast }}</span>
+          </div>
+        }
       </div>
     }
     <div class="shell-header__content shell-container">

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -674,10 +674,18 @@ app-shell .shell-user__email {
   overflow-wrap: anywhere;
 }
 
-app-shell .shell-toast {
+app-shell .shell-toast-stack {
   position: fixed;
   top: clamp(76px, 10vh, 120px);
   right: clamp(12px, 5vw, 48px);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+  z-index: 70;
+}
+
+app-shell .shell-toast {
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
@@ -690,7 +698,6 @@ app-shell .shell-toast {
   font-size: 0.82rem;
   font-weight: 600;
   backdrop-filter: blur(16px);
-  z-index: 70;
   max-inline-size: min(92vw, 420px);
   pointer-events: none;
   animation: shell-toast-in 220ms ease forwards;


### PR DESCRIPTION
## Summary
- wrap the global and profile toast templates in a shared stack container so multiple notifications render together
- adjust the shell toast styles to use a fixed stack with vertical spacing instead of individually fixed positions

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68db4a7e4a888320ab1c612eeff59832