### PR TITLE
Add stdin fallback for run_codex_pipeline task input

### DIFF
--- a/scripts/run_codex_pipeline.sh
+++ b/scripts/run_codex_pipeline.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 TASK_INPUT="${TASK_INPUT:-${1:-}}"
+if [ -z "${TASK_INPUT}" ] && [ ! -t 0 ]; then
+  TASK_INPUT="$(cat)"
+fi
 TASK_INPUT="${TASK_INPUT#${TASK_INPUT%%[![:space:]]*}}"
 TASK_INPUT="${TASK_INPUT%${TASK_INPUT##*[![:space:]]}}"
 


### PR DESCRIPTION
## Summary
- allow the codex pipeline script to consume multi-line TASK_INPUT values from stdin as a fallback
- keep the existing whitespace trimming behavior

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd0665bed48320b90b7a1160c9bbc6