### PR TITLE
Enable SonarQube coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ __pycache__/
 .pytest_cache/
 .env
 backend/.env
+.coverage
+coverage.xml
+backend/.coverage
+backend/coverage.xml
+backend/htmlcov/
+frontend/coverage/

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ sonar-scanner
 ```
 
 The helper script runs `coverage run -m pytest` inside `backend/` and `npm run test:ci` in `frontend/`. It emits `backend/coverage.xml`
-and `frontend/coverage/lcov.info`, which are automatically picked up through `sonar-project.properties`.
+and `frontend/coverage/frontend/lcov.info`, which are automatically picked up through `sonar-project.properties`.
 
 ## Documentation and Scripts
 - Architecture and feature deep-dives live under `docs/` (start with `docs/architecture.md`).

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ Run the relevant checks before sending changes for review:
 
 Documentation-only updates may skip automated checks, but keep README and `docs/` aligned with the latest behavior.
 
+## SonarQube Analysis & Coverage
+Generate coverage reports before invoking `sonar-scanner` so SonarQube can display backend and frontend unit test coverage.
+
+```bash
+pip install -r backend/requirements-dev.txt  # ensures the coverage package is available
+npm install --prefix frontend
+
+./scripts/run_tests_with_coverage.sh
+sonar-scanner
+```
+
+The helper script runs `coverage run -m pytest` inside `backend/` and `npm run test:ci` in `frontend/`. It emits `backend/coverage.xml`
+and `frontend/coverage/lcov.info`, which are automatically picked up through `sonar-project.properties`.
+
 ## Documentation and Scripts
 - Architecture and feature deep-dives live under `docs/` (start with `docs/architecture.md`).
 - `docs/development-rules.md` captures workflow expectations, test strategy, and PR guidelines.

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 black==24.10.0
 ruff==0.6.5
+coverage[toml]==7.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,11 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.coverage.run]
+branch = true
+source = ["backend/app"]
+
+[tool.coverage.report]
+skip_empty = true
+show_missing = true

--- a/scripts/run_tests_with_coverage.sh
+++ b/scripts/run_tests_with_coverage.sh
@@ -20,7 +20,7 @@ cat <<'MSG'
 
 Coverage reports generated:
   - Backend: backend/coverage.xml
-  - Frontend: frontend/coverage/lcov.info
+  - Frontend: frontend/coverage/frontend/lcov.info
 
 Run sonar-scanner after executing this script to publish results to SonarQube.
 MSG

--- a/scripts/run_tests_with_coverage.sh
+++ b/scripts/run_tests_with_coverage.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+printf '\n==> Running backend unit tests with coverage\n'
+pushd "$ROOT_DIR/backend" >/dev/null
+coverage erase || true
+coverage run -m pytest tests
+coverage xml -o coverage.xml
+popd >/dev/null
+
+printf '\n==> Running frontend unit tests with coverage\n'
+pushd "$ROOT_DIR/frontend" >/dev/null
+rm -rf coverage
+CI=1 npm run test:ci -- --watch=false
+popd >/dev/null
+
+cat <<'MSG'
+
+Coverage reports generated:
+  - Backend: backend/coverage.xml
+  - Frontend: frontend/coverage/lcov.info
+
+Run sonar-scanner after executing this script to publish results to SonarQube.
+MSG

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,3 +6,5 @@ sonar.exclusions=frontend/src/**/*.spec.ts,frontend/src/**/*.stories.ts
 sonar.tests=backend/tests,frontend/src
 sonar.test.inclusions=backend/tests/**/*.py,frontend/src/**/*.spec.ts
 sonar.python.version=3.11
+sonar.python.coverage.reportPaths=backend/coverage.xml
+sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,4 +7,4 @@ sonar.tests=backend/tests,frontend/src
 sonar.test.inclusions=backend/tests/**/*.py,frontend/src/**/*.spec.ts
 sonar.python.version=3.11
 sonar.python.coverage.reportPaths=backend/coverage.xml
-sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
+sonar.javascript.lcov.reportPaths=frontend/coverage/frontend/lcov.info


### PR DESCRIPTION
## Summary
- add coverage configuration and dependencies so SonarQube can ingest backend and frontend unit test reports
- add a helper script that runs pytest with coverage and Angular CI tests to produce the required XML/LCOV artifacts
- document the SonarQube workflow and ignore generated coverage directories

## Testing
- `pytest backend/tests`
- `./scripts/run_tests_with_coverage.sh` *(fails in this container because ChromeHeadless cannot start: missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0722184c83208c63660ad1f059c9