### PR TITLE
Handle secret decryption failures gracefully

### DIFF
--- a/backend/tests/utils/test_secrets.py
+++ b/backend/tests/utils/test_secrets.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app.config import DEFAULT_SECRET_ENCRYPTION_KEY
-from app.utils.crypto import SecretCipher
+from app.utils.crypto import SecretCipher, SecretDecryptionError
 from app.utils.secrets import SecretEncryptionKeyError, build_secret_hint, get_secret_cipher
 
 
@@ -87,3 +87,11 @@ def test_secret_cipher_reencrypts_legacy_payload() -> None:
     rotated = modern_cipher.decrypt(result.reencrypted_payload)
     assert rotated.plaintext == secret
     assert rotated.reencrypted_payload is None
+
+
+def test_secret_cipher_raises_when_payload_cannot_be_decrypted() -> None:
+    original = SecretCipher("first-key").encrypt("api-key")
+    cipher = SecretCipher("second-key")
+
+    with pytest.raises(SecretDecryptionError):
+        cipher.decrypt(original)


### PR DESCRIPTION
## Summary
- add a dedicated SecretDecryptionError to guard invalid or unrecoverable payloads
- update Gemini configuration loading to surface a clear recovery message when stored credentials cannot be decrypted
- cover the new error path with a unit test for mismatched encryption keys

## Testing
- pytest backend/tests/utils/test_secrets.py backend/tests/test_gemini_service.py
- ruff check backend/app/utils/crypto.py backend/app/services/gemini.py backend/tests/utils/test_secrets.py
- black --check backend/app/utils/crypto.py backend/app/services/gemini.py backend/tests/utils/test_secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68db8abceff483208f44074265fdd88b