### PR TITLE
Add frontend API gateway specs to raise coverage

### DIFF
--- a/frontend/src/app/core/api/admin-api.service.spec.ts
+++ b/frontend/src/app/core/api/admin-api.service.spec.ts
@@ -1,0 +1,80 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { AdminApiService } from './admin-api.service';
+import { buildApiUrl } from './api.config';
+
+describe('AdminApiService', () => {
+  let service: AdminApiService;
+  let httpMock: HttpTestingController;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AdminApiService],
+    });
+
+    service = TestBed.inject(AdminApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+    baseUrl = buildApiUrl('/');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('maps each admin endpoint to the expected HTTP request', () => {
+    service.listCompetencies().subscribe();
+    httpMock.expectOne(`${baseUrl}admin/competencies`).flush([]);
+
+    service.createCompetency({ name: 'AI literacy' } as never).subscribe();
+    const createCompetency = httpMock.expectOne(`${baseUrl}admin/competencies`);
+    expect(createCompetency.request.method).toBe('POST');
+    createCompetency.flush({ id: 'competency-1' });
+
+    service.updateCompetency('competency-1', { description: 'Updated' }).subscribe();
+    const updateCompetency = httpMock.expectOne(`${baseUrl}admin/competencies/competency-1`);
+    expect(updateCompetency.request.method).toBe('PATCH');
+    updateCompetency.flush({ id: 'competency-1' });
+
+    service.triggerEvaluation('competency-1', { user_id: 'user-1' } as never).subscribe();
+    const triggerEvaluation = httpMock.expectOne(
+      `${baseUrl}admin/competencies/competency-1/evaluate`,
+    );
+    expect(triggerEvaluation.request.method).toBe('POST');
+    triggerEvaluation.flush({ id: 'evaluation-1' });
+
+    service.listEvaluations().subscribe();
+    httpMock.expectOne(`${baseUrl}admin/evaluations`).flush([]);
+
+    service.listUsers().subscribe();
+    httpMock.expectOne(`${baseUrl}admin/users`).flush([]);
+
+    service.updateUser('user-1', { role: 'owner' } as never).subscribe();
+    const updateUser = httpMock.expectOne(`${baseUrl}admin/users/user-1`);
+    expect(updateUser.request.method).toBe('PATCH');
+    updateUser.flush({ id: 'user-1' });
+
+    service.deleteUser('user-1').subscribe();
+    const deleteUser = httpMock.expectOne(`${baseUrl}admin/users/user-1`);
+    expect(deleteUser.request.method).toBe('DELETE');
+    deleteUser.flush(null);
+
+    service.getApiCredential('openai').subscribe();
+    httpMock.expectOne(`${baseUrl}admin/api-credentials/openai`).flush({ provider: 'openai' });
+
+    service.upsertApiCredential('openai', { api_key: 'secret' } as never).subscribe();
+    const upsertCredential = httpMock.expectOne(`${baseUrl}admin/api-credentials/openai`);
+    expect(upsertCredential.request.method).toBe('PUT');
+    upsertCredential.flush({ provider: 'openai' });
+
+    service.getQuotaDefaults().subscribe();
+    httpMock.expectOne(`${baseUrl}admin/quotas/defaults`).flush({ daily: 10 });
+
+    service.updateQuotaDefaults({ daily: 20 } as never).subscribe();
+    const updateQuotaDefaults = httpMock.expectOne(`${baseUrl}admin/quotas/defaults`);
+    expect(updateQuotaDefaults.request.method).toBe('PUT');
+    updateQuotaDefaults.flush({ daily: 20 });
+  });
+});

--- a/frontend/src/app/core/api/board-layouts-api.service.spec.ts
+++ b/frontend/src/app/core/api/board-layouts-api.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { BoardLayoutsApiService } from './board-layouts-api.service';
+import { buildApiUrl } from './api.config';
+
+describe('BoardLayoutsApiService', () => {
+  let service: BoardLayoutsApiService;
+  let httpMock: HttpTestingController;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [BoardLayoutsApiService],
+    });
+
+    service = TestBed.inject(BoardLayoutsApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+    baseUrl = buildApiUrl('/');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('retrieves and updates board layout preferences', () => {
+    service.getBoardLayout().subscribe();
+    httpMock.expectOne(`${baseUrl}board-layouts`).flush({ user_id: 'user-1' });
+
+    service.updateBoardLayout({ visible_fields: ['status'] } as never).subscribe();
+    const updateRequest = httpMock.expectOne(`${baseUrl}board-layouts`);
+    expect(updateRequest.request.method).toBe('PUT');
+    expect(updateRequest.request.body).toEqual({ visible_fields: ['status'] });
+    updateRequest.flush({ user_id: 'user-1' });
+  });
+});

