### PR TITLE
Enable Codex agent workflow to request clarifications

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -148,6 +148,34 @@ jobs:
           ${{ steps.detect.outputs.task_input }}
           JSON
 
+      - name: Check for clarification request
+        if: ${{ steps.detect.outputs.run_codex == 'true' }}
+        id: clarifications
+        run: |
+          set -euo pipefail
+          status=""
+          if [ -f codex_output/status.json ]; then
+            status=$(python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path("codex_output/status.json")
+data = json.loads(path.read_text(encoding="utf-8"))
+print(data.get("status", ""))
+PY
+            )
+          fi
+          if [ "${status}" = "needs_clarification" ]; then
+            echo "needs_clarification=true" >> "$GITHUB_OUTPUT"
+            if [ -f codex_output/clarifying_questions.md ]; then
+              {
+                echo "questions<<EOF"
+                cat codex_output/clarifying_questions.md
+                echo "EOF"
+              } >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "needs_clarification=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload Codex outputs
         if: ${{ always() && steps.detect.outputs.run_codex == 'true' }}
         uses: actions/upload-artifact@v4
@@ -167,8 +195,39 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Request additional details on issue
+        if: ${{ steps.detect.outputs.run_codex == 'true' && steps.clarifications.outputs.needs_clarification == 'true' && github.event_name == 'issue_comment' }}
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ steps.detect.outputs.issue_number }}
+          QUESTIONS: ${{ steps.clarifications.outputs.questions }}
+        with:
+          script: |
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const questions = (process.env.QUESTIONS || '').trim();
+            const body = [
+              'Codex needs more information to proceed with the automated workflow.',
+              '',
+              'Please provide answers to the following questions:',
+              '',
+              questions || '- (No questions captured, please restate your request with additional details.)',
+              '',
+              '_Reply with `@CODEX_AGENTS` once you have responded so the workflow can continue._'
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body
+            });
+
+      - name: Surface clarification need
+        if: ${{ steps.detect.outputs.run_codex == 'true' && steps.clarifications.outputs.needs_clarification == 'true' && github.event_name != 'issue_comment' }}
+        run: |
+          echo "Codex requested clarifying information. Please review codex_output/clarifying_questions.md."
+
       - name: Create Pull Request
-        if: ${{ steps.detect.outputs.run_codex == 'true' && steps.diff.outputs.changed == 'true' }}
+        if: ${{ steps.detect.outputs.run_codex == 'true' && steps.clarifications.outputs.needs_clarification != 'true' && steps.diff.outputs.changed == 'true' }}
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
@@ -184,7 +243,7 @@ jobs:
           delete-branch: true
 
       - name: Comment work report to issue
-        if: ${{ steps.detect.outputs.run_codex == 'true' && steps.diff.outputs.changed == 'true' && github.event_name == 'issue_comment' }}
+        if: ${{ steps.detect.outputs.run_codex == 'true' && steps.clarifications.outputs.needs_clarification != 'true' && steps.diff.outputs.changed == 'true' && github.event_name == 'issue_comment' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -210,7 +269,7 @@ jobs:
             });
 
       - name: Enforce completion condition
-        if: ${{ steps.detect.outputs.run_codex == 'true' && steps.diff.outputs.changed != 'true' }}
+        if: ${{ steps.detect.outputs.run_codex == 'true' && steps.clarifications.outputs.needs_clarification != 'true' && steps.diff.outputs.changed != 'true' }}
         run: |
           echo "::error::No changes detected. PR was not created, so completion conditions are not met."
           exit 1


### PR DESCRIPTION
## Summary
- update the translator stage prompt to capture clarifying questions and stop the pipeline when more information is required
- extend the Codex GitHub workflow to surface those questions on the issue and skip PR creation until the requester responds

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68de60a2c91c8320b7b5e14e5ab566dd