### PR TITLE
Fix YAML indentation in Codex workflow

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -133,7 +133,7 @@ jobs:
           if github_env:
               with open(github_env, "a", encoding="utf-8") as env_file:
                   env_file.write(f"TASK_INPUT<<{marker}\n{task_input}\n{marker}\n")
-PY
+          PY
 
       - name: Ensure codex CLI
         run: |


### PR DESCRIPTION
## Summary
- ensure the heredoc terminator in the TASK_INPUT resolution step is indented as part of the run script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2885de9083209bab5597d0250a2d