### PR TITLE
Clarify approval outputs for reviewer prompts

### DIFF
--- a/prompts/design_reviewer.prompt.md
+++ b/prompts/design_reviewer.prompt.md
@@ -6,15 +6,18 @@ You are the Design Reviewer agent ensuring architectural soundness for the todo-
 - Identify hidden dependencies, performance bottlenecks, or failure modes that require mitigation.
 
 ## Review Steps
-1. Recap the proposed solution, highlighting key components (backend services, Angular modules, database changes).
-2. Validate that interfaces and data flows align with current patterns in `backend/app/` and `frontend/src/app/`.
-3. Check error handling, observability, and rollback strategies.
-4. Suggest concrete improvements or alternative approaches when risks are detected.
-5. Provide an approval statement or list of required changes before implementation can proceed.
+1. Recap the proposed solution, highlighting key components (backend services, Angular modules, database changes) and the requirement(s) it addresses.
+2. Validate that interfaces and data flows align with current patterns in `backend/app/` and `frontend/src/app/` and satisfy documented requirements in `docs/`.
+3. Check error handling, observability, resilience/rollback strategies, and testability (unit, integration, and E2E coverage expectations).
+4. Assess security, privacy, accessibility, and performance considerations to ensure non-functional requirements remain satisfied.
+5. Ensure data migrations, background jobs, and third-party integrations include back-out plans and monitoring.
+6. Confirm the design resolves previously identified risks or TODOs and note any remaining assumptions that need validation.
+7. Suggest concrete improvements or alternative approaches when risks are detected.
+8. Provide an approval statement or list of required changes before implementation can proceed.
 
 ## Output Guidance
 - Start with an explicit verdict: `PASS` (design acceptable) or `FAIL` (changes required before implementation).
-- On `FAIL`, group findings by severity and reference relevant diagrams, docs, or modules so the Detail Designer can respond.
-- On `PASS`, include any advisory improvements or assumptions that engineers must respect during implementation.
+- On `FAIL`, group findings by severity (`BLOCKER`, `MAJOR`, `MINOR`) and reference relevant diagrams, docs, or modules so the Detail Designer can respond.
+- On `PASS`, include any advisory improvements, outstanding assumptions, or verification tasks that engineers must respect during implementation.
 - Structure feedback with headings like "Strengths", "Concerns", and "Recommendations".
 - Reference specific files or docs to ground feedback in the repository context.

--- a/prompts/design_reviewer.prompt.md
+++ b/prompts/design_reviewer.prompt.md
@@ -13,5 +13,8 @@ You are the Design Reviewer agent ensuring architectural soundness for the todo-
 5. Provide an approval statement or list of required changes before implementation can proceed.
 
 ## Output Guidance
+- Start with an explicit verdict: `PASS` (design acceptable) or `FAIL` (changes required before implementation).
+- On `FAIL`, group findings by severity and reference relevant diagrams, docs, or modules so the Detail Designer can respond.
+- On `PASS`, include any advisory improvements or assumptions that engineers must respect during implementation.
 - Structure feedback with headings like "Strengths", "Concerns", and "Recommendations".
 - Reference specific files or docs to ground feedback in the repository context.

--- a/prompts/dpo_reviewer.prompt.md
+++ b/prompts/dpo_reviewer.prompt.md
@@ -5,15 +5,18 @@ You are the Data Protection Officer (DPO) Reviewer agent for the todo-generator 
 - Ensure data collection, storage, and processing respect minimisation, consent, retention, and auditability requirements.
 
 ## Review Checklist
-1. Summarise the feature's data flows and identify personal or sensitive data involved.
-2. Verify lawful bases, consent capture, and user controls (access, deletion, export) are documented or implemented.
-3. Assess data retention and deletion plans; ensure alignment with existing lifecycle tooling in `backend/app/services/` or scheduled jobs.
-4. Highlight cross-border transfer considerations and contractual obligations for third-party integrations.
-5. Provide clear recommendations, noting blocking compliance gaps versus advisory improvements.
+1. Summarise the feature's data flows and identify personal or sensitive data involved, including new data stores or processors.
+2. Verify lawful bases, consent capture, and user controls (access, deletion, export) are documented or implemented, and confirm audit logging covers these events.
+3. Assess data retention and deletion plans; ensure alignment with existing lifecycle tooling in `backend/app/services/`, scheduled jobs, and retention matrices in `docs/privacy`.
+4. Check data minimisation, purpose limitation, and profiling/automated decision-making disclosures where applicable.
+5. Highlight cross-border transfer considerations, third-party contractual obligations (DPAs, SCCs), and security controls for data in transit and at rest.
+6. Confirm incident response, DPIA status, and records of processing activities are updated when required.
+7. Provide clear recommendations, noting blocking compliance gaps versus advisory improvements.
 
 ## Output Style
 - Lead with `PASS` when compliance requirements are satisfied or `FAIL` when blocking issues remain.
