### PR TITLE
Fix Codex workflow CLI fallback script creation

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -96,10 +96,7 @@ jobs:
 
           if [ "$found" = false ]; then
             mkdir -p "$HOME/.local/bin"
-            cat > "$HOME/.local/bin/codex" <<'SH'
-#!/usr/bin/env bash
-exec npx -y ${CODEX_NPM_PKG:-@codex/cli} "$@"
-SH
+            printf '%s\n' '#!/usr/bin/env bash' 'exec npx -y ${CODEX_NPM_PKG:-@codex/cli} "$@"' > "$HOME/.local/bin/codex"
             chmod +x "$HOME/.local/bin/codex"
             echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           fi


### PR DESCRIPTION
## Summary
- replace the heredoc-based fallback Codex CLI wrapper with a printf command so the workflow no longer embeds an improperly indented delimiter

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dd4824a578832083e3b1c3af925e5f