### PR TITLE
Align Gemini model default with v1beta API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Create a `.env` file in the repository root or export variables before launching
 | --- | --- | --- |
 | `DATABASE_URL` | SQLAlchemy connection string. Use PostgreSQL for production workloads. | `sqlite:///./todo.db` |
 | `DEBUG` | Enables verbose logging and exception responses. | `False` |
-| `GEMINI_MODEL` | Gemini model identifier for AI-assisted flows. | `gemini-1.5-flash-latest` |
+| `GEMINI_MODEL` | Gemini model identifier for AI-assisted flows. | `models/gemini-1.5-flash` |
 | `SECRET_ENCRYPTION_KEY` | AES key for encrypting stored secrets. | `verbalize-yourself` |
 | `RECOMMENDATION_WEIGHT_LABEL` | Weight applied to label correlation when computing `ai_confidence`. | `0.6` |
 | `RECOMMENDATION_WEIGHT_PROFILE` | Weight applied to profile alignment when computing `ai_confidence`. | `0.4` |
@@ -106,4 +106,7 @@ Documentation-only updates may skip automated checks, but keep README and `docs/
 ## Troubleshooting
 ### WinError 10055 on Windows
 Long-running async workloads (for example, repeated backend test runs) can exhaust Windows socket buffers and raise `OSError: [WinError 10055]`. Close stray processes holding sockets (`Get-NetTCPConnection`), stagger concurrent test runs, or reboot to reclaim ephemeral ports. Consider increasing `MaxUserPort` and reducing `TcpTimedWaitDelay` if you control the environment.
+
+### Gemini 404 errors after submitting `/analysis`
+If the backend logs `models/gemini-1.5-flash-latest is not found for API version v1beta`, the local environment is using the `google-generativeai` 0.5 SDK, which still targets the `v1beta` API. That API does not expose the `gemini-1.5-flash-latest` alias, so requests fail with HTTP 404. Configure the model as `models/gemini-1.5-flash` (the default value exposed by the admin screen and `GEMINI_MODEL`) or upgrade the SDK to a release that talks to the `v1` endpoint before switching to the `-latest` alias.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -56,7 +56,7 @@ Configuration is managed through environment variables (see `app/config.py`). Ke
 
 - `DATABASE_URL`: SQLAlchemy connection string. Defaults to `sqlite:///./todo.db`.
 - `DEBUG`: Enable FastAPI debug mode (default: `False`).
