### PR TITLE
Align AI confidence displays with scoring contract

### DIFF
--- a/frontend/src/app/core/state/continuous-improvement-store.ts
+++ b/frontend/src/app/core/state/continuous-improvement-store.ts
@@ -317,8 +317,8 @@ export class ContinuousImprovementStore {
       .flatMap((layer) =>
         layer.nodes.map(
           (node) =>
-            `- 第${layer.depth}階層: ${node.statement} (確信度 ${Math.round(
-              node.confidence,
+            `- 第${layer.depth}階層: ${node.statement} (おすすめ度 ${Math.round(
+              node.confidence * 100,
             )}%, 状態 ${node.state}${node.tone === 'direct' ? ' ※率直な指摘' : ''})`,
         ),
       );

--- a/frontend/src/app/core/state/continuous-improvement-store.ts
+++ b/frontend/src/app/core/state/continuous-improvement-store.ts
@@ -318,7 +318,7 @@ export class ContinuousImprovementStore {
         layer.nodes.map(
           (node) =>
             `- 第${layer.depth}階層: ${node.statement} (確信度 ${Math.round(
-              node.confidence * 100,
+              node.confidence,
             )}%, 状態 ${node.state}${node.tone === 'direct' ? ' ※率直な指摘' : ''})`,
         ),
       );

--- a/frontend/src/app/features/analytics/page.html
+++ b/frontend/src/app/features/analytics/page.html
@@ -196,7 +196,7 @@
               <li class="cause-card">
                 <p class="text-sm font-semibold text-on-surface">{{ node.statement }}</p>
                 <p class="text-xs text-slate-500">
-                  確信度 {{ node.confidence * 100 | number: '1.0-0' }}% · 状況 {{ node.state }}
+                  確信度 {{ node.confidence | number: '1.0-0' }}% · 状況 {{ node.state }}
                 </p>
                 <p class="text-xs text-slate-500">
                   推奨指標: {{ node.recommendedMetrics.join(', ') || '未設定' }}

--- a/frontend/src/app/features/analytics/page.html
+++ b/frontend/src/app/features/analytics/page.html
@@ -196,7 +196,7 @@
               <li class="cause-card">
                 <p class="text-sm font-semibold text-on-surface">{{ node.statement }}</p>
                 <p class="text-xs text-slate-500">
-                  確信度 {{ node.confidence | number: '1.0-0' }}% · 状況 {{ node.state }}
+                  おすすめ度 {{ (node.confidence * 100) | number: '1.0-0' }}% · 状況 {{ node.state }}
                 </p>
                 <p class="text-xs text-slate-500">
                   推奨指標: {{ node.recommendedMetrics.join(', ') || '未設定' }}

--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -233,7 +233,7 @@
               <div class="analyze-page__proposal-header">
                 <h4 class="analyze-page__proposal-title">{{ proposal.title }}</h4>
                 <span class="page-badge page-badge--accent">
-                  おすすめ度 {{ proposal.confidence * 100 | number: '1.0-0' }}%
+                  おすすめ度 {{ proposal.confidence | number: '1.0-0' }}%
                 </span>
               </div>
               <p class="analyze-page__proposal-summary">{{ proposal.summary }}</p>

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -368,7 +368,7 @@
               <dd>
                 {{
                   active.confidence !== undefined
-                    ? (active.confidence * 100 | number: '1.0-0') + '%'
+                    ? (active.confidence | number: '1.0-0') + '%'
                     : '未設定'
                 }}
               </dd>


### PR DESCRIPTION
## Summary
- show AI recommendation scores as 0-100 percentages across analyze, board, and analytics pages
- update continuous improvement report generation to avoid multiplying the confidence score twice

## Testing
- CI=1 npm test -- --watch=false *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db82e26d688320b41f820ccac083cf