### PR TITLE
Stack report proposals vertically

### DIFF
--- a/frontend/src/app/features/reports/reports-page.component.html
+++ b/frontend/src/app/features/reports/reports-page.component.html
@@ -203,7 +203,7 @@
           </div>
 
           <ng-container *ngIf="proposalControls.length > 0; else emptyProposals">
-            <ul class="page-list" aria-label="提案中のタスク">
+            <ul class="page-list page-list--stacked" aria-label="提案中のタスク">
               <li class="page-list__item" *ngFor="let proposal of proposalControls; index as index">
                 <div class="report-assistant-page__proposal-editor" [formGroup]="proposal">
                   <div class="report-assistant-page__proposal-header">

--- a/frontend/src/styles/pages/_base.scss
+++ b/frontend/src/styles/pages/_base.scss
@@ -358,6 +358,10 @@
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
 }
 
+.page-list--stacked {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .page-list__item {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- ensure report assistant proposals use the stacked list layout so suggested tasks always render vertically
- add a reusable `.page-list--stacked` utility modifier for single-column list presentations

## Testing
- npx prettier --check src/app/features/reports/reports-page.component.html src/styles/pages/_base.scss

------
https://chatgpt.com/codex/tasks/task_e_68dbe3b9cd688320af58a0994f746c2f