### PR TITLE
Refactor test assertions and harden report subtasks

### DIFF
--- a/backend/tests/test_admin_settings.py
+++ b/backend/tests/test_admin_settings.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest import TestCase
+
 from fastapi.testclient import TestClient
 
 from app import models
@@ -7,16 +9,18 @@ from app.utils.secrets import build_secret_hint, get_secret_cipher
 
 from .conftest import TestingSessionLocal
 
+assertions = TestCase()
+
 
 def _admin_headers(client: TestClient) -> dict[str, str]:
     email = "owner@example.com"
     password = "AdminPass123!"  # noqa: S105 - test credential
 
     register = client.post("/auth/register", json={"email": email, "password": password})
-    assert register.status_code == 201, register.text
+    assertions.assertTrue(register.status_code == 201, register.text)
 
     login = client.post("/auth/login", json={"email": email, "password": password})
-    assert login.status_code == 200, login.text
+    assertions.assertTrue(login.status_code == 200, login.text)
     token = login.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
 
@@ -29,25 +33,25 @@ def test_admin_can_update_gemini_model_without_rotating_secret(client: TestClien
         headers=headers,
         json={"secret": "sk-original", "model": "gemini-1.5-pro"},
     )
-    assert create.status_code == 200, create.text
+    assertions.assertTrue(create.status_code == 200, create.text)
     created_payload = create.json()
-    assert created_payload["model"] == "gemini-1.5-pro"
-    assert created_payload["secret_hint"]
+    assertions.assertTrue(created_payload["model"] == "gemini-1.5-pro")
+    assertions.assertTrue(created_payload["secret_hint"])
 
     update = client.put(
         "/admin/api-credentials/gemini",
         headers=headers,
         json={"model": "gemini-1.5-flash"},
     )
-    assert update.status_code == 200, update.text
+    assertions.assertTrue(update.status_code == 200, update.text)
     updated_payload = update.json()
-    assert updated_payload["model"] == "models/gemini-1.5-flash"
-    assert updated_payload["secret_hint"] == created_payload["secret_hint"]
+    assertions.assertTrue(updated_payload["model"] == "models/gemini-1.5-flash")
+    assertions.assertTrue(updated_payload["secret_hint"] == created_payload["secret_hint"])
 
     fetch = client.get("/admin/api-credentials/gemini", headers=headers)
-    assert fetch.status_code == 200, fetch.text
+    assertions.assertTrue(fetch.status_code == 200, fetch.text)
     fetched_payload = fetch.json()
-    assert fetched_payload["model"] == "models/gemini-1.5-flash"
+    assertions.assertTrue(fetched_payload["model"] == "models/gemini-1.5-flash")
 
 
 def test_admin_credentials_use_default_secret_key(client: TestClient) -> None:
@@ -59,20 +63,20 @@ def test_admin_credentials_use_default_secret_key(client: TestClient) -> None:
         headers=headers,
         json={"secret": secret, "model": "models/gemini-1.5-flash"},
     )
-    assert create.status_code == 200, create.text
+    assertions.assertTrue(create.status_code == 200, create.text)
 
     with TestingSessionLocal() as db:
         credential = db.query(models.ApiCredential).filter(models.ApiCredential.provider == "gemini").one()
 
     cipher = get_secret_cipher()
     decrypted = cipher.decrypt(credential.encrypted_secret)
-    assert decrypted.plaintext == secret
-    assert decrypted.reencrypted_payload is None
+    assertions.assertTrue(decrypted.plaintext == secret)
+    assertions.assertTrue(decrypted.reencrypted_payload is None)
 
     fetch = client.get("/admin/api-credentials/gemini", headers=headers)
-    assert fetch.status_code == 200, fetch.text
+    assertions.assertTrue(fetch.status_code == 200, fetch.text)
     payload = fetch.json()
-    assert payload["secret_hint"] == build_secret_hint(secret)
+    assertions.assertTrue(payload["secret_hint"] == build_secret_hint(secret))
 
 
 def test_admin_cannot_create_credential_without_secret(client: TestClient) -> None:
@@ -83,8 +87,8 @@ def test_admin_cannot_create_credential_without_secret(client: TestClient) -> No
         headers=headers,
         json={"model": "gemini-1.5-pro"},
     )
-    assert response.status_code == 400, response.text
-    assert response.json()["detail"] == "API トークンを入力してください。"
+    assertions.assertTrue(response.status_code == 400, response.text)
+    assertions.assertTrue(response.json()["detail"] == "API トークンを入力してください。")
 
 
 def test_existing_gemini_credential_is_accessible_via_case_insensitive_alias(client: TestClient) -> None:
@@ -92,7 +96,7 @@ def test_existing_gemini_credential_is_accessible_via_case_insensitive_alias(cli
 
     with TestingSessionLocal() as db:
         user = db.query(models.User).filter(models.User.email == "owner@example.com").first()
-        assert user is not None
+        assertions.assertTrue(user is not None)
 
         cipher = get_secret_cipher()
         secret = "sk-alias-token"  # noqa: S105 - test secret
@@ -108,7 +112,7 @@ def test_existing_gemini_credential_is_accessible_via_case_insensitive_alias(cli
         db.commit()
 
     fetch = client.get("/admin/api-credentials/gemini", headers=headers)
-    assert fetch.status_code == 200, fetch.text
+    assertions.assertTrue(fetch.status_code == 200, fetch.text)
     payload = fetch.json()
-    assert payload["model"] == "gemini-1.5-pro"
-    assert payload["secret_hint"] == build_secret_hint("sk-alias-token")
+    assertions.assertTrue(payload["model"] == "gemini-1.5-pro")
+    assertions.assertTrue(payload["secret_hint"] == build_secret_hint("sk-alias-token"))

--- a/backend/tests/test_analysis.py
+++ b/backend/tests/test_analysis.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest import TestCase
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -9,6 +11,8 @@ from app.services.gemini import GeminiError, get_gemini_client
 
 from .conftest import TestingSessionLocal
 
+assertions = TestCase()
+
 
 def _register_and_login(client: TestClient, email: str) -> dict[str, str]:
     password = "Analysis123!"  # noqa: S105 - test credential
@@ -16,13 +20,13 @@ def _register_and_login(client: TestClient, email: str) -> dict[str, str]:
         "/auth/register",
         json={"email": email, "password": password},
     )
-    assert register.status_code == 201, register.text
+    assertions.assertEqual(register.status_code, 201, register.text)
 
     login = client.post(
         "/auth/login",
         json={"email": email, "password": password},
     )
-    assert login.status_code == 200, login.text
+    assertions.assertEqual(login.status_code, 200, login.text)
     token = login.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
 
@@ -38,9 +42,9 @@ def test_analysis_requires_api_key(client: TestClient) -> None:
     if response.status_code != 503:
         pytest.skip("Gemini integration is enabled; skipping configuration error assertion.")
 
-    assert response.status_code == 503
+    assertions.assertEqual(response.status_code, 503)
     payload = response.json()
-    assert "Gemini API key is not configured" in payload["detail"]
+    assertions.assertIn("Gemini API key is not configured", payload["detail"])
 
 
 def test_analysis_persists_session(client: TestClient) -> None:
@@ -69,9 +73,9 @@ def test_analysis_persists_session(client: TestClient) -> None:
             user_profile=None,
             workspace_options=None,
         ) -> schemas.AnalysisResponse:
-            assert request.text
-            assert workspace_options is not None
-            assert getattr(workspace_options, "statuses", ())
+            assertions.assertTrue(request.text)
+            assertions.assertIsNotNone(workspace_options)
+            assertions.assertTrue(getattr(workspace_options, "statuses", ()))
             return response_payload
 
     app.dependency_overrides[get_gemini_client] = lambda: StubGemini()
@@ -87,30 +91,30 @@ def test_analysis_persists_session(client: TestClient) -> None:
     finally:
         app.dependency_overrides.pop(get_gemini_client, None)
 
-    assert response.status_code == 200, response.text
+    assertions.assertEqual(response.status_code, 200, response.text)
     data = response.json()
-    assert data["model"] == "gemini-pro-test"
-    assert len(data["proposals"]) == 1
-    assert data["proposals"][0]["title"] == "Add login coverage"
-    assert data["proposals"][0]["labels"]
+    assertions.assertEqual(data["model"], "gemini-pro-test")
+    assertions.assertEqual(len(data["proposals"]), 1)
+    assertions.assertEqual(data["proposals"][0]["title"], "Add login coverage")
+    assertions.assertTrue(data["proposals"][0]["labels"])
 
     with TestingSessionLocal() as db:
         sessions = db.query(models.AnalysisSession).all()
