### PR TITLE
Force user install for Codex CLI

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -66,15 +66,11 @@ jobs:
         run: |
           set -eux
 
-          rm -f "$HOME/.local/bin/codex"
-
           python -m pip install -U pip
-          python -m pip install "${CODEX_PY_PKG:-codex-cli}"
+          python -m pip install --user "${CODEX_PY_PKG:-codex-cli}"
 
           codex_bin="$(python -m site --user-base)/bin"
-          if [ -d "${codex_bin}" ]; then
-            echo "${codex_bin}" >> "$GITHUB_PATH"
-          fi
+          echo "${codex_bin}" >> "$GITHUB_PATH"
 
           if ! command -v codex >/dev/null 2>&1; then
             echo "::error::codex CLI is unavailable after installation."


### PR DESCRIPTION
## Summary
- ensure the Codex CLI GitHub Actions step installs the package with pip --user
- always append the user base bin directory to PATH so the codex executable is found

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd5cbb36908320a0517c7a8cb26bd7