### PR TITLE
Sanitize Gemini schemas before generation

### DIFF
--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -120,7 +120,56 @@ class GeminiClient:
         " Respond strictly using the provided JSON schema."
     )
 
-    _UNSUPPORTED_SCHEMA_KEYS: ClassVar[set[str]] = {"additionalProperties", "minItems", "maxItems"}
+    _SCHEMA_KEY_ALIASES: ClassVar[dict[str, str]] = {
+        "maxItems": "max_items",
+        "minItems": "min_items",
+    }
+
+    _UNSUPPORTED_SCHEMA_KEYS: ClassVar[set[str]] = {
+        "additionalProperties",
+        "default",
+        "description",
+        "examples",
+        "patternProperties",
+        "propertyNames",
+        "minLength",
+        "maxLength",
+        "pattern",
+        "format",
+        "contentEncoding",
+        "contentMediaType",
+        "title",
+        "$defs",
+        "$id",
+        "$schema",
+        "$ref",
+        "definitions",
+        "deprecated",
+        "readOnly",
+        "writeOnly",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+        "contains",
+        "const",
+        "enum",
+        "anyOf",
+        "oneOf",
+        "allOf",
+        "not",
+        "if",
+        "then",
+        "else",
+        "dependentRequired",
+        "dependentSchemas",
+        "minContains",
+        "maxContains",
+        "maxProperties",
+        "minProperties",
+        "exclusiveMaximum",
+        "exclusiveMinimum",
+        "multipleOf",
+        "uniqueItems",
+    }
 
     def __init__(
         self,
@@ -277,9 +326,13 @@ class GeminiClient:
 
         def _sanitize(value: Any) -> Any:
             if isinstance(value, dict):
-                return {
-                    key: _sanitize(inner) for key, inner in value.items() if key not in cls._UNSUPPORTED_SCHEMA_KEYS
-                }
+                sanitized: dict[str, Any] = {}
+                for key, inner in value.items():
+                    mapped_key = cls._SCHEMA_KEY_ALIASES.get(key, key)
+                    if mapped_key in cls._UNSUPPORTED_SCHEMA_KEYS:
+                        continue
+                    sanitized[mapped_key] = _sanitize(inner)
+                return sanitized
             if isinstance(value, list):
                 return [_sanitize(item) for item in value]
             if isinstance(value, tuple):


### PR DESCRIPTION
## Summary
- deep-copy and sanitize Gemini response schemas, including converting camelCase bounds and dropping unsupported JSON Schema keywords
- ensure analysis and appeal requests send sanitized payloads and expand tests to cover the new behavior

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68db536952b883208617f512afa875ec