-        assert len(sessions) == 1
+        assertions.assertEqual(len(sessions), 1)
         session = sessions[0]
-        assert session.status == "completed"
-        assert session.objective == "Improve QA coverage"
-        assert session.notes == "Login flow intermittently fails"
-        assert session.response_model == "gemini-pro-test"
-        assert session.proposals and session.proposals[0]["title"] == "Add login coverage"
+        assertions.assertEqual(session.status, "completed")
+        assertions.assertEqual(session.objective, "Improve QA coverage")
+        assertions.assertEqual(session.notes, "Login flow intermittently fails")
+        assertions.assertEqual(session.response_model, "gemini-pro-test")
+        assertions.assertTrue(session.proposals and session.proposals[0]["title"] == "Add login coverage")
 
         stored_labels = session.proposals[0].get("labels") or []
         returned_label_id = data["proposals"][0]["labels"][0]
-        assert stored_labels and stored_labels[0] == returned_label_id
+        assertions.assertTrue(stored_labels and stored_labels[0] == returned_label_id)
 
         labels = db.query(models.Label).filter(models.Label.owner_id == session.user_id).all()
-        assert labels
-        assert any(label.id == returned_label_id for label in labels)
+        assertions.assertTrue(labels)
+        assertions.assertTrue(any(label.id == returned_label_id for label in labels))
 
 
 def test_analysis_registers_new_labels(client: TestClient) -> None:
@@ -154,16 +158,16 @@ def test_analysis_registers_new_labels(client: TestClient) -> None:
     finally:
         app.dependency_overrides.pop(get_gemini_client, None)
 
-    assert response.status_code == 200, response.text
+    assertions.assertEqual(response.status_code, 200, response.text)
     data = response.json()
-    assert data["proposals"][0]["labels"]
+    assertions.assertTrue(data["proposals"][0]["labels"])
 
     with TestingSessionLocal() as db:
         user = db.query(models.User).filter(models.User.email == "analysis-labels@example.com").one()
         labels = db.query(models.Label).filter(models.Label.owner_id == user.id).all()
-        assert len(labels) == 1
-        assert labels[0].name == "Customer Advocacy"
-        assert data["proposals"][0]["labels"][0] == labels[0].id
+        assertions.assertEqual(len(labels), 1)
+        assertions.assertEqual(labels[0].name, "Customer Advocacy")
+        assertions.assertEqual(data["proposals"][0]["labels"][0], labels[0].id)
 
 
 def test_analysis_records_failure(client: TestClient) -> None:
@@ -192,12 +196,12 @@ def test_analysis_records_failure(client: TestClient) -> None:
     finally:
         app.dependency_overrides.pop(get_gemini_client, None)
 
-    assert response.status_code == 502
+    assertions.assertEqual(response.status_code, 502)
     detail = response.json()["detail"]
-    assert "Upstream failure" in detail
+    assertions.assertIn("Upstream failure", detail)
 
     with TestingSessionLocal() as db:
         session = db.query(models.AnalysisSession).one()
-        assert session.status == "failed"
-        assert session.failure_reason == "Upstream failure"
-        assert session.proposals == []
+        assertions.assertEqual(session.status, "failed")
+        assertions.assertEqual(session.failure_reason, "Upstream failure")
+        assertions.assertEqual(session.proposals, [])

--- a/backend/tests/test_cards.py
+++ b/backend/tests/test_cards.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from unittest import TestCase
+
 from fastapi.testclient import TestClient
 
 from app.routers import cards as cards_router
 from app.services.recommendation_scoring import RecommendationScore
 from app.utils.quotas import DEFAULT_CARD_DAILY_LIMIT
+
+assertions = TestCase()
 
 DEFAULT_PASSWORD = "Register123!"
 
@@ -14,15 +18,15 @@ def register_and_login(client: TestClient, email: str, password: str = DEFAULT_P
         "/auth/register",
         json={"email": email, "password": password},
     )
-    assert response.status_code == 201, response.text
+    assertions.assertTrue(response.status_code == 201, response.text)
     token_payload = response.json()
-    assert "access_token" in token_payload
-    assert token_payload["user"]["email"] == email
+    assertions.assertTrue("access_token" in token_payload)
+    assertions.assertTrue(token_payload["user"]["email"] == email)
     login_response = client.post(
         "/auth/login",
         json={"email": email, "password": password},
     )
-    assert login_response.status_code == 200, login_response.text
+    assertions.assertTrue(login_response.status_code == 200, login_response.text)
     token = login_response.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
 
@@ -38,7 +42,7 @@ def create_status(client: TestClient, headers: dict[str, str]) -> str:
         },
         headers=headers,
     )
-    assert response.status_code == 201
+    assertions.assertTrue(response.status_code == 201)
     return response.json()["id"]
 
 
@@ -48,7 +52,7 @@ def create_label(client: TestClient, headers: dict[str, str]) -> str:
         json={"name": "Backend", "color": "#ffaa00", "description": "API work"},
         headers=headers,
     )
-    assert response.status_code == 201
+    assertions.assertTrue(response.status_code == 201)
     return response.json()["id"]
 
 
@@ -72,13 +76,13 @@ def test_card_creation_populates_recommendation_score(client: TestClient) -> Non
         },
         headers=headers,
     )
-    assert response.status_code == 201, response.text
+    assertions.assertTrue(response.status_code == 201, response.text)
     data = response.json()
 
-    assert 0 <= data["ai_confidence"] <= 100
-    assert data["ai_confidence"] > 0
-    assert data["ai_notes"].startswith("ラベル相関度")
-    assert data["ai_failure_reason"] is None
+    assertions.assertTrue(0 <= data["ai_confidence"] <= 100)
+    assertions.assertTrue(data["ai_confidence"] > 0)
+    assertions.assertTrue(data["ai_notes"].startswith("ラベル相関度"))
+    assertions.assertTrue(data["ai_failure_reason"] is None)
 
     card_id = data["id"]
 
@@ -87,12 +91,12 @@ def test_card_creation_populates_recommendation_score(client: TestClient) -> Non
         json={"label_ids": [], "ai_failure_reason": "client override"},
         headers=headers,
     )
-    assert update_response.status_code == 200, update_response.text
+    assertions.assertTrue(update_response.status_code == 200, update_response.text)
     updated = update_response.json()
 
-    assert updated["ai_confidence"] == 0
-    assert "ラベルが未設定" in updated["ai_notes"]
-    assert updated["ai_failure_reason"] is None
+    assertions.assertTrue(updated["ai_confidence"] == 0)
+    assertions.assertTrue("ラベルが未設定" in updated["ai_notes"])
+    assertions.assertTrue(updated["ai_failure_reason"] is None)
 
 
 def test_card_creation_scoring_failure_sets_failure_reason(client: TestClient, monkeypatch) -> None:
@@ -129,24 +133,24 @@ def test_card_creation_scoring_failure_sets_failure_reason(client: TestClient, m
         },
         headers=headers,
     )
-    assert response.status_code == 201, response.text
+    assertions.assertTrue(response.status_code == 201, response.text)
     data = response.json()
 
-    assert data["ai_confidence"] == 0
-    assert data["ai_notes"] == "fallback message"
-    assert data["ai_failure_reason"] == "scoring_error"
+    assertions.assertTrue(data["ai_confidence"] == 0)
+    assertions.assertTrue(data["ai_notes"] == "fallback message")
+    assertions.assertTrue(data["ai_failure_reason"] == "scoring_error")
 
     update_response = client.put(
         f"/cards/{data['id']}",
         json={"title": "Updated title", "ai_failure_reason": "client attempt"},
         headers=headers,
     )
-    assert update_response.status_code == 200, update_response.text
+    assertions.assertTrue(update_response.status_code == 200, update_response.text)
     updated = update_response.json()
 
-    assert updated["ai_confidence"] == 0
-    assert updated["ai_notes"] == "fallback message"
-    assert updated["ai_failure_reason"] == "scoring_error"
+    assertions.assertTrue(updated["ai_confidence"] == 0)
+    assertions.assertTrue(updated["ai_notes"] == "fallback message")
+    assertions.assertTrue(updated["ai_failure_reason"] == "scoring_error")
 
 
 def test_create_card_with_subtasks(client: TestClient) -> None:
@@ -173,20 +177,20 @@ def test_create_card_with_subtasks(client: TestClient) -> None:
         },
         headers=headers,
     )
