### PR TITLE
Display timestamps in local time using Temporal

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/forms": "^20.3.2",
         "@angular/platform-browser": "^20.3.2",
         "@angular/router": "^20.3.2",
+        "@js-temporal/polyfill": "^0.5.1",
         "rxjs": "~7.8.2",
         "tslib": "^2.8.1",
         "zone.js": "~0.15.1"
@@ -4698,6 +4699,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@jsonjoy.com/base64": {
@@ -11784,6 +11797,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "@angular/forms": "^20.3.2",
     "@angular/platform-browser": "^20.3.2",
     "@angular/router": "^20.3.2",
+    "@js-temporal/polyfill": "^0.5.1",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1",
     "zone.js": "~0.15.1"

--- a/frontend/src/app/features/admin/page.html
+++ b/frontend/src/app/features/admin/page.html
@@ -96,7 +96,7 @@
               </p>
               <div class="page-list__meta">
                 <span>評価項目: {{ competency.criteria.length }}件</span>
-                <span>最終更新: {{ competency.updated_at | date: 'medium' }}</span>
+                <span>最終更新: {{ competency.updated_at | localDateTime: 'medium' }}</span>
               </div>
             </li>
           }
@@ -283,8 +283,8 @@
                 </div>
                 <span class="admin-evaluations__meta">
                   対象: {{ userEmail(evaluation.user_id) }} ／ 期間:
-                  {{ evaluation.period_start | date: 'yyyy/MM/dd' }} -
-                  {{ evaluation.period_end | date: 'yyyy/MM/dd' }}
+                  {{ evaluation.period_start | localDateTime: 'yyyy/MM/dd' }} -
+                  {{ evaluation.period_end | localDateTime: 'yyyy/MM/dd' }}
                 </span>
               </header>
               <p class="admin-evaluations__rationale">
