### PR TITLE
Normalize Gemini model defaults to latest variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Create a `.env` file in the repository root or export variables before launching
 | --- | --- | --- |
 | `DATABASE_URL` | SQLAlchemy connection string. Use PostgreSQL for production workloads. | `sqlite:///./todo.db` |
 | `DEBUG` | Enables verbose logging and exception responses. | `False` |
-| `GEMINI_MODEL` | Gemini model identifier for AI-assisted flows. | `gemini-1.5-flash` |
+| `GEMINI_MODEL` | Gemini model identifier for AI-assisted flows. | `gemini-1.5-flash-latest` |
 | `SECRET_ENCRYPTION_KEY` | AES key for encrypting stored secrets. | `verbalize-yourself` |
 | `RECOMMENDATION_WEIGHT_LABEL` | Weight applied to label correlation when computing `ai_confidence`. | `0.6` |
 | `RECOMMENDATION_WEIGHT_PROFILE` | Weight applied to profile alignment when computing `ai_confidence`. | `0.4` |

--- a/backend/README.md
+++ b/backend/README.md
@@ -56,7 +56,7 @@ Configuration is managed through environment variables (see `app/config.py`). Ke
 
 - `DATABASE_URL`: SQLAlchemy connection string. Defaults to `sqlite:///./todo.db`.
 - `DEBUG`: Enable FastAPI debug mode (default: `False`).
