### PR TITLE
Ensure workspace data reloads when navigating between pages

### DIFF
--- a/frontend/src/app/core/state/workspace-store.spec.ts
+++ b/frontend/src/app/core/state/workspace-store.spec.ts
@@ -8,7 +8,7 @@ import { CardCreateRequest, CardResponse, CardsApiService } from '@core/api/card
 import { CommentsApiService } from '@core/api/comments-api.service';
 import { WorkspaceConfigApiService } from '@core/api/workspace-config-api.service';
 import { Logger } from '@core/logger/logger';
-import { AnalysisProposal, AuthenticatedUser } from '@core/models';
+import { AnalysisProposal, AuthenticatedUser, Card } from '@core/models';
 
 import { WorkspaceStore } from './workspace-store';
 
@@ -476,6 +476,66 @@ describe('WorkspaceStore', () => {
         localStorage.getItem('verbalize-yourself/workspace-preferences/anonymous') ?? '{}',
       );
       expect(cached.grouping).toBe('label');
+    });
+  });
+
+  describe('refreshWorkspaceData', () => {
+    it('reloads workspace configuration and cards for the active user', async () => {
+      const user = createAuthenticatedUser({ id: 'user-200' });
+      auth.setUser(user);
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      workspaceConfigApi.listStatuses.calls.reset();
+      workspaceConfigApi.listLabels.calls.reset();
+      workspaceConfigApi.listTemplates.calls.reset();
+      cardsApi.listCards.calls.reset();
+
+      await store.refreshWorkspaceData();
+
+      expect(workspaceConfigApi.listStatuses).toHaveBeenCalledTimes(1);
+      expect(workspaceConfigApi.listLabels).toHaveBeenCalledTimes(1);
+      expect(workspaceConfigApi.listTemplates).toHaveBeenCalledTimes(1);
+      expect(cardsApi.listCards).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears cards and skips remote reload when no user is active', async () => {
+      const internalStore = store as unknown as { cardsSignal: { set(value: Card[]): void } };
+      const placeholderCard: Card = {
+        id: 'card-1',
+        title: 'Placeholder',
+        summary: 'Ensure cards reset',
+        statusId: 'status-todo',
+        labelIds: [],
+        templateId: null,
+        priority: 'medium',
+        storyPoints: 3,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        startDate: undefined,
+        dueDate: undefined,
+        assignee: undefined,
+        confidence: undefined,
+        subtasks: [],
+        comments: [],
+        activities: [],
+        originSuggestionId: undefined,
+        initiativeId: undefined,
+      };
+      internalStore.cardsSignal.set([placeholderCard]);
+
+      workspaceConfigApi.listStatuses.calls.reset();
+      workspaceConfigApi.listLabels.calls.reset();
+      workspaceConfigApi.listTemplates.calls.reset();
+      cardsApi.listCards.calls.reset();
+
+      await store.refreshWorkspaceData();
+
+      expect(store.cards()).toEqual([]);
+      expect(workspaceConfigApi.listStatuses).not.toHaveBeenCalled();
+      expect(workspaceConfigApi.listLabels).not.toHaveBeenCalled();
+      expect(workspaceConfigApi.listTemplates).not.toHaveBeenCalled();
+      expect(cardsApi.listCards).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/app/features/analytics/page.ts
+++ b/frontend/src/app/features/analytics/page.ts
@@ -37,6 +37,7 @@ export class AnalyticsPage {
   private readonly statusVisibilityMs = 5000;
 
   public constructor() {
+    void this.workspace.refreshWorkspaceData();
     this.destroyRef.onDestroy(() => {
       this.statusTimers.forEach((timer) => clearTimeout(timer));
       this.statusTimers.clear();

--- a/frontend/src/app/features/analyze/page.ts
+++ b/frontend/src/app/features/analyze/page.ts
@@ -215,6 +215,7 @@ export class AnalyzePage {
   });
 
   public constructor() {
+    void this.workspace.refreshWorkspaceData();
     this.destroyRef.onDestroy(() => {
       this.clearVisualTimers();
       this.clearPublishFeedbackTimer();

--- a/frontend/src/app/features/reports/reports-page.component.ts
+++ b/frontend/src/app/features/reports/reports-page.component.ts
@@ -31,6 +31,10 @@ export class ReportAssistantPageComponent {
   private readonly fb = inject(FormBuilder);
   private readonly workspace = inject(WorkspaceStore);
 
+  public constructor() {
+    void this.workspace.refreshWorkspaceData();
+  }
+
   private readonly pendingState = signal(false);
   private readonly errorState = signal<string | null>(null);
   private readonly successState = signal<string | null>(null);
@@ -148,9 +152,7 @@ export class ReportAssistantPageComponent {
     await this.publishProposals([proposal]);
   }
 
-  private async publishProposals(
-    proposals: readonly StatusReportProposal[],
-  ): Promise<void> {
+  private async publishProposals(proposals: readonly StatusReportProposal[]): Promise<void> {
     if (proposals.length === 0) {
       return;
     }
@@ -215,9 +217,7 @@ export class ReportAssistantPageComponent {
       return undefined;
     }
 
-    const byId = settings.statuses.find(
-      (status) => status.id.trim().toLowerCase() === normalized,
-    );
+    const byId = settings.statuses.find((status) => status.id.trim().toLowerCase() === normalized);
     if (byId) {
       return byId.id;
     }
@@ -340,9 +340,7 @@ export class ReportAssistantPageComponent {
     return description ?? '';
   }
 
-  private resolveSubtaskStatus(
-    statusName: string | null | undefined,
-  ): Subtask['status'] {
+  private resolveSubtaskStatus(statusName: string | null | undefined): Subtask['status'] {
     if (!statusName) {
       return 'todo';
     }
@@ -378,9 +376,7 @@ export class ReportAssistantPageComponent {
     }
   }
 
-  private formatPublishSuccessMessage(
-    proposals: readonly StatusReportProposal[],
-  ): string {
+  private formatPublishSuccessMessage(proposals: readonly StatusReportProposal[]): string {
     if (proposals.length === 1) {
       return `カード「${proposals[0]?.title ?? ''}」をボードに追加しました。`;
     }

--- a/frontend/src/app/features/settings/page.ts
+++ b/frontend/src/app/features/settings/page.ts
@@ -19,6 +19,10 @@ import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
 export class SettingsPage {
   private readonly workspace = inject(WorkspaceStore);
 
+  public constructor() {
+    void this.workspace.refreshWorkspaceData();
+  }
+
   public readonly settingsSignal = this.workspace.settings;
   public readonly labelsById = computed(() => {
     const map = new Map<string, string>();


### PR DESCRIPTION
## Summary
- add a WorkspaceStore.refreshWorkspaceData helper that reloads settings and card data
- refresh workspace data whenever the board, analytics, analyze, reports, or settings pages are displayed
- cover the new refresh behavior with unit tests to ensure API calls and state resets occur as expected

## Testing
- npm test -- --watch=false --progress=false *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- npx prettier --check src/app/core/state/workspace-store.ts src/app/features/board/page.ts src/app/features/analytics/page.ts src/app/features/analyze/page.ts src/app/features/reports/reports-page.component.ts src/app/features/settings/page.ts src/app/core/state/workspace-store.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68dbb7ca1a6883209977ae990cba6630