### PR TITLE
Fix template status display mapping

### DIFF
--- a/frontend/src/app/features/settings/page.html
+++ b/frontend/src/app/features/settings/page.html
@@ -367,9 +367,10 @@
             </p>
 
             <div class="settings-template__meta">
-              <span class="page-badge page-badge--accent"
-                >初期ステータス: {{ template.defaultStatusId }}</span
-              >
+              <span class="page-badge page-badge--accent">
+                初期ステータス:
+                {{ statusesById().get(template.defaultStatusId) ?? template.defaultStatusId }}
+              </span>
               <span class="page-badge"
                 >おすすめ度しきい値: {{ template.confidenceThreshold | number: '1.0-0' }}%</span
               >

--- a/frontend/src/app/features/settings/page.ts
+++ b/frontend/src/app/features/settings/page.ts
@@ -27,6 +27,13 @@ export class SettingsPage {
     }
     return map;
   });
+  public readonly statusesById = computed(() => {
+    const map = new Map<string, string>();
+    for (const status of this.settingsSignal().statuses) {
+      map.set(status.id, status.name);
+    }
+    return map;
+  });
   public readonly statusCount = computed(() => this.settingsSignal().statuses.length);
 
   public readonly labelForm = createSignalForm({ name: '', color: '#38bdf8' });


### PR DESCRIPTION
## Summary
- add a computed lookup for workspace status names in the settings page component
- render template default statuses using the mapped display name instead of the raw identifier

## Testing
- CI=1 npm test -- --watch=false --progress=false *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb825fe5083209cea7f9c4d638826