-- `GEMINI_MODEL`: Logical name for the Gemini model (default: `gemini-1.5-flash`).
+- `GEMINI_MODEL`: Logical name for the Gemini model (default: `gemini-1.5-flash-latest`).
 - `ALLOWED_ORIGINS`: Comma-separated list of origins allowed to call the API with browser credentials (default: `http://localhost:4200`).
 - `SECRET_ENCRYPTION_KEY`: Optional key used to encrypt stored API credentials (defaults to an internal fallback; configure in production).
 - `RECOMMENDATION_WEIGHT_LABEL`: Weight applied to label correlation when combining recommendation scores (default: `0.6`).

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("DEBUG", "debug"),
     )
     gemini_model: str = Field(
-        default="gemini-1.5-flash",
+        default="gemini-1.5-flash-latest",
         validation_alias=AliasChoices(
             "GEMINI_MODEL",
             "gemini_model",

--- a/backend/tests/test_admin_settings.py
+++ b/backend/tests/test_admin_settings.py
@@ -41,13 +41,13 @@ def test_admin_can_update_gemini_model_without_rotating_secret(client: TestClien
     )
     assert update.status_code == 200, update.text
     updated_payload = update.json()
-    assert updated_payload["model"] == "gemini-1.5-flash"
+    assert updated_payload["model"] == "gemini-1.5-flash-latest"
     assert updated_payload["secret_hint"] == created_payload["secret_hint"]
 
     fetch = client.get("/admin/api-credentials/gemini", headers=headers)
     assert fetch.status_code == 200, fetch.text
     fetched_payload = fetch.json()
-    assert fetched_payload["model"] == "gemini-1.5-flash"
+    assert fetched_payload["model"] == "gemini-1.5-flash-latest"
 
 
 def test_admin_credentials_use_default_secret_key(client: TestClient) -> None:
@@ -57,7 +57,7 @@ def test_admin_credentials_use_default_secret_key(client: TestClient) -> None:
     create = client.put(
         "/admin/api-credentials/gemini",
         headers=headers,
-        json={"secret": secret, "model": "gemini-1.5-flash"},
+        json={"secret": secret, "model": "gemini-1.5-flash-latest"},
     )
     assert create.status_code == 200, create.text
 

--- a/backend/tests/test_gemini_service.py
+++ b/backend/tests/test_gemini_service.py
@@ -383,3 +383,8 @@ def test_load_gemini_configuration_respects_disabled_credential(client: TestClie
     finally:
         settings.gemini_api_key = original_key
         db_gen.close()
+
+
+def test_normalize_model_name_maps_legacy_flash() -> None:
+    assert GeminiClient.normalize_model_name("gemini-1.5-flash") == "gemini-1.5-flash-latest"
+    assert GeminiClient.normalize_model_name("models/gemini-1.5-flash") == "gemini-1.5-flash-latest"

--- a/frontend/src/app/features/admin/page.spec.ts
+++ b/frontend/src/app/features/admin/page.spec.ts
@@ -28,7 +28,7 @@ class MockAdminApiService {
     is_active: true,
     created_at: '2024-01-01T00:00:00.000Z',
     updated_at: '2024-01-01T00:00:00.000Z',
-    model: 'gemini-1.5-flash',
+    model: 'gemini-1.5-flash-latest',
     secret_hint: null,
   };
 

--- a/frontend/src/app/features/admin/page.ts
+++ b/frontend/src/app/features/admin/page.ts
@@ -67,7 +67,7 @@ export class AdminPage {
   public readonly feedback = signal<string | null>(null);
   public readonly error = signal<string | null>(null);
 
-  private readonly defaultGeminiModel = 'gemini-1.5-flash';
+  private readonly defaultGeminiModel = 'gemini-1.5-flash-latest';
   private readonly competencyCriteria = new FormArray<CriterionFormGroup>([
     this.createCriterionGroup(),
   ]);
@@ -130,8 +130,8 @@ export class AdminPage {
 
   private readonly userQuotaForms = signal(new Map<string, UserQuotaForm>());
   public readonly geminiModelOptions: ReadonlyArray<{ value: string; label: string }> = [
-    { value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash (推奨)' },
-    { value: 'gemini-1.5-flash-latest', label: 'Gemini 1.5 Flash Latest' },
+    { value: 'gemini-1.5-flash-latest', label: 'Gemini 1.5 Flash (推奨)' },
+    { value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash (旧バージョン)' },
     { value: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro' },
     { value: 'gemini-1.0-pro', label: 'Gemini 1.0 Pro' },
     { value: 'gemini-1.0-pro-vision', label: 'Gemini 1.0 Pro Vision' },

--- a/scripts/auto_resolve_conflicts.py
+++ b/scripts/auto_resolve_conflicts.py
@@ -13,7 +13,7 @@ import google.generativeai as genai
 
 MAX_RETRIES = 3
 
-MODEL_NAME = os.getenv("GEMINI_MODEL", "gemini-1.5-flash")
+MODEL_NAME = os.getenv("GEMINI_MODEL", "gemini-1.5-flash-latest")
 genai.configure()
 model = genai.GenerativeModel(MODEL_NAME)
 
@@ -21,7 +21,7 @@ model = genai.GenerativeModel(MODEL_NAME)
 def run_cmd(cmd: Sequence[str], *, capture: bool = False, cwd: str | None = None) -> Tuple[str, str, int]:
     """Run a shell command and optionally capture its output."""
     print(f"$ {' '.join(cmd)}", flush=True)
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603
         list(cmd),
         cwd=cwd,
         check=False,
@@ -158,7 +158,11 @@ def _run_python_tests() -> Tuple[bool, str, str]:
         stderr_parts.append(err)
         success = success and code == 0
 
-    return success, "\n".join(part for part in stdout_parts if part).strip(), "\n".join(part for part in stderr_parts if part).strip()
+    return (
+        success,
+        "\n".join(part for part in stdout_parts if part).strip(),
+        "\n".join(part for part in stderr_parts if part).strip(),
+    )
 
 
 def _run_node_tests() -> Tuple[bool, str, str]:
@@ -182,7 +186,11 @@ def _run_node_tests() -> Tuple[bool, str, str]:
         stderr_parts.append(err)
         success = success and code == 0
 
-    return success, "\n".join(part for part in stdout_parts if part).strip(), "\n".join(part for part in stderr_parts if part).strip()
+    return (
+        success,
+        "\n".join(part for part in stdout_parts if part).strip(),
+        "\n".join(part for part in stderr_parts if part).strip(),
+    )
 
 
 def run_tests() -> Tuple[bool, str, str]:
@@ -216,10 +224,10 @@ def main() -> None:
         success, out, err = run_tests()
 
         if success:
-            print(f"✅ テスト成功！（{attempt}回目）", flush=True)
+            print(f"✅ テスト成功！（{attempt}回目）", flush=True)  # noqa: RUF001
             return
 
-        print(f"❌ テスト失敗（{attempt}回目） 修正を試みます...", flush=True)
+        print(f"❌ テスト失敗（{attempt}回目） 修正を試みます...", flush=True)  # noqa: RUF001
         error_log = "\n".join(part for part in [out, err] if part)
 
         for file_path in conflicted_files:


### PR DESCRIPTION
## Summary
- default Gemini configuration to `gemini-1.5-flash-latest` and normalize any legacy `gemini-1.5-flash` credentials on load and admin APIs
- update admin UI defaults/options and documentation to reflect the supported model name
- adjust tooling and tests to cover the new normalization helper and refreshed defaults

## Testing
- pytest backend/tests/test_admin_settings.py backend/tests/test_gemini_service.py
- ruff check backend/app/config.py backend/app/routers/admin_settings.py backend/app/services/gemini.py backend/tests/test_admin_settings.py backend/tests/test_gemini_service.py scripts/auto_resolve_conflicts.py
- black --check backend/app/config.py backend/app/routers/admin_settings.py backend/app/services/gemini.py backend/tests/test_admin_settings.py backend/tests/test_gemini_service.py scripts/auto_resolve_conflicts.py

------
https://chatgpt.com/codex/tasks/task_e_68db6d9fb9e4832093125bd228ab4d69