### PR TITLE
Update board page copy

### DIFF
--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -2,7 +2,7 @@
   <app-page-header
     eyebrow="Workspace Board"
     title="カード管理ボード"
-    description="ステータスやラベルでタスクを俯瞰し、サブタスクはステータス別ボードでドラッグ＆ドロップ更新できます。"
+    description="ステータスやラベルでタスクをグルーピングでき、サブタスクはドラッグ＆ドロップ更新できます。"
   >
     <div appPageHeaderActions class="flex flex-wrap items-center gap-2">
       <span class="page-badge">{{ filtersSignal().search || '検索なし' }}</span>
@@ -100,9 +100,6 @@
         </button>
       </div>
     </section>
-    <p class="page-empty board-page__hint">
-      タスクはラベルやステータスで切り替えながら管理でき、サブタスクはステータス別ボードでドラッグ＆ドロップ更新できます。選択したタスクに紐づくサブタスクはハイライト表示されます。
-    </p>
   </div>
 
   <div class="board-page__subtasks">


### PR DESCRIPTION
## Summary
- update the board page header description to reflect the new grouping copy
- remove the outdated overview hint paragraph under the board filters

## Testing
- not run (copy-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e15393685c8320a8cf85fa1cd0a636