### PR TITLE
Add email-validator dependency for backend tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.110.0,<1.0.0
 google-generativeai>=0.5.0,<1.0.0
 SQLAlchemy>=2.0.0,<3.0.0
+email-validator==2.1.1


### PR DESCRIPTION
## Summary
- add the missing email-validator dependency to the shared requirements used by backend tests

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68dc58c8db3883208f9dd53626f3e004