@@ -408,7 +408,7 @@
       @if (apiCredential(); as credential) {
         <p class="form-note">
           現在のキー: {{ credential.secret_hint || '****' }} ／ 更新日:
-          {{ credential.updated_at | date: 'medium' }}
+          {{ credential.updated_at | localDateTime: 'medium' }}
         </p>
       } @else {
         <p class="page-empty">登録済みの API トークンはありません。</p>

--- a/frontend/src/app/features/admin/page.ts
+++ b/frontend/src/app/features/admin/page.ts
@@ -26,6 +26,7 @@ import {
   QuotaDefaults,
 } from '@core/models';
 import { signalForms } from '@shared/utils/signal-forms';
+import { LocalDateTimePipe } from '@shared/pipes/local-date-time.pipe';
 
 type AdminTab = 'competencies' | 'evaluations' | 'users' | 'settings';
 type CriterionFormGroup = FormGroup<{
@@ -47,7 +48,7 @@ type CompetencyFormControls = {
 @Component({
   selector: 'app-admin-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, PageLayoutComponent],
+  imports: [CommonModule, ReactiveFormsModule, PageLayoutComponent, LocalDateTimePipe],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/analytics/page.html
+++ b/frontend/src/app/features/analytics/page.html
@@ -337,7 +337,9 @@
             <ul class="mt-3 space-y-2 text-xs text-slate-500">
               @for (log of initiative.progress; track log.id) {
                 <li>
-                  <span class="font-semibold">{{ log.timestamp | date: 'yyyy/MM/dd' }}</span>
+                  <span class="font-semibold">{{
+                    log.timestamp | localDateTime: 'yyyy/MM/dd'
+                  }}</span>
                   {{ log.status }} — {{ log.notes }}
                 </li>
               }

--- a/frontend/src/app/features/analytics/page.ts
+++ b/frontend/src/app/features/analytics/page.ts
@@ -13,6 +13,7 @@ import { FeedbackSeverity } from '@core/models';
 import { ContinuousImprovementStore } from '@core/state/continuous-improvement-store';
 import { WorkspaceStore } from '@core/state/workspace-store';
 import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
+import { LocalDateTimePipe } from '@shared/pipes/local-date-time.pipe';
 
 type ActionFeedback = { status: 'success' | 'error'; message: string };
 
@@ -22,7 +23,7 @@ type ActionFeedback = { status: 'success' | 'error'; message: string };
 @Component({
   selector: 'app-analytics-page',
   standalone: true,
-  imports: [CommonModule, RouterLink, PageLayoutComponent],
+  imports: [CommonModule, RouterLink, PageLayoutComponent, LocalDateTimePipe],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -280,7 +280,7 @@
                     </div>
                     @if (subtask.dueDate) {
                       <p class="text-[11px] text-slate-500">
-                        期限: {{ subtask.dueDate | date: 'yyyy/MM/dd' }}
+                        期限: {{ subtask.dueDate | localDateTime: 'yyyy/MM/dd' }}
                       </p>
                     }
                     @if (!subtask.isCompact) {
@@ -355,7 +355,9 @@
             </div>
             <div class="card-overview__item">
               <dt>期限</dt>
-              <dd>{{ active.dueDate ? (active.dueDate | date: 'yyyy/MM/dd') : '未設定' }}</dd>
+              <dd>
+                {{ active.dueDate ? (active.dueDate | localDateTime: 'yyyy/MM/dd') : '未設定' }}
+              </dd>
             </div>
             <div class="card-overview__item">
               <dt>AIおすすめ度</dt>
@@ -391,7 +393,7 @@
                     <div class="comment-list__identity">
                       <span class="comment-list__author">{{ comment.authorNickname }}</span>
                       <span class="comment-list__timestamp"
-                        >更新: {{ comment.updatedAt | date: 'yyyy/MM/dd HH:mm' }}</span
+                        >更新: {{ comment.updatedAt | localDateTime: 'yyyy/MM/dd HH:mm' }}</span
                       >
                       @if (isCommentBeingEdited(comment.id)) {
                         <span class="comment-list__status">編集中</span>
@@ -432,7 +434,7 @@
                       <div class="comment-list__identity">
                         <span class="comment-list__author">{{ comment.authorNickname }}</span>
                         <span class="comment-list__timestamp"
-                          >更新: {{ comment.updatedAt | date: 'yyyy/MM/dd HH:mm' }}</span
+                          >更新: {{ comment.updatedAt | localDateTime: 'yyyy/MM/dd HH:mm' }}</span
                         >
                       </div>
                       <div class="comment-list__actions">
@@ -625,7 +627,10 @@
                                     comment.authorNickname
                                   }}</span>
                                   <span class="comment-list__timestamp"
-                                    >更新: {{ comment.updatedAt | date: 'yyyy/MM/dd HH:mm' }}</span
+                                    >更新:
+                                    {{
+                                      comment.updatedAt | localDateTime: 'yyyy/MM/dd HH:mm'
+                                    }}</span
                                   >
                                   @if (isCommentBeingEdited(comment.id)) {
                                     <span class="comment-list__status">編集中</span>

--- a/frontend/src/app/features/board/page.ts
+++ b/frontend/src/app/features/board/page.ts
@@ -9,6 +9,7 @@ import {
 import { CommonModule } from '@angular/common';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
 import { PageHeaderComponent } from '@shared/ui/page-header/page-header';
+import { LocalDateTimePipe } from '@shared/pipes/local-date-time.pipe';
 
 import { WorkspaceStore } from '@core/state/workspace-store';
 import {
@@ -127,7 +128,7 @@ const RESOLVED_SUBTASK_STATUSES = new Set<SubtaskStatus>(['done', 'non-issue']);
 @Component({
   selector: 'app-board-page',
   standalone: true,
-  imports: [CommonModule, DragDropModule, PageHeaderComponent],
+  imports: [CommonModule, DragDropModule, PageHeaderComponent, LocalDateTimePipe],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/profile/evaluations/page.html
+++ b/frontend/src/app/features/profile/evaluations/page.html
@@ -125,9 +125,9 @@
                   </h2>
                   <p class="evaluations-page__latest-meta">
                     評価期間
-                    <span>{{ evaluation.period_start | date: 'yyyy/MM/dd' }}</span>
+                    <span>{{ evaluation.period_start | localDateTime: 'yyyy/MM/dd' }}</span>
                     〜
-                    <span>{{ evaluation.period_end | date: 'yyyy/MM/dd' }}</span>
+                    <span>{{ evaluation.period_end | localDateTime: 'yyyy/MM/dd' }}</span>
                   </p>
                   <p class="evaluations-page__latest-meta">
                     判定種別: {{ triggeredLabel(evaluation.triggered_by) }} / モデル:
@@ -265,8 +265,8 @@
                         <div class="evaluations-page__history-summary">
                           <div class="evaluations-page__history-summary-text">
                             <span class="evaluations-page__history-period"
-                              >{{ item.period_start | date: 'yyyy/MM/dd' }} 〜
-                              {{ item.period_end | date: 'yyyy/MM/dd' }}</span
+                              >{{ item.period_start | localDateTime: 'yyyy/MM/dd' }} 〜
+                              {{ item.period_end | localDateTime: 'yyyy/MM/dd' }}</span
                             >
                             <span class="evaluations-page__history-label">{{
                               item.competency?.name || 'コンピテンシー評価'
@@ -292,7 +292,10 @@
                         <div class="evaluations-page__history-meta">
                           <span>判定種別: {{ triggeredLabel(item.triggered_by) }}</span>
                           <span>モデル: {{ item.ai_model || '未設定' }}</span>
-                          <span>記録日時: {{ item.created_at | date: 'yyyy/MM/dd HH:mm' }}</span>
+                          <span
+                            >記録日時:
+                            {{ item.created_at | localDateTime: 'yyyy/MM/dd HH:mm' }}</span
+                          >
                         </div>
                         @if (
                           hasActions(item.attitude_actions) || hasActions(item.behavior_actions)

--- a/frontend/src/app/features/profile/evaluations/page.ts
+++ b/frontend/src/app/features/profile/evaluations/page.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
+import { LocalDateTimePipe } from '@shared/pipes/local-date-time.pipe';
 import { HttpErrorResponse } from '@angular/common/http';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -43,7 +44,7 @@ const DEFAULT_HISTORY_LIMIT = 12;
 @Component({
   selector: 'app-profile-evaluations-page',
   standalone: true,
-  imports: [CommonModule, PageLayoutComponent],
+  imports: [CommonModule, PageLayoutComponent, LocalDateTimePipe],
   templateUrl: './page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/features/reports/reports-page.component.html
+++ b/frontend/src/app/features/reports/reports-page.component.html
@@ -375,7 +375,7 @@
                 <p class="page-list__title">{{ event.event_type }}</p>
               </div>
               <div class="page-list__meta">
-                <span>{{ event.created_at | date: 'short' }}</span>
+                <span>{{ event.created_at | localDateTime: 'short' }}</span>
               </div>
             </li>
           </ul>

--- a/frontend/src/app/features/reports/reports-page.component.ts
+++ b/frontend/src/app/features/reports/reports-page.component.ts
@@ -25,11 +25,12 @@ import {
 import { WorkspaceStore } from '@core/state/workspace-store';
 import { createId } from '@core/utils/create-id';
 import { PageLayoutComponent } from '@shared/ui/page-layout/page-layout';
+import { LocalDateTimePipe } from '@shared/pipes/local-date-time.pipe';
 
 @Component({
   selector: 'app-report-assistant-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink, PageLayoutComponent],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, PageLayoutComponent, LocalDateTimePipe],
   templateUrl: './reports-page.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/shared/pipes/local-date-time.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/local-date-time.pipe.spec.ts
@@ -1,0 +1,23 @@
+import { LocalDateTimePipe } from './local-date-time.pipe';
+
+describe('LocalDateTimePipe', () => {
+  let pipe: LocalDateTimePipe;
+
+  beforeEach(() => {
+    pipe = new LocalDateTimePipe();
+  });
+
+  it('formats ISO timestamps in the provided timezone', () => {
+    const result = pipe.transform('2024-01-01T12:34:56Z', 'yyyy/MM/dd HH:mm', 'UTC');
+    expect(result).toBe('2024/01/01 12:34');
+  });
+
+  it('formats plain dates without a time component', () => {
+    const result = pipe.transform('2024-03-15', 'yyyy/MM/dd', 'UTC');
+    expect(result).toBe('2024/03/15');
+  });
+
+  it('falls back to an empty string for invalid inputs', () => {
+    expect(pipe.transform('not-a-date', 'yyyy/MM/dd', 'UTC')).toBe('');
+  });
+});

--- a/frontend/src/app/shared/pipes/local-date-time.pipe.ts
+++ b/frontend/src/app/shared/pipes/local-date-time.pipe.ts
@@ -1,0 +1,139 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Temporal } from '@js-temporal/polyfill';
+
+type LocalDateFormat = 'medium' | 'short' | 'yyyy/MM/dd' | 'yyyy/MM/dd HH:mm';
+
+type NormalizedTemporal =
+  | { readonly kind: 'instant'; readonly instant: Temporal.Instant }
+  | { readonly kind: 'date'; readonly date: Temporal.PlainDate };
+
+@Pipe({
+  name: 'localDateTime',
+  standalone: true,
+})
+export class LocalDateTimePipe implements PipeTransform {
+  private static readonly midnight = Temporal.PlainTime.from('00:00');
+
+  transform(value: unknown, format: LocalDateFormat = 'medium', timeZone?: string): string {
+    const normalized = this.normalize(value);
+    if (!normalized) {
+      return '';
+    }
+
+    const zone = this.resolveTimeZone(timeZone);
+
+    switch (format) {
+      case 'yyyy/MM/dd':
+        return this.formatDate(normalized, zone);
+      case 'yyyy/MM/dd HH:mm':
+        return this.formatDateTime(normalized, zone);
+      case 'short':
+        return this.formatShort(normalized, zone);
+      case 'medium':
+      default:
+        return this.formatMedium(normalized, zone);
+    }
+  }
+
+  private normalize(value: unknown): NormalizedTemporal | null {
+    if (!value) {
+      return null;
+    }
+
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime())
+        ? null
+        : { kind: 'instant', instant: Temporal.Instant.from(value.toISOString()) };
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        return null;
+      }
+
+      if (trimmed.includes('T')) {
+        return this.parseDateTime(trimmed);
+      }
+
+      try {
+        return { kind: 'date', date: Temporal.PlainDate.from(trimmed) };
+      } catch {
+        return this.parseDateTime(trimmed);
+      }
+    }
+
+    return null;
+  }
+
+  private parseDateTime(value: string): NormalizedTemporal | null {
+    try {
+      return { kind: 'instant', instant: Temporal.Instant.from(value) };
+    } catch {
+      const parsed = new Date(value);
+      if (Number.isNaN(parsed.getTime())) {
+        return null;
+      }
+
+      return { kind: 'instant', instant: Temporal.Instant.from(parsed.toISOString()) };
+    }
+  }
+
+  private resolveTimeZone(preferred?: string): string {
+    if (preferred && preferred.trim().length > 0) {
+      return preferred;
+    }
+
+    try {
+      const resolved = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (resolved && resolved.trim().length > 0) {
+        return resolved;
+      }
+    } catch {
+      // Ignore resolution errors and fall back to UTC below.
+    }
+
+    return 'UTC';
+  }
+
+  private formatDate(value: NormalizedTemporal, timeZone: string): string {
+    if (value.kind === 'date') {
+      return this.composeDate(value.date.year, value.date.month, value.date.day);
+    }
+
+    const zoned = value.instant.toZonedDateTimeISO(timeZone);
+    const date = zoned.toPlainDate();
+    return this.composeDate(date.year, date.month, date.day);
+  }
+
+  private formatDateTime(value: NormalizedTemporal, timeZone: string): string {
+    const zoned = this.ensureZoned(value, timeZone);
+    return `${this.pad(zoned.year, 4)}/${this.pad(zoned.month)}/${this.pad(zoned.day)} ${this.pad(zoned.hour)}:${this.pad(zoned.minute)}`;
+  }
+
+  private formatMedium(value: NormalizedTemporal, timeZone: string): string {
+    const zoned = this.ensureZoned(value, timeZone);
+    return zoned.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+  }
+
+  private formatShort(value: NormalizedTemporal, timeZone: string): string {
+    const zoned = this.ensureZoned(value, timeZone);
+    return zoned.toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' });
+  }
+
+  private ensureZoned(value: NormalizedTemporal, timeZone: string): Temporal.ZonedDateTime {
+    if (value.kind === 'instant') {
+      return value.instant.toZonedDateTimeISO(timeZone);
+    }
+
+    return value.date.toZonedDateTime({ timeZone, plainTime: LocalDateTimePipe.midnight });
+  }
+
+  private composeDate(year: number, month: number, day: number): string {
+    return `${this.pad(year, 4)}/${this.pad(month)}/${this.pad(day)}`;
+  }
+
+  private pad(value: number, length = 2): string {
+    return value.toString().padStart(length, '0');
+  }
+}


### PR DESCRIPTION
## Summary
- add @js-temporal/polyfill and a standalone LocalDateTimePipe to render timestamps in the viewer's timezone
- replace Angular's date pipe usage across admin, board, analytics, reports, and evaluation views with the new pipe
- cover the pipe with focused unit tests and update imports to expose it to the affected pages

## Testing
- npm run lint
- npx prettier --check src/app/features/admin/page.html src/app/features/admin/page.ts src/app/features/analytics/page.html src/app/features/analytics/page.ts src/app/features/board/page.html src/app/features/board/page.ts src/app/features/profile/evaluations/page.html src/app/features/profile/evaluations/page.ts src/app/features/reports/reports-page.component.html src/app/features/reports/reports-page.component.ts src/app/shared/pipes/local-date-time.pipe.ts src/app/shared/pipes/local-date-time.pipe.spec.ts
- CI=true npx ng test --browsers=ChromeHeadlessNoSandbox --watch=false --code-coverage=false --progress=false *(fails: ChromeHeadless is missing libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ebb377dc8320ad6d565874b41818