### PR TITLE
Fix analyzer proposal recommendation badges

### DIFF
--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -238,9 +238,11 @@
               </div>
               <p class="analyze-page__proposal-summary">{{ proposal.summary }}</p>
               <div class="analyze-page__proposal-tags">
-                <span class="page-badge"> 推奨ステータス: {{ proposal.suggestedStatusId }} </span>
                 <span class="page-badge">
-                  推奨ラベル: {{ proposal.suggestedLabelIds.join(', ') }}
+                  推奨ステータス: {{ formatSuggestedStatus(proposal.suggestedStatusId) }}
+                </span>
+                <span class="page-badge">
+                  推奨ラベル: {{ formatSuggestedLabels(proposal.suggestedLabelIds) }}
                 </span>
               </div>
               <div class="analyze-page__proposal-subtasks">

--- a/frontend/src/app/features/analyze/page.ts
+++ b/frontend/src/app/features/analyze/page.ts
@@ -46,6 +46,12 @@ export class AnalyzePage {
     message: string;
   } | null>(null);
   private readonly highlightResults = signal(false);
+  private readonly statusNameMap = computed(
+    () => new Map(this.workspace.settings().statuses.map((status) => [status.id, status.name])),
+  );
+  private readonly labelNameMap = computed(
+    () => new Map(this.workspace.settings().labels.map((label) => [label.id, label.name])),
+  );
 
   private toastTimer: number | null = null;
   private highlightTimer: number | null = null;
@@ -113,6 +119,26 @@ export class AnalyzePage {
   public readonly generationToastMessage = computed(() => this.toastMessageSignal());
 
   public readonly proposalPublishFeedback = computed(() => this.publishFeedback());
+
+  public readonly formatSuggestedStatus = (statusId: string | null | undefined): string => {
+    if (!statusId) {
+      return '未設定';
+    }
+
+    return this.statusNameMap().get(statusId) ?? '未設定';
+  };
+
+  public readonly formatSuggestedLabels = (labelIds: readonly string[]): string => {
+    if (!labelIds || labelIds.length === 0) {
+      return '未設定';
+    }
+
+    const names = labelIds
+      .map((labelId) => this.labelNameMap().get(labelId))
+      .filter((name): name is string => Boolean(name));
+
+    return names.length > 0 ? names.join('、') : '未設定';
+  };
 
   private readonly analyzerLifecycle = effect(() => {
     const request = this.requestSignal();


### PR DESCRIPTION
## Summary
- map analyzer proposal recommendations to workspace status and label names
- show a fallback when proposals omit suggested statuses or labels

## Testing
- npm run lint
- npx prettier --check src/app/features/analyze/page.ts src/app/features/analyze/page.html

------
https://chatgpt.com/codex/tasks/task_e_68db8920e48c8320a65b2c65536eaee1