### PR TITLE
Add debug logging for Codex installation

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -83,6 +83,16 @@ jobs:
             exit 1
           fi
 
+      - name: Debug Codex install
+        run: |
+          python -m pip show codex-cli
+          python - <<'PY'
+          import pkgutil
+
+          mods = [m.name for m in pkgutil.iter_modules()]
+          print("Installed modules containing 'codex':", [m for m in mods if "codex" in m])
+          PY
+
       - name: Resolve TASK_INPUT
         id: resolve_task_input
         run: |


### PR DESCRIPTION
## Summary
- add a GitHub Actions step to show codex-cli metadata and list installed codex modules for easier debugging

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dda80b173083209cf7ad15f14c6408