-    assert response.status_code == 201, response.text
+    assertions.assertTrue(response.status_code == 201, response.text)
     data = response.json()
-    assert data["title"] == "Implement API skeleton"
-    assert len(data["subtasks"]) == 2
-    assert len(data["labels"]) == 1
-    assert data["status"]["id"] == status_id
+    assertions.assertTrue(data["title"] == "Implement API skeleton")
+    assertions.assertTrue(len(data["subtasks"]) == 2)
+    assertions.assertTrue(len(data["labels"]) == 1)
+    assertions.assertTrue(data["status"]["id"] == status_id)
 
     list_response = client.get("/cards", headers=headers)
-    assert list_response.status_code == 200
-    assert len(list_response.json()) == 1
+    assertions.assertTrue(list_response.status_code == 200)
+    assertions.assertTrue(len(list_response.json()) == 1)
 
     detail_response = client.get(f"/cards/{data['id']}", headers=headers)
-    assert detail_response.status_code == 200
-    assert detail_response.json()["title"] == "Implement API skeleton"
+    assertions.assertTrue(detail_response.status_code == 200)
+    assertions.assertTrue(detail_response.json()["title"] == "Implement API skeleton")
 
 
 def test_create_card_registers_missing_labels(client: TestClient) -> None:
@@ -204,21 +208,21 @@ def test_create_card_registers_missing_labels(client: TestClient) -> None:
         },
         headers=headers,
     )
-    assert response.status_code == 201, response.text
+    assertions.assertTrue(response.status_code == 201, response.text)
     data = response.json()
 
     label_lookup = {label["name"]: label for label in data["labels"]}
-    assert "未登録ラベル" in label_lookup
+    assertions.assertTrue("未登録ラベル" in label_lookup)
     new_label = label_lookup["未登録ラベル"]
-    assert new_label["color"].startswith("#")
+    assertions.assertTrue(new_label["color"].startswith("#"))
 
-    assert existing_label_id in data["label_ids"]
-    assert new_label["id"] in data["label_ids"]
+    assertions.assertTrue(existing_label_id in data["label_ids"])
+    assertions.assertTrue(new_label["id"] in data["label_ids"])
 
     labels_response = client.get("/labels", headers=headers)
-    assert labels_response.status_code == 200
+    assertions.assertTrue(labels_response.status_code == 200)
     labels = labels_response.json()
-    assert any(label["id"] == new_label["id"] and label["name"] == "未登録ラベル" for label in labels)
+    assertions.assertTrue(any(label["id"] == new_label["id"] and label["name"] == "未登録ラベル" for label in labels))
 
 
 def test_duplicate_label_names_reuse_existing_record(client: TestClient) -> None:
@@ -231,7 +235,7 @@ def test_duplicate_label_names_reuse_existing_record(client: TestClient) -> None
         json={"name": "Urgent", "color": "#ff0000"},
         headers=headers,
     )
-    assert create_response.status_code == 201, create_response.text
+    assertions.assertTrue(create_response.status_code == 201, create_response.text)
     label_id = create_response.json()["id"]
 
     response = client.post(
@@ -243,18 +247,18 @@ def test_duplicate_label_names_reuse_existing_record(client: TestClient) -> None
         },
         headers=headers,
     )
-    assert response.status_code == 201, response.text
+    assertions.assertTrue(response.status_code == 201, response.text)
     data = response.json()
 
-    assert data["label_ids"] == [label_id]
-    assert len(data["labels"]) == 1
-    assert data["labels"][0]["id"] == label_id
+    assertions.assertTrue(data["label_ids"] == [label_id])
+    assertions.assertTrue(len(data["labels"]) == 1)
+    assertions.assertTrue(data["labels"][0]["id"] == label_id)
 
     labels_response = client.get("/labels", headers=headers)
-    assert labels_response.status_code == 200
+    assertions.assertTrue(labels_response.status_code == 200)
     labels = labels_response.json()
-    assert len(labels) == 1
-    assert labels[0]["id"] == label_id
+    assertions.assertTrue(len(labels) == 1)
+    assertions.assertTrue(labels[0]["id"] == label_id)
 
 
 def test_subtask_crud_flow(client: TestClient) -> None:
@@ -279,27 +283,27 @@ def test_subtask_crud_flow(client: TestClient) -> None:
         },
         headers=headers,
     )
-    assert create_response.status_code == 201
+    assertions.assertTrue(create_response.status_code == 201)
     subtask = create_response.json()
-    assert subtask["title"] == "Write changelog"
+    assertions.assertTrue(subtask["title"] == "Write changelog")
 
     update_response = client.put(
         f"/cards/{card['id']}/subtasks/{subtask['id']}",
         json={"status": "done", "checklist": [{"label": "Publish", "done": True}]},
         headers=headers,
     )
-    assert update_response.status_code == 200
-    assert update_response.json()["status"] == "done"
+    assertions.assertTrue(update_response.status_code == 200)
+    assertions.assertTrue(update_response.json()["status"] == "done")
 
     delete_response = client.delete(
         f"/cards/{card['id']}/subtasks/{subtask['id']}",
         headers=headers,
     )
-    assert delete_response.status_code == 204
+    assertions.assertTrue(delete_response.status_code == 204)
 
     list_response = client.get(f"/cards/{card['id']}/subtasks", headers=headers)
-    assert list_response.status_code == 200
-    assert list_response.json() == []
+    assertions.assertTrue(list_response.status_code == 200)
+    assertions.assertTrue(list_response.json() == [])
 
 
 def test_analysis_endpoint(client: TestClient) -> None:
@@ -315,11 +319,11 @@ def test_analysis_endpoint(client: TestClient) -> None:
 
     if response.status_code == 200:
         data = response.json()
-        assert data["model"]
-        assert len(data["proposals"]) >= 1
-        assert data["proposals"][0]["title"]
+        assertions.assertTrue(data["model"])
+        assertions.assertTrue(len(data["proposals"]) >= 1)
+        assertions.assertTrue(data["proposals"][0]["title"])
     else:
-        assert response.status_code == 503
+        assertions.assertTrue(response.status_code == 503)
 
 
 def test_card_creation_daily_limit(client: TestClient) -> None:
@@ -333,7 +337,7 @@ def test_card_creation_daily_limit(client: TestClient) -> None:
             json={"title": f"Card {index}", "status_id": status_id},
             headers=headers,
         )
-        assert response.status_code == 201, response.text
+        assertions.assertTrue(response.status_code == 201, response.text)
 
     extra_response = client.post(
         "/cards",
@@ -341,8 +345,10 @@ def test_card_creation_daily_limit(client: TestClient) -> None:
         headers=headers,
     )
 
-    assert extra_response.status_code == 429
-    assert extra_response.json()["detail"] == f"Daily card creation limit of {DEFAULT_CARD_DAILY_LIMIT} reached."
+    assertions.assertTrue(extra_response.status_code == 429)
+    assertions.assertTrue(
+        extra_response.json()["detail"] == f"Daily card creation limit of {DEFAULT_CARD_DAILY_LIMIT} reached."
+    )
 
 
 def test_cards_are_scoped_to_current_user(client: TestClient) -> None:
@@ -354,21 +360,21 @@ def test_cards_are_scoped_to_current_user(client: TestClient) -> None:
         json={"title": "Owner card", "status_id": status_id},
         headers=owner_headers,
     )
-    assert create_response.status_code == 201
+    assertions.assertTrue(create_response.status_code == 201)
     card_id = create_response.json()["id"]
 
     other_email = "bob@example.com"
     other_headers = register_and_login(client, other_email)
     list_other = client.get("/cards", headers=other_headers)
-    assert list_other.status_code == 200
-    assert list_other.json() == []
+    assertions.assertTrue(list_other.status_code == 200)
+    assertions.assertTrue(list_other.json() == [])
 
     detail_other = client.get(f"/cards/{card_id}", headers=other_headers)
-    assert detail_other.status_code == 404
+    assertions.assertTrue(detail_other.status_code == 404)
 
     list_owner = client.get("/cards", headers=owner_headers)
-    assert list_owner.status_code == 200
-    assert len(list_owner.json()) == 1
+    assertions.assertTrue(list_owner.status_code == 200)
+    assertions.assertTrue(len(list_owner.json()) == 1)
 
 
 def test_card_creation_daily_limit_enforced(client: TestClient) -> None:
@@ -382,15 +388,17 @@ def test_card_creation_daily_limit_enforced(client: TestClient) -> None:
             json={"title": f"Task {index}", "status_id": status_id},
             headers=headers,
         )
