### PR TITLE
Enable card creation from status report proposals

### DIFF
--- a/frontend/src/app/features/reports/reports-page.component.html
+++ b/frontend/src/app/features/reports/reports-page.component.html
@@ -171,20 +171,102 @@
 
         <section
           class="report-assistant-page__group"
-          *ngIf="active.cards.length === 0 && active.pending_proposals.length > 0"
+          *ngIf="active.pending_proposals.length > 0"
         >
           <header class="report-assistant-page__group-header">
-            <h3 class="page-section__title">提案中のタスク</h3>
+            <div>
+              <h3 class="page-section__title">提案中のタスク</h3>
+              <p class="page-section__subtitle">
+                追加したい提案にチェックを入れてカードとして起票できます。
+              </p>
+            </div>
+            <div class="report-assistant-page__group-actions">
+              <p class="report-assistant-page__selection" aria-live="polite">
+                選択中: {{ selectedProposalCount() }} 件
+              </p>
+              <button
+                type="button"
+                class="button button--primary focus-ring"
+                (click)="publishSelectedProposals()"
+                [disabled]="!canPublishSelected()"
+              >
+                選択した提案をカードに追加
+              </button>
+            </div>
           </header>
+
+          <div
+            class="app-alert app-alert--success"
+            *ngIf="publishSuccess() as successMessage"
+            role="status"
+          >
+            {{ successMessage }}
+          </div>
+          <div
+            class="app-alert app-alert--error"
+            *ngIf="publishError() as errorMessage"
+            role="alert"
+          >
+            {{ errorMessage }}
+          </div>
+
           <ul class="page-list" aria-label="提案中のタスク">
-            <li class="page-list__item" *ngFor="let proposal of active.pending_proposals">
+            <li
+              class="page-list__item"
+              *ngFor="let proposal of active.pending_proposals; index as index"
+            >
               <div class="page-list__heading">
                 <p class="page-list__title">{{ proposal.title }}</p>
+                <div class="report-assistant-page__proposal-actions">
+                  <label class="report-assistant-page__proposal-select">
+                    <input
+                      type="checkbox"
+                      class="focus-ring"
+                      [checked]="isProposalSelected(index)"
+                      (change)="updateProposalSelection(index, $any($event.target).checked)"
+                      [disabled]="publishPending()"
+                    />
+                    <span>選択</span>
+                  </label>
+                  <button
+                    type="button"
+                    class="button button--secondary focus-ring"
+                    (click)="publishProposal(proposal)"
+                    [disabled]="publishPending()"
+                  >
+                    この提案をカードに追加
+                  </button>
+                </div>
               </div>
               <p class="page-list__description">{{ proposal.summary }}</p>
+
+              <div class="page-list__meta">
+                <span class="page-badge page-badge--accent">
+                  優先度 {{ proposal.priority || 'medium' }}
+                </span>
+                <span class="page-badge" *ngIf="proposal.status">
+                  推奨ステータス: {{ proposal.status }}
+                </span>
+                <span class="page-badge" *ngIf="proposal.labels.length > 0">
+                  推奨ラベル: {{ proposal.labels.join(', ') }}
+                </span>
+                <span
+                  class="page-badge"
+                  *ngIf="proposal.due_in_days !== null && proposal.due_in_days !== undefined"
+                >
+                  期限目安: {{ proposal.due_in_days }} 日以内
+                </span>
+              </div>
+
               <div class="report-assistant-page__subtasks" *ngIf="proposal.subtasks.length > 0">
                 <span class="surface-pill px-3 py-1" *ngFor="let sub of proposal.subtasks">
-                  {{ sub.title }}
+                  <ng-container *ngIf="sub.title; else subDescriptionOnly">
+                    {{ sub.title }}
+                    <ng-container *ngIf="sub.description"> — {{ sub.description }}</ng-container>
+                  </ng-container>
+                  <ng-template #subDescriptionOnly>
+                    {{ sub.description }}
+                  </ng-template>
                 </span>
               </div>
             </li>

