### PR TITLE
Disable proposal publish button when form invalid

### DIFF
--- a/frontend/src/app/features/reports/reports-page.component.html
+++ b/frontend/src/app/features/reports/reports-page.component.html
@@ -223,7 +223,7 @@
                         type="button"
                         class="button button--secondary focus-ring"
                         (click)="publishProposal(index)"
-                        [disabled]="publishPending()"
+                        [disabled]="publishPending() || proposal.invalid"
                       >
                         この提案をカードに追加
                       </button>


### PR DESCRIPTION
## Summary
- disable the report assistant proposal publish button when required fields are missing to prevent creating incomplete cards

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68dbed02c5cc83208c29ce55220f5c3b