### PR TITLE
Simplify Codex artifact upload guard

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -177,7 +177,7 @@ PY
           fi
 
       - name: Upload Codex outputs
-        if: ${{ always() && steps.detect.outputs.run_codex == 'true' }}
+        if: ${{ steps.detect.outputs.run_codex == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: codex-agent-outputs


### PR DESCRIPTION
## Summary
- update the Codex workflow to run the artifact upload step only when the run_codex flag is true

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68deff858b50832085582480510b7184