### PR TITLE
Update documentation for global error handling flows

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,10 @@ Use this index to locate the specs, playbooks, and references that keep Verbaliz
 - **Governance & competencies**: [Governance feature requirements](features/governance/requirements.md) and [Competency evaluations workflow](features/competency-evaluations/requirements.md).
 - **Analytics**: [Analytics insights requirements](features/analytics-insights/requirements.md) plus the [analysis intake detail design](features/analysis-intake/detail-design.md) for proposal handling internals.
 
+## Spec Updates & Implementation Notes
+- [HTTP error interceptor requirements](spec-updates/http-error-interceptor.md) – Shared error handling banner and notifier contract for API failures.
+- [Notification layer relocation](spec-updates/toast-layer-layout.md) – Placement rules for the global error banner, hover message stack, and analyzer toasts.
+
 ## Prompts & Automation
 - [`prompts/`](../prompts) – Prompt references for AI interactions used by backend services and content moderation flows.
 - [`scripts/`](../scripts) – Operational scripts, including the Codex automation pipeline and helper launchers for MCP servers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,7 @@ HTTP concerns are centralised under `core/api`:
 - `workspace-config-api.service.ts` wraps `/statuses`, `/labels`, and `/workspace/templates` plus related request/response contracts.
 - `analysis-gateway.ts` posts analyzer submissions to `/analysis`, maps persisted responses into workspace proposals, and surfaces them to the UI.
 - `status-reports-gateway.ts`, `admin-api.service.ts`, and `competency-api.service.ts` cover the remaining feature areas.
+- `loading.interceptor.ts` and `error.interceptor.ts` wrap HTTP traffic so loading indicators and the global error banner stay in sync via `HttpErrorNotifierService`.
 
 ### UI and UX
 - Tailwind-inspired design tokens live in `frontend/src/styles/pages`, with per-feature SCSS providing layout and component styling.

--- a/docs/ui-design-system.md
+++ b/docs/ui-design-system.md
@@ -126,6 +126,9 @@ Use `--border-card` / `--border-card-strong` as the default borders and reserve 
 
 ### Feedback & Empty States
 - Use `app-alert` for success/warning/error messages with four parts: icon, title, description, and action.
+- Surface blocking API failures through the Shell's `.shell-global-error` banner anchored to the top centre. The HTTP error interceptor feeds this banner so every dismissible alert announces with `role="alert"` and stays readable on mobile widths.
+- Route optimistic success/info notifications (profile saves, workspace hints) through the hover message stack in the bottom-right corner. Keep messages concise so the stack never obscures critical UI elements.
+- Analytics intake toasts (`.analyze-page__toast`) appear along the bottom centre and reuse blurred pill styling for progress, success, and failure states without colliding with the global banner.
 - Empty and loading states use `.page-state` with monochrome line icons around 64px.
 
 ### Dialogs / Modals


### PR DESCRIPTION
## Summary
- document the HTTP loading and error interceptors in the frontend architecture overview
- expand the design system guidance with placement details for the global error banner and toast stacks
- surface the latest spec updates for error handling and notification layout in the documentation index

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dc411c123483208a66d93ac40b5fe4