### PR TITLE
Remove static card count badge from report analysis results

### DIFF
--- a/frontend/src/app/features/reports/reports-page.component.html
+++ b/frontend/src/app/features/reports/reports-page.component.html
@@ -123,7 +123,6 @@
 
         <div class="report-assistant-page__status-group">
           <span class="page-badge page-badge--accent">ステータス {{ active.status }}</span>
-          <span class="page-badge">カード {{ active.cards.length }} 件</span>
           <span class="page-badge">提案 {{ proposalControls.length }} 件</span>
         </div>
 


### PR DESCRIPTION
## Summary
- remove the card count badge from the report analysis results header because it always showed 0

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dbe3fe27f88320a9fa1958cd5f4161