### PR TITLE
Add cache-aware Node setup to workflows

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -51,11 +51,21 @@ jobs:
             exit 1
           fi
 
-      - name: Setup Node (optional)
+      - name: Setup Node (optional, with cache)
+        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      - name: Setup Node (optional, no cache)
+        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') == '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Setup Python deps (optional)
         uses: actions/setup-python@v5

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -34,11 +34,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node (with cache)
+        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') != '' }}
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      - name: Setup Node (no cache)
+        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') == '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: NPM install (no scripts)
         run: npm ci --ignore-scripts || true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,12 +35,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Setup Node (with cache)
+        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      - name: Setup Node (no cache)
+        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') == '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,12 +37,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node (with cache)
+        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') != '' }}
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: |
+            package-lock.json
             frontend/package-lock.json
+
+      - name: Setup Node (no cache)
+        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') == '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- update lint, test, dependency audit, and codex workflows to check for Node lockfiles before enabling npm cache
- fall back to a non-cached Node setup when the lockfiles are absent

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dd3fa1996c83208e7c006fd726775f