### PR TITLE
Remove unsupported maxItems from Gemini schemas

### DIFF
--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -120,7 +120,7 @@ class GeminiClient:
         " Respond strictly using the provided JSON schema."
     )
 
-    _UNSUPPORTED_SCHEMA_KEYS: ClassVar[set[str]] = {"additionalProperties", "minItems"}
+    _UNSUPPORTED_SCHEMA_KEYS: ClassVar[set[str]] = {"additionalProperties", "minItems", "maxItems"}
 
     def __init__(
         self,
@@ -278,9 +278,7 @@ class GeminiClient:
         def _sanitize(value: Any) -> Any:
             if isinstance(value, dict):
                 return {
-                    key: _sanitize(inner)
-                    for key, inner in value.items()
-                    if key not in cls._UNSUPPORTED_SCHEMA_KEYS
+                    key: _sanitize(inner) for key, inner in value.items() if key not in cls._UNSUPPORTED_SCHEMA_KEYS
                 }
             if isinstance(value, list):
                 return [_sanitize(item) for item in value]


### PR DESCRIPTION
## Summary
- add `maxItems` to the list of unsupported Gemini schema keys so sanitation removes it before API calls
- extend Gemini service unit tests to assert `maxItems` is stripped from response format, generation config, and nested schemas

## Testing
- pytest backend/tests/test_gemini_service.py
- ruff check backend/app/services/gemini.py backend/tests/test_gemini_service.py
- black --check backend/app/services/gemini.py backend/tests/test_gemini_service.py

------
https://chatgpt.com/codex/tasks/task_e_68db4eee5cc083208a0336deef4e140b