### PR TITLE
Restore subtask fallback to original proposal

### DIFF
--- a/frontend/src/app/features/analyze/page.ts
+++ b/frontend/src/app/features/analyze/page.ts
@@ -499,7 +499,7 @@ export class AnalyzePage {
       .filter((title) => title.length > 0);
 
     if (sanitized.length === 0) {
-      return [];
+      return original?.subtasks ?? [];
     }
 
     return sanitized;


### PR DESCRIPTION
## Summary
- reuse the original proposal subtasks when the editable draft has no entries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbddaa5d388320a572007411ff3bfe