--- a/frontend/src/app/core/api/cards-api.service.spec.ts
+++ b/frontend/src/app/core/api/cards-api.service.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import {
+  CardsApiService,
+  CardCreateRequest,
+  CardUpdateRequest,
+  SubtaskCreateRequest,
+  SubtaskUpdateRequest,
+} from './cards-api.service';
+import { buildApiUrl } from './api.config';
+
+describe('CardsApiService', () => {
+  let service: CardsApiService;
+  let httpMock: HttpTestingController;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [CardsApiService],
+    });
+
+    service = TestBed.inject(CardsApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+    baseUrl = buildApiUrl('/');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('builds query parameters for listCards while filtering empty values', () => {
+    service
+      .listCards({
+        statusId: 'status-1',
+        labelIds: ['label-1', '  ', undefined as unknown as string],
+        statusIds: ['status-2', null as unknown as string],
+        assignees: ['alice', ''],
+        priorities: ['high', 'low'],
+        createdFrom: '2025-02-01',
+        createdTo: '2025-02-28',
+        dueFrom: '2025-02-10',
+        dueTo: undefined,
+        timeRange: 'last_7_days',
+        search: '  backend  ',
+      })
+      .subscribe();
+
+    const request = httpMock.expectOne((req) => req.url === `${baseUrl}cards`);
+    expect(request.request.method).toBe('GET');
+
+    const params = request.request.params;
+    expect(params.get('status_id')).toBe('status-1');
+    expect(params.getAll('label_ids')).toEqual(['label-1']);
+    expect(params.getAll('status_ids')).toEqual(['status-2']);
+    expect(params.getAll('assignees')).toEqual(['alice']);
+    expect(params.getAll('priorities')).toEqual(['high', 'low']);
+    expect(params.get('created_from')).toBe('2025-02-01');
+    expect(params.get('created_to')).toBe('2025-02-28');
+    expect(params.get('due_from')).toBe('2025-02-10');
+    expect(params.get('due_to')).toBeNull();
+    expect(params.get('time_range')).toBe('last_7_days');
+    expect(params.get('search')).toBe('backend');
+
+    request.flush([]);
+  });
+
+  it('omits params when listCards is called without arguments', () => {
+    service.listCards().subscribe();
+
+    const request = httpMock.expectOne(`${baseUrl}cards`);
+    expect(request.request.method).toBe('GET');
+    expect(request.request.params.keys()).toEqual([]);
+
+    request.flush([]);
+  });
+
+  it('supports all CRUD operations for cards and subtasks', () => {
+    const createPayload = { title: 'Create API card' } as CardCreateRequest;
+    const updatePayload = { title: 'Updated title' } as CardUpdateRequest;
+    const subtaskCreate = { title: 'Initial subtask' } as SubtaskCreateRequest;
+    const subtaskUpdate = { title: 'Updated subtask' } as SubtaskUpdateRequest;
+
+    service.createCard(createPayload).subscribe();
+    const createRequest = httpMock.expectOne(`${baseUrl}cards`);
+    expect(createRequest.request.method).toBe('POST');
+    expect(createRequest.request.body).toBe(createPayload);
+    createRequest.flush({ id: 'card-1' });
+
+    service.updateCard('card-1', updatePayload).subscribe();
+    const updateRequest = httpMock.expectOne(`${baseUrl}cards/card-1`);
+    expect(updateRequest.request.method).toBe('PUT');
+    expect(updateRequest.request.body).toBe(updatePayload);
+    updateRequest.flush({ id: 'card-1' });
+
+    service.deleteCard('card-1').subscribe();
+    const deleteRequest = httpMock.expectOne(`${baseUrl}cards/card-1`);
+    expect(deleteRequest.request.method).toBe('DELETE');
+    deleteRequest.flush(null);
+
+    service.createSubtask('card-1', subtaskCreate).subscribe();
+    const subtaskCreateRequest = httpMock.expectOne(`${baseUrl}cards/card-1/subtasks`);
+    expect(subtaskCreateRequest.request.method).toBe('POST');
+    expect(subtaskCreateRequest.request.body).toBe(subtaskCreate);
+    subtaskCreateRequest.flush({ id: 'subtask-1' });
+
+    service.updateSubtask('card-1', 'subtask-1', subtaskUpdate).subscribe();
+    const subtaskUpdateRequest = httpMock.expectOne(`${baseUrl}cards/card-1/subtasks/subtask-1`);
+    expect(subtaskUpdateRequest.request.method).toBe('PUT');
+    expect(subtaskUpdateRequest.request.body).toBe(subtaskUpdate);
+    subtaskUpdateRequest.flush({ id: 'subtask-1' });
+
+    service.deleteSubtask('card-1', 'subtask-1').subscribe();
+    const subtaskDeleteRequest = httpMock.expectOne(`${baseUrl}cards/card-1/subtasks/subtask-1`);
+    expect(subtaskDeleteRequest.request.method).toBe('DELETE');
+    subtaskDeleteRequest.flush(null);
+  });
+});

