### PR TITLE
Align Codex workflow branches with issues

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -173,7 +173,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: codex/${{ github.run_id }}
+          branch: ${{ github.event_name == 'issue_comment' && format('codex/issue-{0}', steps.detect.outputs.issue_number) || format('codex/run-{0}', github.run_id) }}
           base: ${{ github.event.repository.default_branch }}
           commit-message: "chore(codex): apply generated changes"
           title: "${{ github.event_name == 'issue_comment' && format('Codex: issue #{0}', steps.detect.outputs.issue_number) || 'Codex: manual run' }}"
@@ -194,7 +194,7 @@ jobs:
             const body = [
               "Automated work completed by Codex.",
               "",
-              `- Created PR: #${prNumber} (${prUrl})`,
+              `- Created/updated PR: #${prNumber} (${prUrl})`,
               "- Artifacts: attached as workflow artifact `codex-agent-outputs`",
               "",
               "Task input (JSON):",


### PR DESCRIPTION
## Summary
- reuse a consistent codex branch per GitHub issue so commits accumulate on the same pull request
- clarify the automated status comment to reflect that pull requests may be updated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5fe4ed5c8320a11cf0104c67afad