### PR TITLE
Prevent deleting system default template

### DIFF
--- a/backend/app/routers/workspace_templates.py
+++ b/backend/app/routers/workspace_templates.py
@@ -216,5 +216,10 @@ def delete_template(
     current_user: models.User = Depends(get_current_user),
 ) -> Response:
     template = _get_owned_template(db, owner_id=current_user.id, template_id=template_id)
+    if template.is_system_default:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="System default template cannot be deleted.",
+        )
     delete_model(db, template)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/frontend/src/app/core/api/workspace-config-api.service.ts
+++ b/frontend/src/app/core/api/workspace-config-api.service.ts
@@ -61,6 +61,7 @@ export interface WorkspaceTemplateResponse {
   readonly default_label_ids?: readonly string[] | null;
   readonly confidence_threshold: number;
   readonly field_visibility: WorkspaceTemplateFieldVisibilityResponse;
+  readonly is_system_default: boolean;
   readonly created_at: string;
   readonly updated_at: string;
 }

--- a/frontend/src/app/core/models/workspace.ts
+++ b/frontend/src/app/core/models/workspace.ts
@@ -46,6 +46,7 @@ export interface TemplatePreset {
   readonly defaultLabelIds: readonly string[];
   readonly confidenceThreshold: number;
   readonly fieldVisibility: TemplateFieldVisibility;
+  readonly isSystemDefault: boolean;
 }
 
 /**

--- a/frontend/src/app/features/settings/page.html
+++ b/frontend/src/app/features/settings/page.html
@@ -181,13 +181,6 @@
                 >
                   キャンセル
                 </button>
-                <button
-                  type="button"
-                  class="button button--danger button--pill"
-                  (click)="removeTemplate(template.id)"
-                >
-                  削除
-                </button>
               } @else {
                 <button
                   type="button"
@@ -196,13 +189,19 @@
                 >
                   編集
                 </button>
-                <button
-                  type="button"
-                  class="button button--danger button--pill"
-                  (click)="removeTemplate(template.id)"
-                >
-                  削除
-                </button>
+              }
+              <button
+                type="button"
+                class="button button--danger button--pill"
+                [disabled]="template.isSystemDefault"
+                [attr.aria-disabled]="template.isSystemDefault"
+                title="標準テンプレートは削除できません"
+                (click)="removeTemplate(template.id)"
+              >
+                削除
+              </button>
+              @if (template.isSystemDefault) {
+                <span class="settings-template__note">標準テンプレートは削除できません</span>
               }
             </div>
           </div>

--- a/frontend/src/app/features/settings/page.ts
+++ b/frontend/src/app/features/settings/page.ts
@@ -276,6 +276,11 @@ export class SettingsPage {
    * @param templateId - Identifier of the template to remove.
    */
   public readonly removeTemplate = async (templateId: string): Promise<void> => {
+    const template = this.settingsSignal().templates.find((entry) => entry.id === templateId);
+    if (!template || template.isSystemDefault) {
+      return;
+    }
+
     try {
       await this.workspace.removeTemplate(templateId);
       if (this.editingTemplateId() === templateId) {


### PR DESCRIPTION
## Summary
- block deletion of the system default workspace template and cover the behavior with a regression test
- expose the system-default flag to the Angular workspace store, sort defaults first, and skip deletion attempts client-side
- disable the delete action for the standard template in the settings UI and show a helper note

## Testing
- pytest backend/tests/test_workspace_templates.py
- CI=1 npm test -- --watch=false --code-coverage=false *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing)*
- npx prettier --check src/app/core/api/workspace-config-api.service.ts src/app/core/models/workspace.ts src/app/core/state/workspace-store.ts src/app/features/settings/page.html src/app/features/settings/page.ts


------
https://chatgpt.com/codex/tasks/task_e_68dbef9419888320b27fe422d7c078a2