--- a/frontend/src/app/core/api/comments-api.service.spec.ts
+++ b/frontend/src/app/core/api/comments-api.service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { CommentsApiService } from './comments-api.service';
+import { buildApiUrl } from './api.config';
+
+describe('CommentsApiService', () => {
+  let service: CommentsApiService;
+  let httpMock: HttpTestingController;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [CommentsApiService],
+    });
+
+    service = TestBed.inject(CommentsApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+    baseUrl = buildApiUrl('/');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('performs CRUD requests for comments', () => {
+    const createPayload = { card_id: 'card-1', content: 'First comment' } as never;
+    const updatePayload = { content: 'Updated comment' } as never;
+
+    service.createComment(createPayload).subscribe();
+    const createRequest = httpMock.expectOne(`${baseUrl}comments`);
+    expect(createRequest.request.method).toBe('POST');
+    expect(createRequest.request.body).toBe(createPayload);
+    createRequest.flush({ id: 'comment-1' });
+
+    service.updateComment('comment-1', updatePayload).subscribe();
+    const updateRequest = httpMock.expectOne(`${baseUrl}comments/comment-1`);
+    expect(updateRequest.request.method).toBe('PUT');
+    expect(updateRequest.request.body).toBe(updatePayload);
+    updateRequest.flush({ id: 'comment-1' });
+
+    service.deleteComment('comment-1').subscribe();
+    const deleteRequest = httpMock.expectOne(`${baseUrl}comments/comment-1`);
+    expect(deleteRequest.request.method).toBe('DELETE');
+    deleteRequest.flush(null);
+  });
+});

--- a/frontend/src/app/core/api/competency-api.service.spec.ts
+++ b/frontend/src/app/core/api/competency-api.service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { CompetencyApiService } from './competency-api.service';
+import { buildApiUrl } from './api.config';
+
+describe('CompetencyApiService', () => {
+  let service: CompetencyApiService;
+  let httpMock: HttpTestingController;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [CompetencyApiService],
+    });
+
+    service = TestBed.inject(CompetencyApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+    baseUrl = buildApiUrl('/');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('fetches evaluations with optional limits and manages quota', () => {
+    service.getMyEvaluations().subscribe();
+    const listRequest = httpMock.expectOne(`${baseUrl}users/me/evaluations`);
+    expect(listRequest.request.params.keys()).toEqual([]);
+    listRequest.flush([]);
+
+    service.getMyEvaluations(5).subscribe();
+    const limitedRequest = httpMock.expectOne(
+      (req) => req.url === `${baseUrl}users/me/evaluations` && req.params.get('limit') === '5',
+    );
+    expect(limitedRequest.request.method).toBe('GET');
+    limitedRequest.flush([]);
+
+    service.getMyEvaluationQuota().subscribe();
+    httpMock.expectOne(`${baseUrl}users/me/evaluations/quota`).flush({ remaining: 3 });
+
+    service.runMyEvaluation({ answers: [] } as never).subscribe();
+    const runRequest = httpMock.expectOne(`${baseUrl}users/me/evaluations`);
+    expect(runRequest.request.method).toBe('POST');
+    runRequest.flush({ id: 'evaluation-1' });
+  });
+});

--- a/frontend/src/app/core/api/http-error-notifier.service.spec.ts
+++ b/frontend/src/app/core/api/http-error-notifier.service.spec.ts
@@ -1,0 +1,32 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HttpErrorNotifierService } from './http-error-notifier.service';
+
+describe('HttpErrorNotifierService', () => {
+  let service: HttpErrorNotifierService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [HttpErrorNotifierService],
+    });
+
+    service = TestBed.inject(HttpErrorNotifierService);
+  });
+
+  it('publishes the latest error message and clears it on demand', () => {
+    expect(service.message()).toBeNull();
+
+    service.notify('初回のエラー');
+    const firstSnapshot = service.message();
+    expect(firstSnapshot).toBe('初回のエラー');
+
+    service.notify('初回のエラー');
+    expect(service.message()).toBe('初回のエラー');
+
+    service.notify('再試行してください');
+    expect(service.message()).toBe('再試行してください');
+
+    service.clear();
+    expect(service.message()).toBeNull();
+  });
+});