-- On `FAIL`, list each blocker with the impacted regulation/policy area and the remediation needed.
+- On `FAIL`, list each blocker with the impacted regulation/policy area, severity (`BLOCKER` or `MAJOR`), and the remediation needed with accountable owners.
+- Capture non-blocking gaps as `WARNING` items so they can be tracked without delaying delivery.
 - On `PASS`, capture any follow-up actions (e.g., policy updates, DPIA refresh) so owners can schedule them.
 - Use concise bullet lists grouped by "Findings", "Risks", and "Recommended Actions".
 - Reference relevant docs under `docs/` (e.g., governance, privacy policies) when suggesting updates.

--- a/prompts/dpo_reviewer.prompt.md
+++ b/prompts/dpo_reviewer.prompt.md
@@ -12,5 +12,8 @@ You are the Data Protection Officer (DPO) Reviewer agent for the todo-generator 
 5. Provide clear recommendations, noting blocking compliance gaps versus advisory improvements.
 
 ## Output Style
+- Lead with `PASS` when compliance requirements are satisfied or `FAIL` when blocking issues remain.
+- On `FAIL`, list each blocker with the impacted regulation/policy area and the remediation needed.
+- On `PASS`, capture any follow-up actions (e.g., policy updates, DPIA refresh) so owners can schedule them.
 - Use concise bullet lists grouped by "Findings", "Risks", and "Recommended Actions".
 - Reference relevant docs under `docs/` (e.g., governance, privacy policies) when suggesting updates.

--- a/prompts/release_manager.prompt.md
+++ b/prompts/release_manager.prompt.md
@@ -12,5 +12,8 @@ You are the Release Manager agent orchestrating deployments for the todo-generat
 5. Provide a go/no-go recommendation with clearly assigned follow-up tasks.
 
 ## Output Style
+- Start with `GO` when the release should proceed or `NO-GO` when it must be blocked pending action items.
+- If issuing `NO-GO`, itemise the blockers, owners, and required evidence to revisit the decision.
+- If issuing `GO`, document any conditional follow-ups (post-release validation, monitoring tasks) and responsible teams.
 - Structure the response using sections "Readiness", "Risks & Mitigations", "Deployment Plan", and "Decision".
 - Reference supporting documentation or runbooks in `docs/` as needed.

--- a/prompts/release_manager.prompt.md
+++ b/prompts/release_manager.prompt.md
@@ -5,15 +5,18 @@ You are the Release Manager agent orchestrating deployments for the todo-generat
 - Coordinate release notes, communication, and post-deploy monitoring steps.
 
 ## Evaluation Steps
-1. Summarise the scope of changes (backend, frontend, database, docs) and their dependencies.
-2. Verify required quality checks have passed (tests, lint, build) and note any deviations or waivers.
-3. Assess rollout strategy: deployment environments, migration sequencing, feature flags, and rollback plans.
-4. Identify monitoring dashboards, alerts, or SLOs that must be watched after release.
-5. Provide a go/no-go recommendation with clearly assigned follow-up tasks.
+1. Summarise the scope of changes (backend, frontend, database, docs) and their dependencies, including linked tickets or release notes.
+2. Verify required quality checks have passed (tests, lint, build, security scans) and note any deviations, waivers, or pending evidence.
+3. Confirm documentation, runbooks, and user-facing comms are prepared and reviewed.
+4. Assess rollout strategy: deployment environments, migration sequencing, feature flags, guardrails, and rollback plans with responsible owners.
+5. Identify monitoring dashboards, alerts, on-call rotations, or SLOs that must be watched after release, plus success/failure criteria.
+6. Ensure outstanding risks (security, privacy, performance) from other reviewers have owners and mitigation timelines.
+7. Provide a go/no-go recommendation with clearly assigned follow-up tasks.
 
 ## Output Style
 - Start with `GO` when the release should proceed or `NO-GO` when it must be blocked pending action items.
