### PR TITLE
Fix Codex workflow CLI installation

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 30
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      CODEX_PY_PKG: "codex-cli"
+      CODEX_NPM_PKG: "@openai/codex"
 
     steps:
       - uses: actions/checkout@v4
@@ -64,31 +64,14 @@ jobs:
 
       - name: Install Codex CLI
         run: |
-          pip install ${CODEX_PY_PKG:-codex-cli}
-          echo "/opt/hostedtoolcache/Python/3.11.13/x64/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          hash -r
+          npm i -g ${CODEX_NPM_PKG:-@openai/codex}@0.39.0
+          codex --version
 
-          if python -m codex --version >/dev/null 2>&1; then
-            python -m codex --version
-          elif python -m codex_cli --version >/dev/null 2>&1; then
-            python -m codex_cli --version
-          elif command -v codex >/dev/null 2>&1; then
-            codex --version
-          else
-            echo "::error::Codex CLI not found (neither module nor binary)"
-            exit 1
-          fi
-
-      - name: Debug Codex install
+      - name: Check PATH and codex
         run: |
-          python -m pip show codex-cli
-          python - <<'PY'
-          import pkgutil
-
-          mods = [m.name for m in pkgutil.iter_modules()]
-          print("Installed modules containing 'codex':", [m for m in mods if "codex" in m])
-          PY
+          which codex || true
+          codex --version || true
+          npx -y ${CODEX_NPM_PKG:-@openai/codex}@0.39.0 --version || true
 
       - name: Resolve TASK_INPUT
         id: resolve_task_input

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ and `frontend/coverage/frontend/lcov.info`, which are automatically picked up th
 - Architecture and feature deep-dives live under `docs/` (start with `docs/architecture.md`).
 - `docs/development-rules.md` captures workflow expectations, test strategy, and PR guidelines.
 - Prompt reference files for AI orchestration are stored under `prompts/`.
-- `scripts/run_codex_pipeline.sh` runs the Codex automation pipeline; ensure the [`codex-cli`](https://pypi.org/project/codex-cli/) executable (or Python module) is on your `PATH` before invoking it. `start-mcp-servers.*` launches Model Context Protocol helper servers.
+- `scripts/run_codex_pipeline.sh` runs the Codex automation pipeline; install the [`@openai/codex`](https://www.npmjs.com/package/@openai/codex) CLI globally (`npm i -g @openai/codex`) or expose `node_modules/.bin` on your `PATH` so `codex` (or `npx @openai/codex`) is reachable. `start-mcp-servers.*` launches Model Context Protocol helper servers.
 
 ### Documentation quick links
 - [Documentation index](docs/README.md) – curated map of the most frequently referenced specs and playbooks.

--- a/scripts/run_codex_pipeline.sh
+++ b/scripts/run_codex_pipeline.sh
@@ -13,10 +13,10 @@ if [ -z "${TASK_INPUT}" ]; then
   exit 1
 fi
 
-if command -v codex-cli >/dev/null 2>&1; then
-  CODEX_CLI=(codex-cli)
-elif command -v codex >/dev/null 2>&1; then
+if command -v codex >/dev/null 2>&1; then
   CODEX_CLI=(codex)
+elif command -v codex-cli >/dev/null 2>&1; then
+  CODEX_CLI=(codex-cli)
 elif command -v python >/dev/null 2>&1 && python -c "import codex" >/dev/null 2>&1; then
   CODEX_CLI=(python -m codex)
 elif command -v python3 >/dev/null 2>&1 && python3 -c "import codex" >/dev/null 2>&1; then
@@ -25,8 +25,11 @@ elif command -v python >/dev/null 2>&1 && python -c "import codex_cli" >/dev/nul
   CODEX_CLI=(python -m codex_cli)
 elif command -v python3 >/dev/null 2>&1 && python3 -c "import codex_cli" >/dev/null 2>&1; then
   CODEX_CLI=(python3 -m codex_cli)
+elif command -v npx >/dev/null 2>&1; then
+  CODEX_NPM_PKG="${CODEX_NPM_PKG:-@openai/codex}"
+  CODEX_CLI=(npx -y "${CODEX_NPM_PKG}")
 else
-  echo "Error: codex CLI not found (checked codex-cli, codex, python -m codex, python3 -m codex, codex_cli)." >&2
+  echo "Error: codex CLI not found (checked codex, codex-cli, python -m codex, python3 -m codex, codex_cli, and npx)." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- install the @openai/codex CLI in the Codex workflow using npm and add diagnostic checks
- fall back to npx when invoking the Codex pipeline script so the CLI can run without a global install
- update the README to document the new CLI installation path

## Testing
- not run (configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ddb9044fb88320ae490f2d96184e9c