### PR TITLE
Update CI cache detection for frontend lockfile

### DIFF
--- a/.github/workflows/auto-resolve-pr.yml
+++ b/.github/workflows/auto-resolve-pr.yml
@@ -37,17 +37,16 @@ jobs:
           git merge --no-commit --no-ff origin/${{ github.base_ref }} || true
 
       - name: Set up Node.js (with cache)
-        if: ${{ hashFiles('package-lock.json','npm-shrinkwrap.json','yarn.lock','frontend/package-lock.json','frontend/npm-shrinkwrap.json','frontend/yarn.lock') != '' }}
+        if: ${{ hashFiles('frontend/package-lock.json','frontend/npm-shrinkwrap.json','frontend/yarn.lock') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: |
-            package-lock.json
             frontend/package-lock.json
 
       - name: Set up Node.js (no cache)
-        if: ${{ hashFiles('package-lock.json','npm-shrinkwrap.json','yarn.lock','frontend/package-lock.json','frontend/npm-shrinkwrap.json','frontend/yarn.lock') == '' }}
+        if: ${{ hashFiles('frontend/package-lock.json','frontend/npm-shrinkwrap.json','frontend/yarn.lock') == '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -52,17 +52,16 @@ jobs:
           fi
 
       - name: Setup Node (optional, with cache)
-        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') != '' }}
+        if: ${{ hashFiles('frontend/package-lock.json') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: |
-            package-lock.json
             frontend/package-lock.json
 
       - name: Setup Node (optional, no cache)
-        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') == '' }}
+        if: ${{ hashFiles('frontend/package-lock.json') == '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -35,17 +35,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node (with cache)
-        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') != '' }}
+        if: ${{ hashFiles('frontend/package-lock.json') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: |
-            package-lock.json
             frontend/package-lock.json
 
       - name: Setup Node (no cache)
-        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') == '' }}
+        if: ${{ hashFiles('frontend/package-lock.json') == '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,17 +36,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node (with cache)
-        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') != '' }}
+        if: ${{ hashFiles('frontend/package-lock.json') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: |
-            package-lock.json
             frontend/package-lock.json
 
       - name: Setup Node (no cache)
-        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') == '' }}
+        if: ${{ hashFiles('frontend/package-lock.json') == '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -130,17 +130,16 @@ jobs:
           PY
 
       - name: Set up Node.js (with cache)
-        if: ${{ steps.sonar_prereqs.outputs.should_run == 'true' && hashFiles('package-lock.json','npm-shrinkwrap.json','yarn.lock','frontend/package-lock.json','frontend/npm-shrinkwrap.json','frontend/yarn.lock') != '' }}
+        if: ${{ steps.sonar_prereqs.outputs.should_run == 'true' && hashFiles('frontend/package-lock.json','frontend/npm-shrinkwrap.json','frontend/yarn.lock') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: |
-            package-lock.json
             frontend/package-lock.json
 
       - name: Set up Node.js (no cache)
-        if: ${{ steps.sonar_prereqs.outputs.should_run == 'true' && hashFiles('package-lock.json','npm-shrinkwrap.json','yarn.lock','frontend/package-lock.json','frontend/npm-shrinkwrap.json','frontend/yarn.lock') == '' }}
+        if: ${{ steps.sonar_prereqs.outputs.should_run == 'true' && hashFiles('frontend/package-lock.json','frontend/npm-shrinkwrap.json','frontend/yarn.lock') == '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,17 +38,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node (with cache)
-        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') != '' }}
+        if: ${{ hashFiles('frontend/package-lock.json') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: |
-            package-lock.json
             frontend/package-lock.json
 
       - name: Setup Node (no cache)
-        if: ${{ hashFiles('package-lock.json','frontend/package-lock.json') == '' }}
+        if: ${{ hashFiles('frontend/package-lock.json') == '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- ensure GitHub Actions workflows detect the frontend lockfile when deciding whether to use cached Node installs
- align cache dependency paths with the frontend lockfile location across CI pipelines

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd4204b8a083209163925855544bbd