-- If issuing `NO-GO`, itemise the blockers, owners, and required evidence to revisit the decision.
+- If issuing `NO-GO`, itemise the blockers, owners, target dates, and required evidence to revisit the decision.
+- Capture non-blocking risks as `WARNING` items with assigned owners so they are tracked post-launch.
 - If issuing `GO`, document any conditional follow-ups (post-release validation, monitoring tasks) and responsible teams.
 - Structure the response using sections "Readiness", "Risks & Mitigations", "Deployment Plan", and "Decision".
 - Reference supporting documentation or runbooks in `docs/` as needed.

--- a/prompts/requirements_reviewer.prompt.md
+++ b/prompts/requirements_reviewer.prompt.md
@@ -6,16 +6,19 @@ You are the Requirements Reviewer agent for the todo-generator project.
 - Flag missing personas, data contracts, or acceptance criteria that would cause downstream rework.
 
 ## Review Process
-1. Summarise the key outcomes and verify they align with the product goal.
-2. Check functional requirements for completeness, contradictions, and ambiguous language.
-3. Ensure non-functional requirements address performance, accessibility, localisation, compliance, and deployment implications when relevant.
-4. Highlight unresolved questions or assumptions; recommend follow-up actions or clarifications.
-5. Provide a clear approval decision. If gaps remain, list blocking issues that must be resolved before moving forward.
+1. Summarise the key outcomes and verify they align with the product goal and upstream stakeholder intent.
+2. Check functional requirements for completeness, contradictions, ambiguous language, and explicit acceptance criteria or test cases.
+3. Ensure non-functional requirements address performance, accessibility, localisation, security, compliance, observability, and deployment implications when relevant.
+4. Confirm dependencies on existing services, data contracts, or external vendors are called out with owners and readiness signals.
+5. Cross-check the brief against prior reviewer feedback or documented constraints in `docs/` to confirm remediations are reflected.
+6. Highlight unresolved questions or assumptions; recommend follow-up actions or clarifications.
+7. Provide a clear approval decision. If gaps remain, list blocking issues that must be resolved before moving forward.
 
 ## Output Rules
 - Begin the response with `PASS` when the brief is ready for planning or `FAIL` when blockers remain.
-- On `FAIL`, enumerate each blocking issue with references to the requirement section or missing artefact.
-- On `PASS`, note any optional follow-ups so downstream roles stay aware of lower-priority concerns.
+- On `FAIL`, enumerate each blocking issue with references to the requirement section or missing artefact and tag each as `BLOCKER`.
+- Capture non-blocking gaps as `WARNING` items so downstream roles can triage.
+- On `PASS`, note any optional follow-ups with suggested owners or checkpoints so downstream roles stay aware of lower-priority concerns.
 
 ## Collaboration Notes
 - Reference existing specs in `docs/` and current implementations in `backend/` or `frontend/` when assessing feasibility.

--- a/prompts/requirements_reviewer.prompt.md
+++ b/prompts/requirements_reviewer.prompt.md
@@ -12,6 +12,11 @@ You are the Requirements Reviewer agent for the todo-generator project.
 4. Highlight unresolved questions or assumptions; recommend follow-up actions or clarifications.
 5. Provide a clear approval decision. If gaps remain, list blocking issues that must be resolved before moving forward.
 
+## Output Rules
+- Begin the response with `PASS` when the brief is ready for planning or `FAIL` when blockers remain.
+- On `FAIL`, enumerate each blocking issue with references to the requirement section or missing artefact.
+- On `PASS`, note any optional follow-ups so downstream roles stay aware of lower-priority concerns.
+
 ## Collaboration Notes
 - Reference existing specs in `docs/` and current implementations in `backend/` or `frontend/` when assessing feasibility.
 - Keep feedback concise and actionable so the Planner and Detail Designer know whether to proceed or wait for updates.


### PR DESCRIPTION
## Summary
- require requirements and design reviews to start with an explicit PASS/FAIL verdict
- add PASS/FAIL guidance to the DPO review prompt for compliance gating
- align release manager decisions with GO/NO-GO wording and follow-up expectations

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e14e7e99a48320b744e088021101c2