### PR TITLE
Update Gemini default model to 2.0 flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Create a `.env` file in the repository root or export variables before launching
 | --- | --- | --- |
 | `DATABASE_URL` | SQLAlchemy connection string. Use PostgreSQL for production workloads. | `sqlite:///./todo.db` |
 | `DEBUG` | Enables verbose logging and exception responses. | `False` |
-| `GEMINI_MODEL` | Gemini model identifier for AI-assisted flows. | `models/gemini-1.5-flash` |
+| `GEMINI_MODEL` | Gemini model identifier for AI-assisted flows. | `models/gemini-2.0-flash` |
 | `SECRET_ENCRYPTION_KEY` | AES key for encrypting stored secrets. | `verbalize-yourself` |
 | `RECOMMENDATION_WEIGHT_LABEL` | Weight applied to label correlation when computing `ai_confidence`. | `0.6` |
 | `RECOMMENDATION_WEIGHT_PROFILE` | Weight applied to profile alignment when computing `ai_confidence`. | `0.4` |
@@ -108,15 +108,15 @@ Documentation-only updates may skip automated checks, but keep README and `docs/
 Long-running async workloads (for example, repeated backend test runs) can exhaust Windows socket buffers and raise `OSError: [WinError 10055]`. Close stray processes holding sockets (`Get-NetTCPConnection`), stagger concurrent test runs, or reboot to reclaim ephemeral ports. Consider increasing `MaxUserPort` and reducing `TcpTimedWaitDelay` if you control the environment.
 
 ### Gemini 404 errors after submitting `/analysis`
-When the backend raises `google.api_core.exceptions.NotFound: 404 models/gemini-1.5-flash is not found for API version v1beta, or is not supported for generateContent`, the Google Generative AI SDK is hitting the legacy `v1beta` API. That endpoint does not expose `gemini-1.5-flash` (or the newer `-latest` aliases), so FastAPI ultimately returns `502 Bad Gateway` to the Angular client.
+When the backend raises `google.api_core.exceptions.NotFound: 404 models/gemini-2.0-flash is not found for API version v1beta, or is not supported for generateContent`, the Google Generative AI SDK is hitting the legacy `v1beta` API. That endpoint does not expose `gemini-2.0-flash` (or other `2.0` Flash variants), so FastAPI ultimately returns `502 Bad Gateway` to the Angular client.
 
 The stack traces point back to `backend/app/services/gemini.py`, where the client invokes `generate_content()` via gRPC. You may also notice `ALTS creds ignored. Not running on GCP ...` in the logs—this warning is safe to ignore outside Google Cloud.
 
 To recover:
 
-1. **Enumerate supported models** – Run `from google.generativeai import list_models; print(list_models())` in a Python shell to verify which models and methods your account can access. The backend now performs this discovery step automatically and will either map `models/gemini-1.5-flash` to an available variant (for example `models/gemini-1.5-flash-002`) or return `503 Service Unavailable` with the supported model names.
-2. **Switch to an available model** – Configure `GEMINI_MODEL` (or the admin credential form) with an identifier such as `gemini-pro`, `gemini-1.0-pro`, or `gemini-1.5-pro-latest` that still works with `v1beta`.
-3. **Upgrade the SDK for `v1` support** – Install the latest `google-generativeai` release so you can target the `v1` API and restore access to `gemini-1.5-flash`/`gemini-1.5-flash-latest`.
+1. **Enumerate supported models** – Run `from google.generativeai import list_models; print(list_models())` in a Python shell to verify which models and methods your account can access. The backend now performs this discovery step automatically and will either map `models/gemini-2.0-flash` to an available variant (for example `models/gemini-2.0-flash-002`) or return `503 Service Unavailable` with the supported model names.
+2. **Switch to an available model** – Configure `GEMINI_MODEL` (or the admin credential form) with an identifier surfaced by the error, such as `models/gemini-2.0-flash`, `models/gemini-2.0-flash-lite`, or `gemini-1.5-pro-latest`, that your account can access.
+3. **Upgrade the SDK for `v1` support** – Install the latest `google-generativeai` release so you can target the `v1` API and restore access to the Flash families if you are pinned to older runtimes.
 
 Re-run the `list_models()` check after each change to confirm the API now exposes the desired model before retrying the `/analysis` workflow.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -56,7 +56,7 @@ Configuration is managed through environment variables (see `app/config.py`). Ke
 
 - `DATABASE_URL`: SQLAlchemy connection string. Defaults to `sqlite:///./todo.db`.
 - `DEBUG`: Enable FastAPI debug mode (default: `False`).
