### PR TITLE
Add Python module fallback when Codex CLI is unavailable

### DIFF
--- a/scripts/run_codex_pipeline.sh
+++ b/scripts/run_codex_pipeline.sh
@@ -17,10 +17,14 @@ if command -v codex >/dev/null 2>&1; then
   CODEX_CLI=(codex)
 elif command -v python >/dev/null 2>&1 && python -c "import codex" >/dev/null 2>&1; then
   CODEX_CLI=(python -m codex)
+elif command -v python3 >/dev/null 2>&1 && python3 -c "import codex" >/dev/null 2>&1; then
+  CODEX_CLI=(python3 -m codex)
 elif command -v python >/dev/null 2>&1 && python -c "import codex_cli" >/dev/null 2>&1; then
   CODEX_CLI=(python -m codex_cli)
+elif command -v python3 >/dev/null 2>&1 && python3 -c "import codex_cli" >/dev/null 2>&1; then
+  CODEX_CLI=(python3 -m codex_cli)
 else
-  echo "Codex CLI not found in PATH or as a Python module. Install @google/generative-ai." >&2
+  echo "Error: codex CLI not found (checked codex, python -m codex, python3 -m codex, codex_cli)." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- detect the available Codex interface, preferring the CLI but falling back to python -m codex or codex_cli
- reuse the detected command for login and exec calls in the pipeline script

## Testing
- not run (script change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd98906af88320aea5ce00664e1b37