-        assert response.status_code == 201, response.text
+        assertions.assertTrue(response.status_code == 201, response.text)
 
     limit_response = client.post(
         "/cards",
         json={"title": "Limit exceeded", "status_id": status_id},
         headers=headers,
     )
-    assert limit_response.status_code == 429
-    assert limit_response.json()["detail"] == f"Daily card creation limit of {DEFAULT_CARD_DAILY_LIMIT} reached."
+    assertions.assertTrue(limit_response.status_code == 429)
+    assertions.assertTrue(
+        limit_response.json()["detail"] == f"Daily card creation limit of {DEFAULT_CARD_DAILY_LIMIT} reached."
+    )
 
 
 def test_status_and_label_scoping(client: TestClient) -> None:
@@ -400,7 +408,7 @@ def test_status_and_label_scoping(client: TestClient) -> None:
         json={"name": "Todo", "category": "todo", "order": 1},
         headers=owner_headers,
     )
-    assert status_response.status_code == 201
+    assertions.assertTrue(status_response.status_code == 201)
     status_id = status_response.json()["id"]
 
     label_response = client.post(
@@ -408,39 +416,39 @@ def test_status_and_label_scoping(client: TestClient) -> None:
         json={"name": "Backend", "color": "#123456"},
         headers=owner_headers,
     )
-    assert label_response.status_code == 201
+    assertions.assertTrue(label_response.status_code == 201)
     label_id = label_response.json()["id"]
 
     other_headers = register_and_login(client, "other-scope@example.com")
 
     status_list_other = client.get("/statuses", headers=other_headers)
-    assert status_list_other.status_code == 200
+    assertions.assertTrue(status_list_other.status_code == 200)
     other_status_names = {status["name"] for status in status_list_other.json()}
-    assert other_status_names == {"To Do", "Doing", "Done"}
+    assertions.assertTrue(other_status_names == {"To Do", "Doing", "Done"})
 
     update_other = client.put(
         f"/statuses/{status_id}",
         json={"name": "Updated"},
         headers=other_headers,
     )
-    assert update_other.status_code == 404
+    assertions.assertTrue(update_other.status_code == 404)
 
     label_list_other = client.get("/labels", headers=other_headers)
-    assert label_list_other.status_code == 200
-    assert label_list_other.json() == []
+    assertions.assertTrue(label_list_other.status_code == 200)
+    assertions.assertTrue(label_list_other.json() == [])
 
     delete_other = client.delete(f"/labels/{label_id}", headers=other_headers)
-    assert delete_other.status_code == 404
+    assertions.assertTrue(delete_other.status_code == 404)
 
     status_list_owner = client.get("/statuses", headers=owner_headers)
-    assert status_list_owner.status_code == 200
+    assertions.assertTrue(status_list_owner.status_code == 200)
     owner_status_names = {status["name"] for status in status_list_owner.json()}
-    assert {"To Do", "Doing", "Done"}.issubset(owner_status_names)
-    assert "Todo" in owner_status_names
+    assertions.assertTrue({"To Do", "Doing", "Done"}.issubset(owner_status_names))
+    assertions.assertTrue("Todo" in owner_status_names)
 
     label_list_owner = client.get("/labels", headers=owner_headers)
-    assert label_list_owner.status_code == 200
-    assert len(label_list_owner.json()) == 1
+    assertions.assertTrue(label_list_owner.status_code == 200)
+    assertions.assertTrue(len(label_list_owner.json()) == 1)
 
 
 def test_error_categories_are_user_scoped(client: TestClient) -> None:
@@ -450,67 +458,67 @@ def test_error_categories_are_user_scoped(client: TestClient) -> None:
         json={"name": "Bug", "description": "Unexpected issue"},
         headers=owner_headers,
     )
-    assert create_response.status_code == 201
+    assertions.assertTrue(create_response.status_code == 201)
     category_id = create_response.json()["id"]
 
     other_headers = register_and_login(client, "error-other@example.com")
 
     list_other = client.get("/error-categories", headers=other_headers)
-    assert list_other.status_code == 200
-    assert list_other.json() == []
+    assertions.assertTrue(list_other.status_code == 200)
+    assertions.assertTrue(list_other.json() == [])
 
     update_other = client.patch(
         f"/error-categories/{category_id}",
         json={"description": "Updated"},
         headers=other_headers,
     )
-    assert update_other.status_code == 404
+    assertions.assertTrue(update_other.status_code == 404)
 
     delete_other = client.delete(
         f"/error-categories/{category_id}",
         headers=other_headers,
     )
-    assert delete_other.status_code == 404
+    assertions.assertTrue(delete_other.status_code == 404)
 
     list_owner = client.get("/error-categories", headers=owner_headers)
-    assert list_owner.status_code == 200
-    assert len(list_owner.json()) == 1
+    assertions.assertTrue(list_owner.status_code == 200)
+    assertions.assertTrue(len(list_owner.json()) == 1)
 
 
 def test_board_layouts_are_user_specific(client: TestClient) -> None:
     headers_a = register_and_login(client, "layout-a@example.com")
     initial_a = client.get("/board-layouts", headers=headers_a)
-    assert initial_a.status_code == 200
-    assert initial_a.json()["user_id"]
+    assertions.assertTrue(initial_a.status_code == 200)
+    assertions.assertTrue(initial_a.json()["user_id"])
 
     update_a = client.put(
         "/board-layouts",
         json={"board_grouping": "status", "visible_fields": ["title", "status"]},
         headers=headers_a,
     )
-    assert update_a.status_code == 200
-    assert update_a.json()["board_grouping"] == "status"
+    assertions.assertTrue(update_a.status_code == 200)
+    assertions.assertTrue(update_a.json()["board_grouping"] == "status")
 
     headers_b = register_and_login(client, "layout-b@example.com")
     initial_b = client.get("/board-layouts", headers=headers_b)
-    assert initial_b.status_code == 200
-    assert initial_b.json()["board_grouping"] is None
+    assertions.assertTrue(initial_b.status_code == 200)
+    assertions.assertTrue(initial_b.json()["board_grouping"] is None)
 
     list_filters_a = client.get("/filters", headers=headers_a)
-    assert list_filters_a.status_code == 200
-    assert list_filters_a.json() == []
+    assertions.assertTrue(list_filters_a.status_code == 200)
+    assertions.assertTrue(list_filters_a.json() == [])
 
     create_filter = client.post(
         "/filters",
         json={"name": "My filter", "definition": {"priority": "high"}},
         headers=headers_a,
     )
-    assert create_filter.status_code == 201
+    assertions.assertTrue(create_filter.status_code == 201)
     filter_id = create_filter.json()["id"]
 
     list_filters_b = client.get("/filters", headers=headers_b)
-    assert list_filters_b.status_code == 200
-    assert list_filters_b.json() == []
+    assertions.assertTrue(list_filters_b.status_code == 200)
+    assertions.assertTrue(list_filters_b.json() == [])
 
     get_filter_b = client.get(f"/filters/{filter_id}", headers=headers_b)
-    assert get_filter_b.status_code == 404
+    assertions.assertTrue(get_filter_b.status_code == 404)

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from unittest import TestCase
+
 from fastapi.testclient import TestClient
 
 from .test_cards import create_status, register_and_login
+
+assertions = TestCase()
 
 
 def _update_nickname(client: TestClient, headers: dict[str, str], nickname: str) -> None:
@@ -11,7 +15,7 @@ def _update_nickname(client: TestClient, headers: dict[str, str], nickname: str)
         data={"nickname": nickname},
         headers=headers,
     )
-    assert response.status_code == 200, response.text
+    assertions.assertTrue(response.status_code == 200, response.text)
 
 
 def _create_card_with_subtask(
@@ -28,7 +32,7 @@ def _create_card_with_subtask(
         },
         headers=headers,
     )
-    assert response.status_code == 201, response.text
+    assertions.assertTrue(response.status_code == 201, response.text)
     payload = response.json()
     card_id = payload["id"]
     subtask_id = payload["subtasks"][0]["id"]
@@ -51,45 +55,45 @@ def test_subtask_comment_crud_flow(client: TestClient) -> None:
         },
         headers=headers,
     )
-    assert create_response.status_code == 201, create_response.text
+    assertions.assertTrue(create_response.status_code == 201, create_response.text)
     created = create_response.json()
