### PR TITLE
Fix Codex workflow Python scripts path

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -69,7 +69,7 @@ jobs:
           python -m pip install -U pip
           python -m pip install "${CODEX_PY_PKG:-codex-cli}"
 
-          codex_bin="$(python -m site --prefix)/bin"
+          codex_bin="$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')"
           echo "${codex_bin}" >> "$GITHUB_PATH"
 
           which codex || { echo "::error::codex not found"; exit 1; }


### PR DESCRIPTION
## Summary
- replace the invalid `python -m site --prefix` invocation with a sysconfig-based lookup so the Codex CLI directory is added to the PATH reliably

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd948e26ac83209ec71ff81192abff