-- `GEMINI_MODEL`: Logical name for the Gemini model (default: `models/gemini-1.5-flash`).
+- `GEMINI_MODEL`: Logical name for the Gemini model (default: `models/gemini-2.0-flash`).
 - `ALLOWED_ORIGINS`: Comma-separated list of origins allowed to call the API with browser credentials (default: `http://localhost:4200`).
 - `SECRET_ENCRYPTION_KEY`: Optional key used to encrypt stored API credentials (defaults to an internal fallback; configure in production).
 - `RECOMMENDATION_WEIGHT_LABEL`: Weight applied to label correlation when combining recommendation scores (default: `0.6`).

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("DEBUG", "debug"),
     )
     gemini_model: str = Field(
-        default="models/gemini-1.5-flash",
+        default="models/gemini-2.0-flash",
         validation_alias=AliasChoices(
             "GEMINI_MODEL",
             "gemini_model",

--- a/backend/app/services/gemini.py
+++ b/backend/app/services/gemini.py
@@ -174,6 +174,7 @@ class GeminiClient:
 
     _LEGACY_MODEL_ALIASES: ClassVar[dict[str, str]] = {
         "gemini-1.5-flash": "models/gemini-1.5-flash",
+        "gemini-2.0-flash": "models/gemini-2.0-flash",
     }
 
     def __init__(
@@ -311,6 +312,8 @@ class GeminiClient:
         if normalized.startswith("models/"):
             return normalized
         if normalized.startswith("gemini-1.5-flash"):
+            return f"models/{normalized}"
+        if normalized.startswith("gemini-2.0-flash"):
             return f"models/{normalized}"
         return normalized
 

--- a/backend/tests/test_gemini_service.py
+++ b/backend/tests/test_gemini_service.py
@@ -385,11 +385,14 @@ def test_load_gemini_configuration_respects_disabled_credential(client: TestClie
         db_gen.close()
 
 
-def test_normalize_model_name_maps_legacy_flash() -> None:
+def test_normalize_model_name_maps_flash_families() -> None:
     assert GeminiClient.normalize_model_name("gemini-1.5-flash") == "models/gemini-1.5-flash"
     assert GeminiClient.normalize_model_name("gemini-1.5-flash-latest") == "models/gemini-1.5-flash-latest"
     assert GeminiClient.normalize_model_name("models/gemini-1.5-flash") == "models/gemini-1.5-flash"
     assert GeminiClient.normalize_model_name("models/gemini-1.5-flash-latest") == "models/gemini-1.5-flash-latest"
+    assert GeminiClient.normalize_model_name("gemini-2.0-flash") == "models/gemini-2.0-flash"
+    assert GeminiClient.normalize_model_name("gemini-2.0-flash-lite") == "models/gemini-2.0-flash-lite"
+    assert GeminiClient.normalize_model_name("models/gemini-2.0-flash") == "models/gemini-2.0-flash"
 
 
 def test_client_resolves_available_flash_variant(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -405,8 +408,8 @@ def test_client_resolves_available_flash_variant(monkeypatch: pytest.MonkeyPatch
 
     def fake_list_models() -> list[FakeModel]:
         return [
-            FakeModel("models/gemini-1.5-flash-001", ("generateContent",)),
-            FakeModel("models/gemini-1.5-flash-002", ("generateContent",)),
+            FakeModel("models/gemini-2.0-flash-001", ("generateContent",)),
+            FakeModel("models/gemini-2.0-flash-002", ("generateContent",)),
         ]
 
     class DummyGenerativeModel:
@@ -423,12 +426,12 @@ def test_client_resolves_available_flash_variant(monkeypatch: pytest.MonkeyPatch
         ),
     )
 
-    client = GeminiClient(model="models/gemini-1.5-flash", api_key="sk-test")
+    client = GeminiClient(model="models/gemini-2.0-flash", api_key="sk-test")
 
     assert configured["api_key"] == "sk-test"
-    assert client.model == "models/gemini-1.5-flash-002"
+    assert client.model == "models/gemini-2.0-flash-002"
     assert isinstance(client._client, DummyGenerativeModel)  # type: ignore[attr-defined]
-    assert client._client.name == "models/gemini-1.5-flash-002"  # type: ignore[attr-defined]
+    assert client._client.name == "models/gemini-2.0-flash-002"  # type: ignore[attr-defined]
 
 
 def test_client_raises_when_requested_model_missing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -465,6 +468,6 @@ def test_client_keeps_model_when_catalog_unavailable(monkeypatch: pytest.MonkeyP
         ),
     )
 
-    client = GeminiClient(model="models/gemini-1.5-flash", api_key="sk-fallback")
+    client = GeminiClient(model="models/gemini-2.0-flash", api_key="sk-fallback")
 
-    assert client.model == "models/gemini-1.5-flash"
+    assert client.model == "models/gemini-2.0-flash"

--- a/frontend/src/app/features/admin/page.spec.ts
+++ b/frontend/src/app/features/admin/page.spec.ts
@@ -28,7 +28,7 @@ class MockAdminApiService {
     is_active: true,
     created_at: '2024-01-01T00:00:00.000Z',
     updated_at: '2024-01-01T00:00:00.000Z',
-    model: 'models/gemini-1.5-flash',
+    model: 'models/gemini-2.0-flash',
     secret_hint: null,
   };
 

--- a/frontend/src/app/features/admin/page.ts
+++ b/frontend/src/app/features/admin/page.ts
@@ -67,7 +67,7 @@ export class AdminPage {
   public readonly feedback = signal<string | null>(null);
   public readonly error = signal<string | null>(null);
 
-  private readonly defaultGeminiModel = 'models/gemini-1.5-flash';
+  private readonly defaultGeminiModel = 'models/gemini-2.0-flash';
   private readonly competencyCriteria = new FormArray<CriterionFormGroup>([
     this.createCriterionGroup(),
   ]);
@@ -130,7 +130,15 @@ export class AdminPage {
 
   private readonly userQuotaForms = signal(new Map<string, UserQuotaForm>());
   public readonly geminiModelOptions: ReadonlyArray<{ value: string; label: string }> = [
-    { value: 'models/gemini-1.5-flash', label: 'Gemini 1.5 Flash (推奨)' },
+    { value: 'models/gemini-2.0-flash', label: 'Gemini 2.0 Flash (推奨)' },
+    { value: 'models/gemini-2.0-flash-lite', label: 'Gemini 2.0 Flash Lite' },
+    { value: 'models/gemini-2.0-flash-exp', label: 'Gemini 2.0 Flash Experimental' },
+    {
+      value: 'models/gemini-2.0-flash-exp-image-generation',
+      label: 'Gemini 2.0 Flash Experimental (画像生成)',
+    },
+    { value: 'models/gemini-2.0-flash-001', label: 'Gemini 2.0 Flash 001' },
+    { value: 'models/gemini-1.5-flash', label: 'Gemini 1.5 Flash (互換)' },
     { value: 'gemini-1.5-flash-latest', label: 'Gemini 1.5 Flash (-latest エイリアス)' },
     { value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash (互換モード)' },
     { value: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro' },

--- a/scripts/auto_resolve_conflicts.py
+++ b/scripts/auto_resolve_conflicts.py
@@ -13,7 +13,7 @@ import google.generativeai as genai
 
 MAX_RETRIES = 3
 
-MODEL_NAME = os.getenv("GEMINI_MODEL", "models/gemini-1.5-flash")
+MODEL_NAME = os.getenv("GEMINI_MODEL", "models/gemini-2.0-flash")
 genai.configure()
 model = genai.GenerativeModel(MODEL_NAME)
 


### PR DESCRIPTION
## Summary
- set the backend default Gemini model to `models/gemini-2.0-flash` and keep normalization compatible with 1.5 fallbacks
- update Gemini client tests, tooling defaults, and the admin UI model picker to surface 2.0 Flash variants
- refresh documentation to reference the new default model and troubleshooting guidance

## Testing
- pytest backend/tests/test_gemini_service.py backend/tests/test_admin_settings.py
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68db7f86c084832090c8685146b057ac