--- a/frontend/src/app/core/api/status-reports-gateway.spec.ts
+++ b/frontend/src/app/core/api/status-reports-gateway.spec.ts
@@ -1,0 +1,127 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { StatusReportsGateway } from './status-reports-gateway';
+import {
+  StatusReportCreateRequest,
+  StatusReportDetail,
+  StatusReportListItem,
+  StatusReportRead,
+  StatusReportUpdateRequest,
+} from '@core/models';
+import { buildApiUrl } from './api.config';
+
+const baseTimestamp = '2025-02-01T00:00:00.000Z';
+
+const buildRead = (overrides: Partial<StatusReportRead> = {}): StatusReportRead => ({
+  id: 'report-1',
+  shift_type: 'remote',
+  tags: ['daily'],
+  status: 'draft',
+  auto_ticket_enabled: true,
+  sections: [],
+  analysis_model: null,
+  analysis_started_at: null,
+  analysis_completed_at: null,
+  failure_reason: null,
+  confidence: null,
+  created_at: baseTimestamp,
+  updated_at: baseTimestamp,
+  ...overrides,
+});
+
+const buildDetail = (overrides: Partial<StatusReportDetail> = {}): StatusReportDetail => ({
+  ...buildRead(overrides),
+  cards: [],
+  events: [],
+  processing_meta: {},
+  pending_proposals: [],
+  ...overrides,
+});
+
+describe('StatusReportsGateway', () => {
+  let gateway: StatusReportsGateway;
+  let httpMock: HttpTestingController;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [StatusReportsGateway],
+    });
+
+    gateway = TestBed.inject(StatusReportsGateway);
+    httpMock = TestBed.inject(HttpTestingController);
+    baseUrl = buildApiUrl('/');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('lists reports with provided query parameters', () => {
+    let response: StatusReportListItem[] | undefined;
+
+    gateway.listReports({ status: 'completed' }).subscribe((value) => {
+      response = value;
+    });
+
+    const request = httpMock.expectOne(
+      (req) => req.url === `${baseUrl}status-reports` && req.params.get('status') === 'completed',
+    );
+    expect(request.request.method).toBe('GET');
+    request.flush([] satisfies StatusReportListItem[]);
+
+    expect(response).toEqual([]);
+  });
+
+  it('lists reports without adding empty parameters', () => {
+    gateway.listReports({ status: '' }).subscribe();
+
+    const request = httpMock.expectOne(`${baseUrl}status-reports`);
+    expect(request.request.method).toBe('GET');
+    expect(request.request.params.keys()).toEqual([]);
+    request.flush([]);
+  });
+
+  it('creates, updates, fetches, submits and retries reports', () => {
+    const createPayload: StatusReportCreateRequest = {
+      shift_type: 'remote',
+      tags: ['daily'],
+      sections: [{ title: '対応内容', body: 'モニタリングを強化' }],
+      auto_ticket_enabled: true,
+    };
+    const updatePayload: StatusReportUpdateRequest = {
+      auto_ticket_enabled: false,
+    };
+
+    gateway.createReport(createPayload).subscribe();
+    const createRequest = httpMock.expectOne(`${baseUrl}status-reports`);
+    expect(createRequest.request.method).toBe('POST');
+    expect(createRequest.request.body).toBe(createPayload);
+    createRequest.flush(buildRead());
+
+    gateway.updateReport('report-1', updatePayload).subscribe();
+    const updateRequest = httpMock.expectOne(`${baseUrl}status-reports/report-1`);
+    expect(updateRequest.request.method).toBe('PUT');
+    expect(updateRequest.request.body).toBe(updatePayload);
+    updateRequest.flush(buildRead({ auto_ticket_enabled: false }));
+
+    gateway.getReport('report-1').subscribe();
+    const getRequest = httpMock.expectOne(`${baseUrl}status-reports/report-1`);
+    expect(getRequest.request.method).toBe('GET');
+    getRequest.flush(buildDetail());
+
+    gateway.submitReport('report-1').subscribe();
+    const submitRequest = httpMock.expectOne(`${baseUrl}status-reports/report-1/submit`);
+    expect(submitRequest.request.method).toBe('POST');
+    expect(submitRequest.request.body).toEqual({});
+    submitRequest.flush(buildDetail({ status: 'completed' }));
+
+    gateway.retryReport('report-1').subscribe();
+    const retryRequest = httpMock.expectOne(`${baseUrl}status-reports/report-1/retry`);
+    expect(retryRequest.request.method).toBe('POST');
+    expect(retryRequest.request.body).toEqual({});
+    retryRequest.flush(buildDetail({ status: 'completed' }));
+  });
+});

