### PR TITLE
Use module invocation for Codex CLI in workflow

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -64,16 +64,19 @@ jobs:
 
       - name: Install Codex CLI
         run: |
-          set -eux
+          set -euo pipefail
 
           python -m pip install -U pip
           python -m pip install "${CODEX_PY_PKG:-codex-cli}"
 
-          codex_bin=$(python -c "import sysconfig; print(sysconfig.get_path('scripts'))")
-          echo "${codex_bin}" >> "$GITHUB_PATH"
-
-          which codex || { echo "::error::codex not found"; exit 1; }
-          codex --version
+          if python -m codex --version >/dev/null 2>&1; then
+            python -m codex --version
+          elif python -m codex_cli --version >/dev/null 2>&1; then
+            python -m codex_cli --version
+          else
+            echo "::error::codex module entry point not found"
+            exit 1
+          fi
 
       - name: Resolve TASK_INPUT
         id: resolve_task_input


### PR DESCRIPTION
## Summary
- replace the workflow's Codex CLI invocation with python -m execution so it works without a console script
- keep verifying the CLI installation by falling back to codex_cli when codex is unavailable

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dd9c7131d88320b992027ea496e930