### PR TITLE
Add missing backend dependencies to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ fastapi>=0.110.0,<1.0.0
 google-generativeai>=0.5.0,<1.0.0
 SQLAlchemy>=2.0.0,<3.0.0
 email-validator==2.1.1
+Jinja2>=3.1.4,<4.0.0
+Pillow>=10.4.0,<11.0.0
+cryptography>=42.0.0,<44.0.0
+python-multipart>=0.0.7,<0.0.10


### PR DESCRIPTION
## Summary
- include the optional backend runtime libraries in the root requirements so the test image installs them

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68dc5bf13e848320ba2abe830cb51688