--- a/frontend/src/app/core/api/workspace-config-api.service.spec.ts
+++ b/frontend/src/app/core/api/workspace-config-api.service.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { WorkspaceConfigApiService } from './workspace-config-api.service';
+import { buildApiUrl } from './api.config';
+
+describe('WorkspaceConfigApiService', () => {
+  let service: WorkspaceConfigApiService;
+  let httpMock: HttpTestingController;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [WorkspaceConfigApiService],
+    });
+
+    service = TestBed.inject(WorkspaceConfigApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+    baseUrl = buildApiUrl('/');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('manages statuses, labels and templates through dedicated endpoints', () => {
+    service.listStatuses().subscribe();
+    httpMock.expectOne(`${baseUrl}statuses`).flush([]);
+
+    service.createStatus({ name: 'In Review' } as never).subscribe();
+    const createStatus = httpMock.expectOne(`${baseUrl}statuses`);
+    expect(createStatus.request.method).toBe('POST');
+    createStatus.flush({ id: 'status-review' });
+
+    service.updateStatus('status-review', { color: '#facc15' }).subscribe();
+    const updateStatus = httpMock.expectOne(`${baseUrl}statuses/status-review`);
+    expect(updateStatus.request.method).toBe('PUT');
+    updateStatus.flush({ id: 'status-review' });
+
+    service.deleteStatus('status-review').subscribe();
+    const deleteStatus = httpMock.expectOne(`${baseUrl}statuses/status-review`);
+    expect(deleteStatus.request.method).toBe('DELETE');
+    deleteStatus.flush(null);
+
+    service.listLabels().subscribe();
+    httpMock.expectOne(`${baseUrl}labels`).flush([]);
+
+    service.createLabel({ name: 'Ops', color: '#2563eb' } as never).subscribe();
+    const createLabel = httpMock.expectOne(`${baseUrl}labels`);
+    expect(createLabel.request.method).toBe('POST');
+    createLabel.flush({ id: 'label-ops' });
+
+    service.updateLabel('label-ops', { color: '#1d4ed8' }).subscribe();
+    const updateLabel = httpMock.expectOne(`${baseUrl}labels/label-ops`);
+    expect(updateLabel.request.method).toBe('PUT');
+    updateLabel.flush({ id: 'label-ops' });
+
+    service.deleteLabel('label-ops').subscribe();
+    const deleteLabel = httpMock.expectOne(`${baseUrl}labels/label-ops`);
+    expect(deleteLabel.request.method).toBe('DELETE');
+    deleteLabel.flush(null);
+
+    service.listTemplates().subscribe();
+    httpMock.expectOne(`${baseUrl}workspace/templates`).flush([]);
+
+    service.createTemplate({ name: 'Default' } as never).subscribe();
+    const createTemplate = httpMock.expectOne(`${baseUrl}workspace/templates`);
+    expect(createTemplate.request.method).toBe('POST');
+    createTemplate.flush({ id: 'template-1' });
+
+    service.updateTemplate('template-1', { description: 'Updated' }).subscribe();
+    const updateTemplate = httpMock.expectOne(`${baseUrl}workspace/templates/template-1`);
+    expect(updateTemplate.request.method).toBe('PATCH');
+    updateTemplate.flush({ id: 'template-1' });
+
+    service.deleteTemplate('template-1').subscribe();
+    const deleteTemplate = httpMock.expectOne(`${baseUrl}workspace/templates/template-1`);
+    expect(deleteTemplate.request.method).toBe('DELETE');
+    deleteTemplate.flush(null);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jasmine specs for the admin, workspace, board layout, and status report gateways to verify URL construction and payload handling
- exercise CardsApiService parameter normalization together with comments and competency API CRUD flows
- cover the HttpErrorNotifierService signal to ensure error state publication is observable

## Testing
- npm run format:check
- npm run lint
- npm run test:ci *(fails: ChromeHeadless missing libatk shared library)*

------
https://chatgpt.com/codex/tasks/task_e_68dc60e8112c8320bdcd5a00371c450b