### PR TITLE
Detect codex-cli binary in pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ and `frontend/coverage/frontend/lcov.info`, which are automatically picked up th
 - Architecture and feature deep-dives live under `docs/` (start with `docs/architecture.md`).
 - `docs/development-rules.md` captures workflow expectations, test strategy, and PR guidelines.
 - Prompt reference files for AI orchestration are stored under `prompts/`.
-- `scripts/run_codex_pipeline.sh` runs the Codex automation pipeline; `start-mcp-servers.*` launches Model Context Protocol helper servers.
+- `scripts/run_codex_pipeline.sh` runs the Codex automation pipeline; ensure the [`codex-cli`](https://pypi.org/project/codex-cli/) executable (or Python module) is on your `PATH` before invoking it. `start-mcp-servers.*` launches Model Context Protocol helper servers.
 
 ### Documentation quick links
 - [Documentation index](docs/README.md) – curated map of the most frequently referenced specs and playbooks.

--- a/scripts/run_codex_pipeline.sh
+++ b/scripts/run_codex_pipeline.sh
@@ -13,7 +13,9 @@ if [ -z "${TASK_INPUT}" ]; then
   exit 1
 fi
 
-if command -v codex >/dev/null 2>&1; then
+if command -v codex-cli >/dev/null 2>&1; then
+  CODEX_CLI=(codex-cli)
+elif command -v codex >/dev/null 2>&1; then
   CODEX_CLI=(codex)
 elif command -v python >/dev/null 2>&1 && python -c "import codex" >/dev/null 2>&1; then
   CODEX_CLI=(python -m codex)
@@ -24,7 +26,7 @@ elif command -v python >/dev/null 2>&1 && python -c "import codex_cli" >/dev/nul
 elif command -v python3 >/dev/null 2>&1 && python3 -c "import codex_cli" >/dev/null 2>&1; then
   CODEX_CLI=(python3 -m codex_cli)
 else
-  echo "Error: codex CLI not found (checked codex, python -m codex, python3 -m codex, codex_cli)." >&2
+  echo "Error: codex CLI not found (checked codex-cli, codex, python -m codex, python3 -m codex, codex_cli)." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- prefer the `codex-cli` executable when resolving the Codex runner in `run_codex_pipeline.sh`
- document the need to expose `codex-cli` (or the Python module) on `PATH` before invoking the Codex pipeline script

## Testing
- not run (not required for this change)


------
https://chatgpt.com/codex/tasks/task_e_68ddb3f99bac8320b9e093e40367f9d6