--- a/frontend/src/app/features/reports/reports-page.component.ts
+++ b/frontend/src/app/features/reports/reports-page.component.ts
@@ -6,7 +6,17 @@ import { firstValueFrom } from 'rxjs';
 import { RouterLink } from '@angular/router';
 
 import { StatusReportsGateway } from '@core/api/status-reports-gateway';
-import { StatusReportDetail, StatusReportCreateRequest } from '@core/models';
+import {
+  StatusReportDetail,
+  StatusReportCreateRequest,
+  StatusReportProposal,
+  StatusReportProposalSubtask,
+  WorkspaceSettings,
+  Card,
+  Subtask,
+} from '@core/models';
+import { WorkspaceStore } from '@core/state/workspace-store';
+import { createId } from '@core/utils/create-id';
 import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 
 @Component({
@@ -19,11 +29,16 @@ import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 export class ReportAssistantPageComponent {
   private readonly gateway = inject(StatusReportsGateway);
   private readonly fb = inject(FormBuilder);
+  private readonly workspace = inject(WorkspaceStore);
 
   private readonly pendingState = signal(false);
   private readonly errorState = signal<string | null>(null);
   private readonly successState = signal<string | null>(null);
   private readonly detailState = signal<StatusReportDetail | null>(null);
+  private readonly proposalSelection = signal<readonly number[]>([]);
+  private readonly publishPendingState = signal(false);
+  private readonly publishErrorState = signal<string | null>(null);
+  private readonly publishSuccessState = signal<string | null>(null);
 
   public readonly form = this.fb.group({
     tags: [''],
@@ -34,6 +49,13 @@ export class ReportAssistantPageComponent {
   public readonly error = computed(() => this.errorState());
   public readonly successMessage = computed(() => this.successState());
   public readonly detail = computed(() => this.detailState());
+  public readonly selectedProposalCount = computed(() => this.proposalSelection().length);
+  public readonly publishPending = computed(() => this.publishPendingState());
+  public readonly publishError = computed(() => this.publishErrorState());
+  public readonly publishSuccess = computed(() => this.publishSuccessState());
+  public readonly canPublishSelected = computed(
+    () => this.selectedProposalCount() > 0 && !this.publishPending(),
+  );
 
   public get sections(): FormArray<FormGroup> {
     return this.form.get('sections') as FormArray<FormGroup>;
@@ -71,12 +93,315 @@ export class ReportAssistantPageComponent {
       const detail = await firstValueFrom(this.gateway.submitReport(created.id));
       this.detailState.set(detail);
       this.successState.set('AI 解析が完了しました。提案されたタスクを確認してください。');
+      this.clearProposalSelection();
+      this.clearPublishFeedback();
       this.resetForm();
     } catch (error) {
       this.errorState.set(this.extractErrorMessage(error));
     } finally {
       this.pendingState.set(false);
     }
+  }
+
+  public isProposalSelected(index: number): boolean {
+    return this.proposalSelection().includes(index);
+  }
+
+  public updateProposalSelection(index: number, selected: boolean): void {
+    this.proposalSelection.update((current) => {
+      const next = new Set(current);
+      if (selected) {
+        next.add(index);
+      } else {
+        next.delete(index);
+      }
+      this.publishErrorState.set(null);
+      return Array.from(next).sort((a, b) => a - b);
+    });
+  }
+
+  public async publishSelectedProposals(): Promise<void> {
+    if (this.publishPending()) {
+      return;
+    }
+
+    const detail = this.detail();
+    if (!detail) {
+      return;
+    }
+
+    const proposals = this.proposalSelection()
+      .map((index) => detail.pending_proposals[index])
+      .filter((proposal): proposal is StatusReportProposal => Boolean(proposal));
+
+    if (proposals.length === 0) {
+      this.publishErrorState.set('カードに追加する提案を選択してください。');
+      return;
+    }
+
+    await this.publishProposals(proposals, { clearSelection: true });
+  }
+
+  public async publishProposal(proposal: StatusReportProposal): Promise<void> {
+    if (this.publishPending()) {
+      return;
+    }
+
+    await this.publishProposals([proposal]);
+  }
+
+  private async publishProposals(
+    proposals: readonly StatusReportProposal[],
+    options?: { clearSelection?: boolean },
+  ): Promise<void> {
+    if (proposals.length === 0) {
+      return;
+    }
+
+    this.publishPendingState.set(true);
+    this.publishErrorState.set(null);
+    this.publishSuccessState.set(null);
+
+    const createdCardIds: string[] = [];
+    try {
+      const settings = this.workspace.settings();
+      for (const proposal of proposals) {
+        const card = await this.workspace.createCardFromSuggestion(
+          this.mapProposalToSuggestion(proposal, settings),
+        );
+        createdCardIds.push(card.id);
+      }
+
+      this.publishSuccessState.set(this.formatPublishSuccessMessage(proposals));
+      if (options?.clearSelection) {
+        this.clearProposalSelection();
+      }
+    } catch (error) {
+      console.error('Failed to publish status report proposals', error);
+      for (const cardId of createdCardIds) {
+        this.workspace.removeCard(cardId);
+      }
+      this.publishErrorState.set('カードの追加に失敗しました。時間をおいて再度お試しください。');
+    } finally {
+      this.publishPendingState.set(false);
+    }
+  }
+
+  private mapProposalToSuggestion(
+    proposal: StatusReportProposal,
+    settings: WorkspaceSettings,
+  ): Parameters<WorkspaceStore['createCardFromSuggestion']>[0] {
+    const statusId = this.resolveStatusId(proposal.status, settings);
+    const labelIds = this.resolveLabelIds(proposal.labels, settings);
+    const dueDate = this.resolveDueDate(proposal.due_in_days);
+    const priority = this.resolvePriority(proposal.priority);
+    const subtasks = this.mapSubtasks(proposal.subtasks);
+
+    return {
+      title: proposal.title,
+      summary: proposal.summary,
+      statusId,
+      labelIds,
+      priority,
+      dueDate,
+      subtasks,
+    };
+  }
+
+  private resolveStatusId(
+    statusName: string | null | undefined,
+    settings: WorkspaceSettings,
+  ): string | undefined {
+    if (!statusName) {
+      return undefined;
+    }
+
+    const normalized = statusName.trim().toLowerCase();
+    if (!normalized) {
+      return undefined;
+    }
+
+    const byId = settings.statuses.find(
+      (status) => status.id.trim().toLowerCase() === normalized,
+    );
+    if (byId) {
+      return byId.id;
+    }
+
+    const byName = settings.statuses.find(
+      (status) => status.name.trim().toLowerCase() === normalized,
+    );
+    if (byName) {
+      return byName.id;
+    }
+
+    const byCategory = settings.statuses.find((status) => status.category === normalized);
+    return byCategory?.id;
+  }
+
+  private resolveLabelIds(
+    labels: readonly string[] | undefined,
+    settings: WorkspaceSettings,
+  ): readonly string[] | undefined {
+    if (!labels || labels.length === 0) {
+      return undefined;
+    }
+
+    const lookup = new Map<string, string>();
+    for (const label of settings.labels) {
+      lookup.set(label.id.trim().toLowerCase(), label.id);
+      lookup.set(label.name.trim().toLowerCase(), label.id);
+    }
+
+    const resolved = labels
+      .map((label) => lookup.get(label.trim().toLowerCase()))
+      .filter((value): value is string => Boolean(value));
+
+    if (resolved.length === 0) {
+      return undefined;
+    }
+
+    return Array.from(new Set(resolved));
+  }
+
+  private resolveDueDate(dueInDays: number | null | undefined): string | undefined {
+    if (dueInDays === null || dueInDays === undefined) {
+      return undefined;
+    }
+
+    const numeric = Number(dueInDays);
+    if (!Number.isFinite(numeric)) {
+      return undefined;
+    }
+
+    const today = new Date();
+    today.setUTCDate(today.getUTCDate() + Math.trunc(numeric));
+    return today.toISOString();
+  }
+
+  private resolvePriority(priority: string | null | undefined): Card['priority'] {
+    if (!priority) {
+      return 'medium';
+    }
+
+    const normalized = priority.trim().toLowerCase();
+    switch (normalized) {
+      case 'low':
+      case 'minor':
+      case 'lowest':
+        return 'low';
+      case 'high':
+      case 'important':
+      case 'major':
+        return 'high';
+      case 'urgent':
+      case 'critical':
+      case 'highest':
+      case 'immediate':
+        return 'urgent';
+      default:
+        return 'medium';
+    }
+  }
+
+  private mapSubtasks(
+    subtasks: readonly StatusReportProposalSubtask[] | undefined,
+  ): readonly Subtask[] | undefined {
+    if (!subtasks || subtasks.length === 0) {
+      return undefined;
+    }
+
+    const mapped: Subtask[] = [];
+    for (const subtask of subtasks) {
+      const title = (subtask.title ?? '').trim();
+      const description = subtask.description?.trim();
+      const combined = this.composeSubtaskTitle(title, description);
+      if (!combined) {
+        continue;
+      }
+
+      mapped.push({
+        id: createId(),
+        title: combined,
+        status: this.resolveSubtaskStatus(subtask.status),
+      });
+    }
+
+    if (mapped.length === 0) {
+      return undefined;
+    }
+
+    return mapped;
+  }
+
+  private composeSubtaskTitle(title: string, description: string | undefined): string {
+    if (title && description) {
+      return `${title} — ${description}`;
+    }
+
+    if (title) {
+      return title;
+    }
+
+    return description ?? '';
+  }
+
+  private resolveSubtaskStatus(
+    statusName: string | null | undefined,
+  ): Subtask['status'] {
+    if (!statusName) {
+      return 'todo';
+    }
+
+    const normalized = statusName.trim().toLowerCase();
+    switch (normalized) {
+      case 'done':
+      case 'completed':
+      case 'complete':
+      case 'resolved':
+      case 'closed':
+        return 'done';
+      case 'in-progress':
+      case 'in_progress':
+      case 'doing':
+      case 'active':
+      case 'progress':
+      case 'review':
+      case 'qa':
+      case 'testing':
+      case 'blocked':
+        return 'in-progress';
+      case 'non-issue':
+      case 'non_issue':
+      case 'not-applicable':
+      case 'not_applicable':
+      case 'skipped':
+      case 'n/a':
+      case 'na':
+        return 'non-issue';
+      default:
+        return 'todo';
+    }
+  }
+
+  private formatPublishSuccessMessage(
+    proposals: readonly StatusReportProposal[],
+  ): string {
+    if (proposals.length === 1) {
+      return `カード「${proposals[0]?.title ?? ''}」をボードに追加しました。`;
+    }
+
+    const [first] = proposals;
+    return `${proposals.length}件のカードをボードに追加しました（最初の提案: 「${first?.title ?? ''}」）。`;
+  }
+
+  private clearProposalSelection(): void {
+    this.proposalSelection.set([]);
+  }
+
+  private clearPublishFeedback(): void {
+    this.publishErrorState.set(null);
+    this.publishSuccessState.set(null);
   }
 
   private createSectionGroup(): FormGroup {


### PR DESCRIPTION
## Summary
- allow status report proposals to be selected and published as new cards through the workspace store
- add selection controls, per-proposal publishing, and success/error messaging in the status report results panel

## Testing
- npm test -- --watch=false --progress=false *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db8a2c93a88320a961f5f99bb16f1d