### PR TITLE
Handle optional Node lockfiles in CI tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,13 +37,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve Node cache paths
+        id: node-cache
+        run: |
+          paths=()
+          if [ -f package-lock.json ]; then
+            paths+=("package-lock.json")
+          fi
+          if [ -f frontend/package-lock.json ]; then
+            paths+=("frontend/package-lock.json")
+          fi
+          if [ ${#paths[@]} -gt 0 ]; then
+            printf "paths<<'EOF'\n%s\nEOF\n" "$(printf "%s\n" "${paths[@]}")" >> "${GITHUB_OUTPUT}"
+            echo "cache=npm" >> "${GITHUB_OUTPUT}"
+          else
+            echo "paths=" >> "${GITHUB_OUTPUT}"
+            echo "cache=" >> "${GITHUB_OUTPUT}"
+          fi
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            frontend/package-lock.json
+          cache: ${{ steps.node-cache.outputs.cache }}
+          cache-dependency-path: ${{ steps.node-cache.outputs.paths }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,11 +48,17 @@ jobs:
             paths+=("frontend/package-lock.json")
           fi
           if [ ${#paths[@]} -gt 0 ]; then
-            printf "paths<<'EOF'\n%s\nEOF\n" "$(printf "%s\n" "${paths[@]}")" >> "${GITHUB_OUTPUT}"
-            echo "cache=npm" >> "${GITHUB_OUTPUT}"
+            {
+              echo "paths<<EOF"
+              printf '%s\n' "${paths[@]}"
+              echo "EOF"
+              echo "cache=npm"
+            } >> "${GITHUB_OUTPUT}"
           else
-            echo "paths=" >> "${GITHUB_OUTPUT}"
-            echo "cache=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "paths="
+              echo "cache="
+            } >> "${GITHUB_OUTPUT}"
           fi
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- detect available lockfiles before configuring the npm cache step
- only enable npm caching when lockfiles exist to prevent setup-node from failing

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd2a4e6b208320bc0984439e547e26