### PR TITLE
Fix tests workflow node cache path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,35 +37,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Resolve Node cache paths
-        id: node-cache
-        run: |
-          paths=()
-          if [ -f package-lock.json ]; then
-            paths+=("package-lock.json")
-          fi
-          if [ -f frontend/package-lock.json ]; then
-            paths+=("frontend/package-lock.json")
-          fi
-          if [ ${#paths[@]} -gt 0 ]; then
-            {
-              echo "paths<<EOF"
-              printf '%s\n' "${paths[@]}"
-              echo "EOF"
-              echo "cache=npm"
-            } >> "${GITHUB_OUTPUT}"
-          else
-            {
-              echo "paths="
-              echo "cache="
-            } >> "${GITHUB_OUTPUT}"
-          fi
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: ${{ steps.node-cache.outputs.cache }}
-          cache-dependency-path: ${{ steps.node-cache.outputs.paths }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- update the tests workflow to configure the Node cache directly with the frontend lockfile
- avoid setup-node failures when no repository root lockfile is present

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd2d1c4bd083208a86d36328a313f4