-- `GEMINI_MODEL`: Logical name for the Gemini model (default: `gemini-1.5-flash-latest`).
+- `GEMINI_MODEL`: Logical name for the Gemini model (default: `models/gemini-1.5-flash`).
 - `ALLOWED_ORIGINS`: Comma-separated list of origins allowed to call the API with browser credentials (default: `http://localhost:4200`).
 - `SECRET_ENCRYPTION_KEY`: Optional key used to encrypt stored API credentials (defaults to an internal fallback; configure in production).
 - `RECOMMENDATION_WEIGHT_LABEL`: Weight applied to label correlation when combining recommendation scores (default: `0.6`).

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("DEBUG", "debug"),
     )
     gemini_model: str = Field(
-        default="gemini-1.5-flash-latest",
+        default="models/gemini-1.5-flash",
         validation_alias=AliasChoices(
             "GEMINI_MODEL",
             "gemini_model",

--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -172,9 +172,9 @@ class GeminiClient:
     }
 
     _LEGACY_MODEL_ALIASES: ClassVar[dict[str, str]] = {
-        "gemini-1.5-flash": "gemini-1.5-flash-latest",
-        "models/gemini-1.5-flash": "gemini-1.5-flash-latest",
-        "models/gemini-1.5-flash-latest": "gemini-1.5-flash-latest",
+        "gemini-1.5-flash": "models/gemini-1.5-flash",
+        "gemini-1.5-flash-latest": "models/gemini-1.5-flash",
+        "models/gemini-1.5-flash-latest": "models/gemini-1.5-flash",
     }
 
     def __init__(

--- a/backend/tests/test_admin_settings.py
+++ b/backend/tests/test_admin_settings.py
@@ -41,13 +41,13 @@ def test_admin_can_update_gemini_model_without_rotating_secret(client: TestClien
     )
     assert update.status_code == 200, update.text
     updated_payload = update.json()
-    assert updated_payload["model"] == "gemini-1.5-flash-latest"
+    assert updated_payload["model"] == "models/gemini-1.5-flash"
     assert updated_payload["secret_hint"] == created_payload["secret_hint"]
 
     fetch = client.get("/admin/api-credentials/gemini", headers=headers)
     assert fetch.status_code == 200, fetch.text
     fetched_payload = fetch.json()
-    assert fetched_payload["model"] == "gemini-1.5-flash-latest"
+    assert fetched_payload["model"] == "models/gemini-1.5-flash"
 
 
 def test_admin_credentials_use_default_secret_key(client: TestClient) -> None:
@@ -57,7 +57,7 @@ def test_admin_credentials_use_default_secret_key(client: TestClient) -> None:
     create = client.put(
         "/admin/api-credentials/gemini",
         headers=headers,
-        json={"secret": secret, "model": "gemini-1.5-flash-latest"},
+        json={"secret": secret, "model": "models/gemini-1.5-flash"},
     )
     assert create.status_code == 200, create.text
 

--- a/backend/tests/test_gemini_service.py
+++ b/backend/tests/test_gemini_service.py
@@ -386,5 +386,7 @@ def test_load_gemini_configuration_respects_disabled_credential(client: TestClie
 
 
 def test_normalize_model_name_maps_legacy_flash() -> None:
-    assert GeminiClient.normalize_model_name("gemini-1.5-flash") == "gemini-1.5-flash-latest"
-    assert GeminiClient.normalize_model_name("models/gemini-1.5-flash") == "gemini-1.5-flash-latest"
+    assert GeminiClient.normalize_model_name("gemini-1.5-flash") == "models/gemini-1.5-flash"
+    assert GeminiClient.normalize_model_name("gemini-1.5-flash-latest") == "models/gemini-1.5-flash"
+    assert GeminiClient.normalize_model_name("models/gemini-1.5-flash") == "models/gemini-1.5-flash"
+    assert GeminiClient.normalize_model_name("models/gemini-1.5-flash-latest") == "models/gemini-1.5-flash"

--- a/frontend/src/app/features/admin/page.spec.ts
+++ b/frontend/src/app/features/admin/page.spec.ts
@@ -28,7 +28,7 @@ class MockAdminApiService {
     is_active: true,
     created_at: '2024-01-01T00:00:00.000Z',
     updated_at: '2024-01-01T00:00:00.000Z',
-    model: 'gemini-1.5-flash-latest',
+    model: 'models/gemini-1.5-flash',
     secret_hint: null,
   };
 

--- a/frontend/src/app/features/admin/page.ts
+++ b/frontend/src/app/features/admin/page.ts
@@ -67,7 +67,7 @@ export class AdminPage {
   public readonly feedback = signal<string | null>(null);
   public readonly error = signal<string | null>(null);
 
-  private readonly defaultGeminiModel = 'gemini-1.5-flash-latest';
+  private readonly defaultGeminiModel = 'models/gemini-1.5-flash';
   private readonly competencyCriteria = new FormArray<CriterionFormGroup>([
     this.createCriterionGroup(),
   ]);
@@ -130,8 +130,9 @@ export class AdminPage {
 
   private readonly userQuotaForms = signal(new Map<string, UserQuotaForm>());
   public readonly geminiModelOptions: ReadonlyArray<{ value: string; label: string }> = [
-    { value: 'gemini-1.5-flash-latest', label: 'Gemini 1.5 Flash (推奨)' },
-    { value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash (旧バージョン)' },
+    { value: 'models/gemini-1.5-flash', label: 'Gemini 1.5 Flash (推奨)' },
+    { value: 'gemini-1.5-flash-latest', label: 'Gemini 1.5 Flash (-latest エイリアス)' },
+    { value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash (互換モード)' },
     { value: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro' },
     { value: 'gemini-1.0-pro', label: 'Gemini 1.0 Pro' },
     { value: 'gemini-1.0-pro-vision', label: 'Gemini 1.0 Pro Vision' },

--- a/scripts/auto_resolve_conflicts.py
+++ b/scripts/auto_resolve_conflicts.py
@@ -13,7 +13,7 @@ import google.generativeai as genai
 
 MAX_RETRIES = 3
 
-MODEL_NAME = os.getenv("GEMINI_MODEL", "gemini-1.5-flash-latest")
+MODEL_NAME = os.getenv("GEMINI_MODEL", "models/gemini-1.5-flash")
 genai.configure()
 model = genai.GenerativeModel(MODEL_NAME)
 


### PR DESCRIPTION
## Summary
- normalize Gemini client aliases so `gemini-1.5-flash` and `gemini-1.5-flash-latest` resolve to the v1beta-compatible `models/gemini-1.5-flash`
- refresh backend defaults, admin UI options, and scripts to surface the supported identifier by default
- document the 404 failure mode in the README and update tests to lock in the new normalization behavior

## Testing
- pytest backend/tests/test_gemini_service.py backend/tests/test_admin_settings.py
- npm test -- --watch=false *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68db70cabd688320b0d20ab94d8cf44d