### PR TITLE
Prevent analyzer proposals from clearing status

### DIFF
--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -264,7 +264,6 @@
                       [value]="proposal.statusId"
                       (change)="updateProposalStatus(proposal.id, $any($event.target).value)"
                     >
-                      <option value="">未設定</option>
                       @for (status of workspaceStatuses(); track status.id) {
                         <option [value]="status.id">{{ status.name }}</option>
                       }

--- a/frontend/src/app/features/analyze/page.ts
+++ b/frontend/src/app/features/analyze/page.ts
@@ -350,7 +350,7 @@ export class AnalyzePage {
       confidence: proposal.confidence,
       title: proposal.title,
       summary: proposal.summary,
-      statusId: proposal.suggestedStatusId,
+      statusId: this.resolveStatusId(proposal.suggestedStatusId),
       labelIds: [...proposal.suggestedLabelIds],
       subtasks: proposal.subtasks.map((task) => this.createEditableSubtask(task)),
     }));
@@ -372,7 +372,11 @@ export class AnalyzePage {
   };
 
   public readonly updateProposalStatus = (proposalId: string, statusId: string): void => {
-    this.updateEditableProposal(proposalId, (proposal) => ({ ...proposal, statusId }));
+    const resolvedStatusId = this.resolveStatusId(statusId);
+    this.updateEditableProposal(proposalId, (proposal) => ({
+      ...proposal,
+      statusId: resolvedStatusId,
+    }));
   };
 
   public readonly toggleProposalLabel = (proposalId: string, labelId: string): void => {
@@ -479,7 +483,24 @@ export class AnalyzePage {
       return trimmed;
     }
 
-    return original?.suggestedStatusId?.trim() ?? '';
+    return this.resolveStatusId(original?.suggestedStatusId);
+  }
+
+  private resolveStatusId(statusId: string | null | undefined): string {
+    const normalized = statusId?.trim() ?? '';
+    const settings = this.workspace.settings();
+    const statuses = settings.statuses;
+
+    if (normalized.length > 0 && statuses.some((status) => status.id === normalized)) {
+      return normalized;
+    }
+
+    const defaultStatusId = settings.defaultStatusId?.trim() ?? '';
+    if (defaultStatusId.length > 0 && statuses.some((status) => status.id === defaultStatusId)) {
+      return defaultStatusId;
+    }
+
+    return statuses[0]?.id ?? defaultStatusId;
   }
 
   private normalizeLabels(proposal: EditableProposalDraft): readonly string[] {

--- a/frontend/src/app/features/analyze/page.ts
+++ b/frontend/src/app/features/analyze/page.ts
@@ -491,16 +491,32 @@ export class AnalyzePage {
     const settings = this.workspace.settings();
     const statuses = settings.statuses;
 
-    if (normalized.length > 0 && statuses.some((status) => status.id === normalized)) {
-      return normalized;
+    if (normalized.length > 0) {
+      if (statuses.length === 0) {
+        return normalized;
+      }
+
+      if (statuses.some((status) => status.id === normalized)) {
+        return normalized;
+      }
     }
 
     const defaultStatusId = settings.defaultStatusId?.trim() ?? '';
-    if (defaultStatusId.length > 0 && statuses.some((status) => status.id === defaultStatusId)) {
-      return defaultStatusId;
+    if (defaultStatusId.length > 0) {
+      if (statuses.length === 0) {
+        return defaultStatusId;
+      }
+
+      if (statuses.some((status) => status.id === defaultStatusId)) {
+        return defaultStatusId;
+      }
     }
 
-    return statuses[0]?.id ?? defaultStatusId;
+    if (statuses.length > 0) {
+      return statuses[0]?.id ?? defaultStatusId;
+    }
+
+    return normalized || defaultStatusId;
   }
 
   private normalizeLabels(proposal: EditableProposalDraft): readonly string[] {


### PR DESCRIPTION
## Summary
- resolve analyzer proposal statuses to valid workspace defaults so they cannot be cleared after generation
- remove the "未設定" option from the status dropdown to prevent users from reverting proposals to an unset state

## Testing
- npm test -- --watchAll=false --runInBand --testEnvironment=jsdom *(fails: Unknown arguments)*
- CI=1 npm test -- --watch=false *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- npx prettier --check "src/app/features/analyze/page.{ts,html}"

------
https://chatgpt.com/codex/tasks/task_e_68dbe2d0d1cc8320b737867fa0bf3a44