### PR TITLE
Replace report status input with selector

### DIFF
--- a/frontend/src/app/features/reports/reports-page.component.html
+++ b/frontend/src/app/features/reports/reports-page.component.html
@@ -252,12 +252,12 @@
                   <div class="form-grid form-grid--two report-assistant-page__proposal-grid">
                     <div class="form-field">
                       <label class="form-field__label">推奨ステータス</label>
-                      <input
-                        type="text"
-                        class="form-control"
-                        formControlName="status"
-                        placeholder="例: In Progress"
-                      />
+                      <select class="form-control" formControlName="status">
+                        <option value="">ステータスを選択</option>
+                        @for (status of statusOptions(); track status.id) {
+                          <option [value]="status.id">{{ status.name }}</option>
+                        }
+                      </select>
                     </div>
                     <div class="form-field">
                       <label class="form-field__label">推奨ラベル</label>


### PR DESCRIPTION
## Summary
- replace the free-text status field in the report proposal editor with a select element backed by workspace statuses
- initialize proposal forms with canonical status identifiers so published cards map directly to workspace status IDs

## Testing
- CI=1 npx ng test --browsers=ChromeHeadlessNoSandbox --watch=false --code-coverage=false --progress=false *(fails: ChromeHeadless requires libatk-1.0.so.0 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ed8d14748320add3a4cbb65442a2