-    assert created["card_id"] == card_id
-    assert created["subtask_id"] == subtask_id
-    assert created["content"] == "初回メモ"
-    assert created["author_id"]
-    assert created["author_nickname"] == "ボード担当者"
+    assertions.assertTrue(created["card_id"] == card_id)
+    assertions.assertTrue(created["subtask_id"] == subtask_id)
+    assertions.assertTrue(created["content"] == "初回メモ")
+    assertions.assertTrue(created["author_id"])
+    assertions.assertTrue(created["author_nickname"] == "ボード担当者")
 
     list_response = client.get(
         "/comments",
         params={"card_id": card_id, "subtask_id": subtask_id},
         headers=headers,
     )
-    assert list_response.status_code == 200, list_response.text
+    assertions.assertTrue(list_response.status_code == 200, list_response.text)
     listed = list_response.json()
-    assert len(listed) == 1
-    assert listed[0]["author_nickname"] == "ボード担当者"
+    assertions.assertTrue(len(listed) == 1)
+    assertions.assertTrue(listed[0]["author_nickname"] == "ボード担当者")
 
     update_response = client.put(
         f"/comments/{created['id']}",
         json={"content": "更新済みメモ", "subtask_id": subtask_id},
         headers=headers,
     )
-    assert update_response.status_code == 200, update_response.text
+    assertions.assertTrue(update_response.status_code == 200, update_response.text)
     updated = update_response.json()
-    assert updated["content"] == "更新済みメモ"
-    assert updated["author_nickname"] == "ボード担当者"
-    assert updated["updated_at"] != created["updated_at"]
+    assertions.assertTrue(updated["content"] == "更新済みメモ")
+    assertions.assertTrue(updated["author_nickname"] == "ボード担当者")
+    assertions.assertTrue(updated["updated_at"] != created["updated_at"])
 
     delete_response = client.delete(
         f"/comments/{created['id']}",
         headers=headers,
     )
-    assert delete_response.status_code == 204, delete_response.text
+    assertions.assertTrue(delete_response.status_code == 204, delete_response.text)
 
     empty_response = client.get(
         "/comments",
         params={"card_id": card_id, "subtask_id": subtask_id},
         headers=headers,
     )
-    assert empty_response.status_code == 200
-    assert empty_response.json() == []
+    assertions.assertTrue(empty_response.status_code == 200)
+    assertions.assertTrue(empty_response.json() == [])

--- a/backend/tests/test_competency_evaluator.py
+++ b/backend/tests/test_competency_evaluator.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from unittest import TestCase
 
 import pytest
 
@@ -6,6 +7,8 @@ from app import models
 from app.services.competency_evaluator import CompetencyEvaluator
 
 from .conftest import TestingSessionLocal
+
+assertions = TestCase()
 
 
 @pytest.fixture()
@@ -22,7 +25,7 @@ def test_recent_completions_are_emphasized(db_session):
     today = now.date()
     period_start = today - timedelta(days=120)
 
-    user = models.User(email="member@example.com", password_hash="hashed")
+    user = models.User(email="member@example.com", password_hash="hashed")  # noqa: S106
     competency = models.Competency(name="成長テスト", level="intermediate")
     db_session.add_all([user, competency])
     db_session.flush()
@@ -71,19 +74,19 @@ def test_recent_completions_are_emphasized(db_session):
     )
 
     metrics = evaluation.context["metrics"]
-    assert metrics["cards_completed"] == 2
-    assert metrics["subtasks_completed"] == 3
-    assert metrics["recent_cards_completed"] == 1
-    assert metrics["recent_subtasks_completed"] == 2
-    assert metrics["effective_completed"] == 8
-    assert metrics["recent_completed_total"] == 3
-    assert metrics["older_completed_total"] == 2
-    assert metrics["recent_completion_window_days"] == 30
+    assertions.assertTrue(metrics["cards_completed"] == 2)
+    assertions.assertTrue(metrics["subtasks_completed"] == 3)
+    assertions.assertTrue(metrics["recent_cards_completed"] == 1)
+    assertions.assertTrue(metrics["recent_subtasks_completed"] == 2)
+    assertions.assertTrue(metrics["effective_completed"] == 8)
+    assertions.assertTrue(metrics["recent_completed_total"] == 3)
+    assertions.assertTrue(metrics["older_completed_total"] == 2)
+    assertions.assertTrue(metrics["recent_completion_window_days"] == 30)
 
-    assert evaluation.score_value == 3
-    assert evaluation.score_label == "標準"
-    assert "直近30日" in evaluation.rationale
-    assert evaluation.items[0].rationale.count("直近30日") == 1
+    assertions.assertTrue(evaluation.score_value == 3)
+    assertions.assertTrue(evaluation.score_label == "標準")
+    assertions.assertTrue("直近30日" in evaluation.rationale)
+    assertions.assertTrue(evaluation.items[0].rationale.count("直近30日") == 1)
 
 
 def test_editing_completed_work_does_not_count_as_recent(db_session):
@@ -91,7 +94,7 @@ def test_editing_completed_work_does_not_count_as_recent(db_session):
     today = now.date()
     period_start = today - timedelta(days=200)
 
-    user = models.User(email="member@example.com", password_hash="hashed")
+    user = models.User(email="member@example.com", password_hash="hashed")  # noqa: S106
     competency = models.Competency(name="完了済みテスト", level="intermediate")
     db_session.add_all([user, competency])
     db_session.flush()
@@ -123,9 +126,9 @@ def test_editing_completed_work_does_not_count_as_recent(db_session):
     )
 
     metrics = evaluation.context["metrics"]
-    assert metrics["cards_completed"] == 1
-    assert metrics["subtasks_completed"] == 1
-    assert metrics["recent_cards_completed"] == 0
-    assert metrics["recent_subtasks_completed"] == 0
-    assert metrics["recent_completed_total"] == 0
-    assert metrics["older_completed_total"] == 2
+    assertions.assertTrue(metrics["cards_completed"] == 1)
+    assertions.assertTrue(metrics["subtasks_completed"] == 1)
+    assertions.assertTrue(metrics["recent_cards_completed"] == 0)
+    assertions.assertTrue(metrics["recent_subtasks_completed"] == 0)
+    assertions.assertTrue(metrics["recent_completed_total"] == 0)
+    assertions.assertTrue(metrics["older_completed_total"] == 2)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,6 +1,10 @@
 """Tests for application configuration settings."""
 
+from unittest import TestCase
+
 from backend.app.config import Settings
+
+assertions = TestCase()
 
 
 def test_allowed_origins_strip_trailing_slash(monkeypatch):
@@ -13,7 +17,10 @@ def test_allowed_origins_strip_trailing_slash(monkeypatch):
 
     settings = Settings()
 
-    assert settings.allowed_origins == [
-        "http://localhost:4200",
-        "https://app.example.com",
-    ]
+    assertions.assertTrue(
+        settings.allowed_origins
+        == [
+            "http://localhost:4200",
+            "https://app.example.com",
+        ]
+    )

--- a/backend/tests/test_full_coverage.py
+++ b/backend/tests/test_full_coverage.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 from typing import Iterable
+from unittest import TestCase
 
 import pytest
+
+assertions = TestCase()
 
 
 def _iter_python_files(root: Path) -> Iterable[Path]:
@@ -39,7 +42,7 @@ def test_backend_app_coverage_completeness() -> None:
         pytest.skip("Coverage measurement must be active during tests")
 
     cov = coverage_mod.Coverage.current()
-    assert cov is not None
+    assertions.assertTrue(cov is not None)
 
     covdata = cov.get_data()
     app_root = Path(__file__).resolve().parents[2] / "backend" / "app"

--- a/backend/tests/test_recommendation_scoring.py
+++ b/backend/tests/test_recommendation_scoring.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import logging
 from types import SimpleNamespace
+from unittest import TestCase
 
 import pytest
 
 from app.services.recommendation_scoring import RecommendationScoringService
+
+assertions = TestCase()
 
 
 def test_score_card_emits_debug_log(caplog: pytest.LogCaptureFixture) -> None:
@@ -25,12 +28,12 @@ def test_score_card_emits_debug_log(caplog: pytest.LogCaptureFixture) -> None:
         log for log in caplog.records if log.levelno == logging.DEBUG and log.msg == "Recommendation scoring completed"
     )
 
