### PR TITLE
Queue hover messages at top right

### DIFF
--- a/frontend/src/app/core/layout/shell/shell.html
+++ b/frontend/src/app/core/layout/shell/shell.html
@@ -38,22 +38,24 @@
         </button>
       </div>
     }
-    @let profileToast = profileToastMessage();
-    @if (profileToast) {
+    @let hoverMessages = hoverMessageList();
+    @if (hoverMessages.length > 0) {
       <div class="shell-toast-stack" role="region" aria-live="polite" aria-label="グローバル通知">
-        <div class="shell-toast" role="status">
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 24 24"
-            class="h-4 w-4"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.8"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M5 12.5 10 17l9-10" />
-          </svg>
-          <span>{{ profileToast }}</span>
-        </div>
+        @for (toast of hoverMessages; track toast.id) {
+          <div class="shell-toast" role="status">
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+              class="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 12.5 10 17l9-10" />
+            </svg>
+            <span>{{ toast.text }}</span>
+          </div>
+        }
       </div>
     }
     <div class="shell-header__content shell-container">

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -676,7 +676,7 @@ app-shell .shell-user__email {
 
 app-shell .shell-toast-stack {
   position: fixed;
-  bottom: clamp(24px, 6vh, 72px);
+  top: clamp(88px, 8vh, 128px);
   right: clamp(12px, 5vw, 48px);
   display: flex;
   flex-direction: column;
@@ -752,7 +752,7 @@ app-shell .shell-global-error__dismiss:hover {
 @keyframes shell-toast-in {
   from {
     opacity: 0;
-    transform: translateY(10px);
+    transform: translateY(-10px);
   }
 
   to {


### PR DESCRIPTION
## Summary
- move the shell hover message stack to the top-right corner and adjust the entry animation for the new position
- replace the single-message toast state with a queued hover message list so multiple notifications stack without overlapping

## Testing
- npm run lint
- npx prettier --check src/app/core/layout/shell/shell.ts src/app/core/layout/shell/shell.html src/styles.scss
- npm run build
- npm run test:ci *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db6de0c43c8320a0773df0fe3e134e