### PR TITLE
Add FastAPI dependency to root requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+fastapi>=0.110.0,<1.0.0
 google-generativeai>=0.5.0,<1.0.0


### PR DESCRIPTION
## Summary
- add the FastAPI package to the root requirements list so pytest can import TestClient during backend tests

## Testing
- not run (dependency update only)


------
https://chatgpt.com/codex/tasks/task_e_68dbd366a5fc83209cf83c1222921f7f