-    assert record.elapsed_ms >= 0
-    assert record.label_weight == pytest.approx(service._label_weight)
-    assert record.profile_weight == pytest.approx(service._profile_weight)
-    assert record.label_score == pytest.approx(result.label_correlation)
-    assert record.profile_score == pytest.approx(result.profile_alignment)
-    assert record.score == result.score
+    assertions.assertTrue(record.elapsed_ms >= 0)
+    assertions.assertTrue(record.label_weight == pytest.approx(service._label_weight))
+    assertions.assertTrue(record.profile_weight == pytest.approx(service._profile_weight))
+    assertions.assertTrue(record.label_score == pytest.approx(result.label_correlation))
+    assertions.assertTrue(record.profile_score == pytest.approx(result.profile_alignment))
+    assertions.assertTrue(record.score == result.score)
 
 
 def test_score_card_logs_debug_on_failure(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -51,7 +54,7 @@ def test_score_card_logs_debug_on_failure(caplog: pytest.LogCaptureFixture, monk
             profile=profile,
         )
 
-    assert result.failure_reason == "scoring_error"
+    assertions.assertTrue(result.failure_reason == "scoring_error")
 
     record = next(
         log
@@ -59,9 +62,9 @@ def test_score_card_logs_debug_on_failure(caplog: pytest.LogCaptureFixture, monk
         if log.levelno == logging.DEBUG and log.msg == "Recommendation scoring failed; returning fallback"
     )
 
-    assert record.elapsed_ms >= 0
-    assert record.label_weight == pytest.approx(service._label_weight)
-    assert record.profile_weight == pytest.approx(service._profile_weight)
-    assert record.label_score is None
-    assert record.profile_score is None
-    assert record.score == 0
+    assertions.assertTrue(record.elapsed_ms >= 0)
+    assertions.assertTrue(record.label_weight == pytest.approx(service._label_weight))
+    assertions.assertTrue(record.profile_weight == pytest.approx(service._profile_weight))
+    assertions.assertTrue(record.label_score is None)
+    assertions.assertTrue(record.profile_score is None)
+    assertions.assertTrue(record.score == 0)

--- a/backend/tests/test_report_templates.py
+++ b/backend/tests/test_report_templates.py
@@ -1,9 +1,15 @@
+from unittest import TestCase
+
 from fastapi.testclient import TestClient
 
+assertions = TestCase()
 
-def _register_user(client: TestClient, email: str, password: str = "SecurePass123!") -> dict:
+
+def _register_user(
+    client: TestClient, email: str, password: str = "SecurePass123!",  # noqa: S107
+) -> dict:
     response = client.post("/auth/register", json={"email": email, "password": password})
-    assert response.status_code == 201, response.text
+    assertions.assertTrue(response.status_code == 201, response.text)
     return response.json()
 
 
@@ -19,8 +25,8 @@ def test_report_templates_are_scoped_per_admin(client: TestClient) -> None:
         headers=admin_one_headers,
         json={"is_admin": True},
     )
-    assert promote_response.status_code == 200, promote_response.text
-    assert promote_response.json()["is_admin"] is True
+    assertions.assertTrue(promote_response.status_code == 200, promote_response.text)
+    assertions.assertTrue(promote_response.json()["is_admin"] is True)
 
     owner_template_response = client.post(
         "/reports/templates",
@@ -32,9 +38,9 @@ def test_report_templates_are_scoped_per_admin(client: TestClient) -> None:
             "branding": {"accent": "blue"},
         },
     )
-    assert owner_template_response.status_code == 201, owner_template_response.text
+    assertions.assertTrue(owner_template_response.status_code == 201, owner_template_response.text)
     owner_template = owner_template_response.json()
-    assert owner_template["owner_id"] == admin_one["user"]["id"]
+    assertions.assertTrue(owner_template["owner_id"] == admin_one["user"]["id"])
 
     other_template_response = client.post(
         "/reports/templates",
@@ -46,29 +52,29 @@ def test_report_templates_are_scoped_per_admin(client: TestClient) -> None:
             "branding": {},
         },
     )
-    assert other_template_response.status_code == 201, other_template_response.text
+    assertions.assertTrue(other_template_response.status_code == 201, other_template_response.text)
     other_template = other_template_response.json()
-    assert other_template["owner_id"] == admin_two["user"]["id"]
+    assertions.assertTrue(other_template["owner_id"] == admin_two["user"]["id"])
 
     owner_list_response = client.get("/reports/templates", headers=admin_one_headers)
-    assert owner_list_response.status_code == 200, owner_list_response.text
+    assertions.assertTrue(owner_list_response.status_code == 200, owner_list_response.text)
     owner_templates = owner_list_response.json()
-    assert [template["name"] for template in owner_templates] == ["Owner template"]
+    assertions.assertTrue([template["name"] for template in owner_templates] == ["Owner template"])
 
     other_list_response = client.get("/reports/templates", headers=admin_two_headers)
-    assert other_list_response.status_code == 200, other_list_response.text
+    assertions.assertTrue(other_list_response.status_code == 200, other_list_response.text)
     other_templates = other_list_response.json()
-    assert [template["name"] for template in other_templates] == ["Second template"]
+    assertions.assertTrue([template["name"] for template in other_templates] == ["Second template"])
 
     forbidden_get = client.get(
         f"/reports/templates/{other_template['id']}",
         headers=admin_one_headers,
     )
-    assert forbidden_get.status_code == 404
+    assertions.assertTrue(forbidden_get.status_code == 404)
 
     forbidden_update = client.patch(
         f"/reports/templates/{other_template['id']}",
         headers=admin_one_headers,
         json={"name": "Should not work"},
     )
-    assert forbidden_update.status_code == 404
+    assertions.assertTrue(forbidden_update.status_code == 404)

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,4 +1,5 @@
 import hashlib
+from unittest import TestCase
 
 import pytest
 from fastapi.middleware.cors import CORSMiddleware
@@ -10,15 +11,17 @@ from app.config import Settings, settings
 from app.database import get_db
 from app.main import app
 
+assertions = TestCase()
+
 
 def _register_user(client: TestClient, email: str, password: str) -> dict:
     response = client.post("/auth/register", json={"email": email, "password": password})
-    assert response.status_code == 201, response.text
+    assertions.assertTrue(response.status_code == 201, response.text)
     return response.json()
 
 
 def _bootstrap_admin_and_member(client: TestClient) -> tuple[dict, dict]:
-    password = "SecurePass123!"
+    password = "SecurePass123!"  # noqa: S105
     admin_payload = _register_user(client, "admin@example.com", password)
     member_payload = _register_user(client, "member@example.com", password)
     return admin_payload, member_payload
@@ -29,13 +32,13 @@ def test_cors_configuration_disallows_wildcard_credentials() -> None:
         (middleware for middleware in app.user_middleware if middleware.cls is CORSMiddleware),
         None,
     )
-    assert cors_middleware is not None, "CORS middleware should be registered"
+    assertions.assertTrue(cors_middleware is not None, "CORS middleware should be registered")
 
     allow_origins = cors_middleware.kwargs.get("allow_origins")
-    assert isinstance(allow_origins, (list, tuple))
-    assert "*" not in allow_origins
-    assert allow_origins == settings.allowed_origins
-    assert cors_middleware.kwargs.get("allow_all_origins") in (None, False)
+    assertions.assertTrue(isinstance(allow_origins, (list, tuple)))
+    assertions.assertTrue("*" not in allow_origins)
+    assertions.assertTrue(allow_origins == settings.allowed_origins)
+    assertions.assertTrue(cors_middleware.kwargs.get("allow_all_origins") in (None, False))
 
 
 def test_settings_reject_wildcard_origins() -> None:
@@ -45,65 +48,68 @@ def test_settings_reject_wildcard_origins() -> None:
 
 def test_settings_split_comma_separated_origins() -> None:
     custom_settings = Settings(allowed_origins="http://a.example,http://b.example")
-    assert custom_settings.allowed_origins == [
-        "http://a.example",
-        "http://b.example",
-    ]
+    assertions.assertTrue(
+        custom_settings.allowed_origins
+        == [
+            "http://a.example",
+            "http://b.example",
+        ]
+    )
 
 
 def test_email_login_flow_accepts_user_input_variations(client: TestClient) -> None:
-    email_input = " Ｔｅｓｔ.User+1@Example.Com "
-    password = "SecurePass123!"
+    email_input = " Ｔｅｓｔ.User+1@Example.Com "  # noqa: RUF001
+    password = "SecurePass123!"  # noqa: S105
 
     register_response = client.post(
         "/auth/register",
         json={"email": email_input, "password": password},
     )
-    assert register_response.status_code == 201, register_response.text
+    assertions.assertTrue(register_response.status_code == 201, register_response.text)
     register_payload = register_response.json()
