### PR TITLE
Add SQLAlchemy dependency for backend tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi>=0.110.0,<1.0.0
 google-generativeai>=0.5.0,<1.0.0
+SQLAlchemy>=2.0.0,<3.0.0


### PR DESCRIPTION
## Summary
- add SQLAlchemy to the root requirements so pytest can import backend fixtures

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68dc55a83a1c832090b211dc4a122835