### PR TITLE
Add programming language options to profile roles

### DIFF
--- a/frontend/src/app/core/profile/profile-dialog.ts
+++ b/frontend/src/app/core/profile/profile-dialog.ts
@@ -142,6 +142,22 @@ const ROLE_TREE_DEFINITION = [
         valuePrefix: 'フルスタック',
         options: [{ label: 'フルスタック開発' }, { label: '技術選定・アーキテクチャ' }],
       },
+      {
+        label: 'プログラミング言語',
+        valuePrefix: 'プログラミング言語',
+        options: [
+          { label: 'JavaScript / TypeScript' },
+          { label: 'Python' },
+          { label: 'Java' },
+          { label: 'Go' },
+          { label: 'C#' },
+          { label: 'C++' },
+          { label: 'Ruby' },
+          { label: 'PHP' },
+          { label: 'Swift' },
+          { label: 'Kotlin' },
+        ],
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- add a programming language category to the profile role tree so members can record major languages alongside existing responsibilities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbc03ad65c83209dc11025a5116dec