-    assert register_payload["user"]["email"] == "test.user+1@example.com"
-    assert register_payload["user"]["is_admin"] is True
+    assertions.assertTrue(register_payload["user"]["email"] == "test.user+1@example.com")
+    assertions.assertTrue(register_payload["user"]["is_admin"] is True)
 
     login_response = client.post(
         "/auth/login",
         json={"email": email_input, "password": password},
     )
-    assert login_response.status_code == 200, login_response.text
+    assertions.assertTrue(login_response.status_code == 200, login_response.text)
     login_payload = login_response.json()
-    assert login_payload["user"]["email"] == "test.user+1@example.com"
-    assert login_payload["user"]["is_admin"] is True
+    assertions.assertTrue(login_payload["user"]["email"] == "test.user+1@example.com")
+    assertions.assertTrue(login_payload["user"]["is_admin"] is True)
 
 
 def test_second_registered_user_is_not_admin(client: TestClient) -> None:
-    password = "SecurePass123!"
+    password = "SecurePass123!"  # noqa: S105
 
     first_register_response = client.post(
         "/auth/register",
         json={"email": "owner@example.com", "password": password},
     )
-    assert first_register_response.status_code == 201, first_register_response.text
-    assert first_register_response.json()["user"]["is_admin"] is True
+    assertions.assertTrue(first_register_response.status_code == 201, first_register_response.text)
+    assertions.assertTrue(first_register_response.json()["user"]["is_admin"] is True)
 
     second_register_response = client.post(
         "/auth/register",
         json={"email": "member@example.com", "password": password},
     )
-    assert second_register_response.status_code == 201, second_register_response.text
+    assertions.assertTrue(second_register_response.status_code == 201, second_register_response.text)
     second_register_payload = second_register_response.json()
-    assert second_register_payload["user"]["is_admin"] is False
+    assertions.assertTrue(second_register_payload["user"]["is_admin"] is False)
 
     login_response = client.post(
         "/auth/login",
         json={"email": "member@example.com", "password": password},
     )
-    assert login_response.status_code == 200, login_response.text
-    assert login_response.json()["user"]["is_admin"] is False
+    assertions.assertTrue(login_response.status_code == 200, login_response.text)
+    assertions.assertTrue(login_response.json()["user"]["is_admin"] is False)
 
 
 def test_login_allows_legacy_normalized_emails(client: TestClient) -> None:
     login_input = "Straße@Example.com"
     stored_email = login_input.strip().lower()
-    password = "SecurePass123!"
+    password = "SecurePass123!"  # noqa: S105
 
     override = client.app.dependency_overrides[get_db]
     db_gen = override()
@@ -119,9 +125,9 @@ def test_login_allows_legacy_normalized_emails(client: TestClient) -> None:
         "/auth/login",
         json={"email": login_input, "password": password},
     )
-    assert login_response.status_code == 200, login_response.text
+    assertions.assertTrue(login_response.status_code == 200, login_response.text)
     login_payload = login_response.json()
-    assert login_payload["user"]["email"] == stored_email
+    assertions.assertTrue(login_payload["user"]["email"] == stored_email)
 
 
 def test_session_tokens_are_hashed(client: TestClient) -> None:
@@ -136,10 +142,10 @@ def test_session_tokens_are_hashed(client: TestClient) -> None:
     finally:
         db_gen.close()
 
-    assert stored_tokens, "Session token should be stored"
+    assertions.assertTrue(stored_tokens, "Session token should be stored")
     stored_token = stored_tokens[0]
     expected_hash = hashlib.sha256(access_token.encode("utf-8")).hexdigest()
-    assert stored_token.token == expected_hash
+    assertions.assertTrue(stored_token.token == expected_hash)
 
 
 def test_analytics_routes_require_admin(client: TestClient) -> None:
@@ -148,20 +154,20 @@ def test_analytics_routes_require_admin(client: TestClient) -> None:
     member_token = member_payload["access_token"]
 
     unauthenticated = client.get("/analytics/snapshots")
-    assert unauthenticated.status_code == 401
+    assertions.assertTrue(unauthenticated.status_code == 401)
 
     forbidden = client.get(
         "/analytics/snapshots",
         headers={"Authorization": f"Bearer {member_token}"},
     )
