### PR TITLE
Replace XOR secret cipher with authenticated encryption

### DIFF
--- a/backend/app/utils/secrets.py
+++ b/backend/app/utils/secrets.py
@@ -52,6 +52,12 @@ def build_secret_hint(secret: str, *, mask_char: str = _DEFAULT_MASK_CHAR) -> st
         masked_length = max(length - (visible * 2), visible)
         return prefix + (mask_char * masked_length) + suffix
 
+    if length <= 8:
+        prefix_length = 1 if length > 1 else 0
+        prefix = secret[:prefix_length]
+        masked_length = max(length - prefix_length, visible)
+        return prefix + (mask_char * masked_length)
+
     prefix_length = min(visible, max(1, length // 2))
     suffix_length = max(length - prefix_length, 1)
     prefix = secret[:prefix_length]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ httpx==0.27.2
 google-generativeai>=0.5.0,<1.0.0
 Pillow==10.4.0
 Jinja2>=3.1.4,<4.0.0
+cryptography>=42.0.0,<44.0.0


### PR DESCRIPTION
## Summary
- replace the legacy XOR-based `SecretCipher` with a Fernet-backed authenticated encryption scheme while preserving legacy payload support
- harden secret hint masking to avoid revealing short values and adjust related tests
- add the cryptography dependency and refresh tests covering secret utilities

## Testing
- pytest backend/tests
- ruff check backend/app/utils/crypto.py backend/app/utils/secrets.py backend/tests/utils/test_secrets.py
- black --check backend/app/utils/crypto.py backend/app/utils/secrets.py backend/tests/utils/test_secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68dc54aa95ac83209003f1e83e16ab92