-    assert forbidden.status_code == 403
+    assertions.assertTrue(forbidden.status_code == 403)
 
     allowed = client.get(
         "/analytics/snapshots",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
-    assert allowed.status_code == 200, allowed.text
-    assert isinstance(allowed.json(), list)
+    assertions.assertTrue(allowed.status_code == 200, allowed.text)
+    assertions.assertTrue(isinstance(allowed.json(), list))
 
 
 def test_suggested_actions_routes_require_admin(client: TestClient) -> None:
@@ -170,20 +176,20 @@ def test_suggested_actions_routes_require_admin(client: TestClient) -> None:
     member_token = member_payload["access_token"]
 
     unauthenticated = client.get("/suggested-actions/")
-    assert unauthenticated.status_code == 401
+    assertions.assertTrue(unauthenticated.status_code == 401)
 
     forbidden = client.get(
         "/suggested-actions/",
         headers={"Authorization": f"Bearer {member_token}"},
     )
-    assert forbidden.status_code == 403
+    assertions.assertTrue(forbidden.status_code == 403)
 
     allowed = client.get(
         "/suggested-actions/",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
-    assert allowed.status_code == 200, allowed.text
-    assert isinstance(allowed.json(), list)
+    assertions.assertTrue(allowed.status_code == 200, allowed.text)
+    assertions.assertTrue(isinstance(allowed.json(), list))
 
 
 def test_reports_routes_require_admin(client: TestClient) -> None:
@@ -192,27 +198,27 @@ def test_reports_routes_require_admin(client: TestClient) -> None:
     member_token = member_payload["access_token"]
 
     unauthenticated = client.get("/reports/templates")
-    assert unauthenticated.status_code == 401
+    assertions.assertTrue(unauthenticated.status_code == 401)
 
     forbidden = client.get(
         "/reports/templates",
         headers={"Authorization": f"Bearer {member_token}"},
     )
-    assert forbidden.status_code == 403
+    assertions.assertTrue(forbidden.status_code == 403)
 
     allowed = client.get(
         "/reports/templates",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
-    assert allowed.status_code == 200, allowed.text
-    assert isinstance(allowed.json(), list)
+    assertions.assertTrue(allowed.status_code == 200, allowed.text)
+    assertions.assertTrue(isinstance(allowed.json(), list))
 
     forbidden_generate = client.post(
         "/reports/generate",
         headers={"Authorization": f"Bearer {member_token}"},
         json={"parameters": {}},
     )
-    assert forbidden_generate.status_code == 403
+    assertions.assertTrue(forbidden_generate.status_code == 403)
 
 
 def test_generate_report_sets_author_to_authenticated_admin(client: TestClient) -> None:
@@ -227,6 +233,6 @@ def test_generate_report_sets_author_to_authenticated_admin(client: TestClient) 
             "parameters": {"title": "Security Review"},
         },
     )
-    assert response.status_code == 201, response.text
+    assertions.assertTrue(response.status_code == 201, response.text)
     data = response.json()
-    assert data["author_id"] == admin_payload["user"]["id"]
+    assertions.assertTrue(data["author_id"] == admin_payload["user"]["id"])

--- a/backend/tests/test_sqlalchemy_py313_compat.py
+++ b/backend/tests/test_sqlalchemy_py313_compat.py
@@ -4,10 +4,13 @@ import importlib.abc
 import importlib.machinery
 import sys
 from types import ModuleType, SimpleNamespace
+from unittest import TestCase
 
 import pytest
 
 from backend.app import sqlalchemy_py313_compat as compat
+
+assertions = TestCase()
 
 
 @pytest.fixture(autouse=True)
@@ -51,16 +54,16 @@ def test_patch_langhelpers_enforces_typingonly_contract() -> None:
         __firstlineno__ = 1
         __static_attributes__ = ()
 
-    assert ValidSubclass in module.call_log  # type: ignore[attr-defined]
+    assertions.assertTrue(ValidSubclass in module.call_log)
     patched_descriptor = module.TypingOnly.__dict__["__init_subclass__"]  # type: ignore[attr-defined]
-    assert getattr(patched_descriptor, compat._PATCH_ATTRIBUTE) is True
+    assertions.assertTrue(getattr(patched_descriptor, compat._PATCH_ATTRIBUTE) is True)
 
     with pytest.raises(AssertionError) as exc:
 
         class InvalidSubclass(module.TypingOnly):  # type: ignore[misc, valid-type]
             extra_attribute = True
 
-    assert "extra_attribute" in str(exc.value)
+    assertions.assertTrue("extra_attribute" in str(exc.value))
 
     # Patching again should be a no-op once the sentinel attribute is set.
     compat._patch_langhelpers(module)
@@ -84,7 +87,7 @@ def test_patch_langhelpers_detects_existing_patch() -> None:
     module.TypingOnly.__init_subclass__ = descriptor  # type: ignore[attr-defined]
 
     compat._patch_langhelpers(module)
-    assert module.TypingOnly.__dict__["__init_subclass__"].calls == 0  # type: ignore[attr-defined]
+    assertions.assertTrue(module.TypingOnly.__dict__["__init_subclass__"].calls == 0)
 
 
 def test_patch_langhelpers_ignores_missing_typingonly() -> None:
@@ -104,11 +107,11 @@ def test_langhelpers_loader_executes_wrapped_loader_and_deactivates_finder(resto
 
     loader = compat._LanghelpersLoader(LoaderWithoutCreate(), finder)
     spec = importlib.machinery.ModuleSpec("sqlalchemy.util.langhelpers", loader)
-    assert loader.create_module(spec) is None
+    assertions.assertTrue(loader.create_module(spec) is None)
 
     loader.exec_module(module)
-    assert module.executed is True  # type: ignore[attr-defined]
-    assert finder not in sys.meta_path
+    assertions.assertTrue(module.executed is True)
+    assertions.assertTrue(finder not in sys.meta_path)
 
 
 def test_langhelpers_loader_respects_wrapped_create_module(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -131,17 +134,17 @@ def test_langhelpers_loader_respects_wrapped_create_module(monkeypatch: pytest.M
     loader = compat._LanghelpersLoader(LoaderWithCreate(), finder)
     spec = importlib.machinery.ModuleSpec("sqlalchemy.util.langhelpers", loader)
     created = loader.create_module(spec)
-    assert created is module
+    assertions.assertTrue(created is module)
     loader.exec_module(module)
-    assert loader._wrapped_loader.calls == ["create", "exec"]
+    assertions.assertTrue(loader._wrapped_loader.calls == ["create", "exec"])
 
 
 def test_finder_wraps_langhelpers_spec(monkeypatch: pytest.MonkeyPatch) -> None:
     finder = compat._Finder()
 
-    assert finder.find_spec("something_else", None) is None
+    assertions.assertTrue(finder.find_spec("something_else", None) is None)
     finder._active = False
-    assert finder.find_spec("sqlalchemy.util.langhelpers", None) is None
+    assertions.assertTrue(finder.find_spec("sqlalchemy.util.langhelpers", None) is None)
     finder._active = True
 
     dummy_loader = SimpleNamespace(exec_module=lambda module: None)
@@ -149,7 +152,7 @@ def test_finder_wraps_langhelpers_spec(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(importlib.machinery.PathFinder, "find_spec", lambda fullname, path: spec)
 
     wrapped_spec = finder.find_spec("sqlalchemy.util.langhelpers", None)
-    assert isinstance(wrapped_spec.loader, compat._LanghelpersLoader)
+    assertions.assertTrue(isinstance(wrapped_spec.loader, compat._LanghelpersLoader))
 
 
 def test_finder_deactivate_handles_missing_meta_path_entry(restore_meta_path: None) -> None:
@@ -157,7 +160,7 @@ def test_finder_deactivate_handles_missing_meta_path_entry(restore_meta_path: No
     sys.meta_path.insert(0, finder)
     sys.meta_path.remove(finder)
     finder.deactivate()
-    assert not finder._active
+    assertions.assertTrue(not finder._active)
     finder.deactivate()
 
 
@@ -167,7 +170,7 @@ def test_finder_returns_spec_when_loader_missing(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(importlib.machinery.PathFinder, "find_spec", lambda fullname, path: spec)
 
     result = finder.find_spec("sqlalchemy.util.langhelpers", None)
-    assert result is spec
+    assertions.assertTrue(result is spec)
 
 
 def test_ensure_typingonly_short_circuits_on_old_python(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -182,7 +185,7 @@ def test_ensure_typingonly_patches_loaded_module(monkeypatch: pytest.MonkeyPatch
 
     compat.ensure_typingonly_is_compatible()
     patched_descriptor = module.TypingOnly.__dict__["__init_subclass__"]  # type: ignore[attr-defined]
-    assert getattr(patched_descriptor, compat._PATCH_ATTRIBUTE) is True
+    assertions.assertTrue(getattr(patched_descriptor, compat._PATCH_ATTRIBUTE) is True)
 
 
 def test_ensure_typingonly_inserts_meta_path_finder(monkeypatch: pytest.MonkeyPatch, restore_meta_path: None) -> None:
@@ -190,8 +193,8 @@ def test_ensure_typingonly_inserts_meta_path_finder(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(sys, "version_info", (3, 13, 0))
 
     compat.ensure_typingonly_is_compatible()
-    assert isinstance(compat._finder, compat._Finder)
-    assert compat._finder in sys.meta_path
+    assertions.assertTrue(isinstance(compat._finder, compat._Finder))
+    assertions.assertTrue(compat._finder in sys.meta_path)
 
     compat.ensure_typingonly_is_compatible()
-    assert sys.meta_path.count(compat._finder) == 1
+    assertions.assertTrue(sys.meta_path.count(compat._finder) == 1)

--- a/backend/tests/utils/test_repository.py
+++ b/backend/tests/utils/test_repository.py
@@ -1,7 +1,11 @@
+from unittest import TestCase
+
 import pytest
 
 from app import models
 from app.utils.repository import apply_updates
+
+assertions = TestCase()
 
 
 class _Dummy:
@@ -14,7 +18,7 @@ def test_apply_updates_sets_existing_attribute_on_plain_object() -> None:
 
     apply_updates(dummy, {"name": "after"})
 
-    assert dummy.name == "after"
+    assertions.assertTrue(dummy.name == "after")
 
 
 def test_apply_updates_rejects_unknown_attribute_on_plain_object() -> None:
@@ -28,7 +32,7 @@ def test_apply_updates_rejects_unknown_attribute_on_sqlalchemy_model() -> None:
     status = models.Status(id="status-1", name="In Progress", owner_id="owner-1")
 
     apply_updates(status, {"name": "Done"})
-    assert status.name == "Done"
+    assertions.assertTrue(status.name == "Done")
 
     with pytest.raises(AttributeError):
         apply_updates(status, {"not_a_column": "value"})

--- a/frontend/src/app/features/reports/reports-page.component.ts
+++ b/frontend/src/app/features/reports/reports-page.component.ts
@@ -370,9 +370,9 @@ export class ReportAssistantPageComponent {
     }
   }
 
-  private mapSubtasks(
+  private readonly mapSubtasks = (
     subtasks: readonly StatusReportProposalSubtask[] | undefined,
-  ): readonly Subtask[] | undefined {
+  ): readonly Subtask[] | undefined => {
     if (!subtasks || subtasks.length === 0) {
       return undefined;
     }
@@ -381,7 +381,10 @@ export class ReportAssistantPageComponent {
     for (const subtask of subtasks) {
       const title = (subtask.title ?? '').trim();
       const description = subtask.description?.trim();
-      const combined = this.composeSubtaskTitle(title, description);
+      const combined =
+        typeof this.composeSubtaskTitle === 'function'
+          ? this.composeSubtaskTitle(title, description)
+          : [title, description].filter((segment) => segment).join(' — ');
       if (!combined) {
         continue;
       }
@@ -398,9 +401,12 @@ export class ReportAssistantPageComponent {
     }
 
     return mapped;
-  }
+  };
 
-  private composeSubtaskTitle(title: string, description: string | undefined): string {
+  private readonly composeSubtaskTitle = (
+    title: string,
+    description: string | undefined,
+  ): string => {
     if (title && description) {
       return `${title} — ${description}`;
     }
@@ -410,7 +416,7 @@ export class ReportAssistantPageComponent {
     }
 
     return description ?? '';
-  }
+  };
 
   private resolveSubtaskStatus(statusName: string | null | undefined): Subtask['status'] {
     if (!statusName) {


### PR DESCRIPTION
## Summary
- replace Python `assert` statements across backend tests with `unittest.TestCase` helpers to satisfy Bandit requirements
- update the reports page subtask mapper to guard the composer call and retain lexical `this` binding

## Testing
- black backend/tests
- ruff check backend/tests
- pytest backend/tests
- CI=1 npm run format:check
- CI=1 npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox --progress=false *(fails: missing system dependency libatk-1.0.so.0)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb0c859b483208a8d8f1dad20fe84