### PR TITLE
Refresh select styling across workspace UI

### DIFF
--- a/frontend/src/app/features/admin/page.html
+++ b/frontend/src/app/features/admin/page.html
@@ -126,7 +126,7 @@
           </label>
           <label class="form-field">
             <span class="form-field__label">レベル</span>
-            <select class="form-control" name="competency-level" formControlName="level">
+            <select class="form-control app-select" name="competency-level" formControlName="level">
               <option value="junior">初級 (3段階)</option>
               <option value="intermediate">中級 (5段階)</option>
             </select>
@@ -215,7 +215,12 @@
         <div class="form-grid form-grid--two">
           <label class="form-field">
             <span class="form-field__label">対象ユーザ</span>
-            <select class="form-control" formControlName="userId" name="evaluation-user" required>
+            <select
+              class="form-control app-select"
+              formControlName="userId"
+              name="evaluation-user"
+              required
+            >
               <option value="">選択してください</option>
               @for (user of users(); track user.id) {
                 <option [value]="user.id">{{ user.email }}</option>
@@ -225,7 +230,7 @@
           <label class="form-field">
             <span class="form-field__label">コンピテンシー</span>
             <select
-              class="form-control"
+              class="form-control app-select"
               formControlName="competencyId"
               name="evaluation-competency"
               required
@@ -417,7 +422,7 @@
       <form class="page-form" [formGroup]="apiForm" (submit)="updateApiCredential($event)">
         <label class="form-field">
           <span class="form-field__label">利用モデル</span>
-          <select class="form-control" name="api-model" formControlName="model">
+          <select class="form-control app-select" name="api-model" formControlName="model">
             @if (!isKnownModel(apiForm.controls.model.value)) {
               <option [value]="apiForm.controls.model.value">
                 {{ apiForm.controls.model.value }} (保存済み)

--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -260,7 +260,7 @@
                   <label class="form-field">
                     <span class="form-field__label">ステータス</span>
                     <select
-                      class="form-control"
+                      class="form-control app-select"
                       [value]="proposal.statusId"
                       (change)="updateProposalStatus(proposal.id, $any($event.target).value)"
                     >

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -560,7 +560,7 @@
                     <label class="subtask-editor__field">
                       <span class="subtask-editor__field-label">ステータス</span>
                       <select
-                        class="subtask-editor__input"
+                        class="subtask-editor__input app-select"
                         [value]="task.status"
                         (change)="
                           changeSubtaskStatus(active.id, task.id, $any($event.target).value)
@@ -722,7 +722,7 @@
             <label class="subtask-editor__field">
               <span class="subtask-editor__field-label">ステータス</span>
               <select
-                class="subtask-editor__input"
+                class="subtask-editor__input app-select"
                 [value]="newSubtaskForm.controls.status.value()"
                 (change)="newSubtaskForm.controls.status.setValue($any($event.target).value)"
               >

--- a/frontend/src/app/features/reports/reports-page.component.html
+++ b/frontend/src/app/features/reports/reports-page.component.html
@@ -271,7 +271,7 @@
                     </div>
                     <div class="form-field">
                       <label class="form-field__label">優先度</label>
-                      <select class="form-control" formControlName="priority">
+                      <select class="form-control app-select" formControlName="priority">
                         <option value="urgent">urgent</option>
                         <option value="high">high</option>
                         <option value="medium">medium</option>

--- a/frontend/src/app/features/settings/page.html
+++ b/frontend/src/app/features/settings/page.html
@@ -246,7 +246,7 @@
                   >
                   <select
                     [attr.id]="'template-edit-status-' + template.id"
-                    class="form-control"
+                    class="form-control app-select"
                     [value]="templateEditForm.controls.defaultStatusId.value()"
                     (change)="
                       templateEditForm.controls.defaultStatusId.setValue($any($event.target).value)
@@ -425,7 +425,7 @@
           <span class="form-field__label" for="template-status">初期ステータス</span>
           <select
             id="template-status"
-            class="form-control"
+            class="form-control app-select"
             [value]="templateForm.controls.defaultStatusId.value()"
             (change)="templateForm.controls.defaultStatusId.setValue($any($event.target).value)"
           >

--- a/frontend/src/styles/pages/_base.scss
+++ b/frontend/src/styles/pages/_base.scss
@@ -52,11 +52,12 @@
   border: 1px solid var(--border-subtle);
   padding: 0.85rem 1.1rem;
   font-size: 0.95rem;
-  background: color-mix(in srgb, var(--surface-card) 80%, transparent);
+  background-color: color-mix(in srgb, var(--surface-card) 80%, transparent);
   color: var(--text-primary);
   transition:
     border-color 150ms ease,
-    background-color 150ms ease;
+    background-color 150ms ease,
+    box-shadow 180ms ease;
 }
 
 .form-control::placeholder {
@@ -79,6 +80,137 @@
   border-color: color-mix(in srgb, var(--danger) 55%, transparent);
   outline: 2px solid color-mix(in srgb, var(--danger) 24%, transparent);
   outline-offset: 2px;
+}
+
+.app-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  display: block;
+  width: 100%;
+  min-height: 3rem;
+  padding: 0.85rem calc(1.1rem + 1.85rem) 0.85rem 1.1rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-subtle);
+  font-size: 0.95rem;
+  line-height: 1.35;
+  color: var(--text-primary);
+  background-color: color-mix(in srgb, var(--surface-card) 88%, transparent);
+  background-image:
+    linear-gradient(
+      45deg,
+      transparent 50%,
+      color-mix(in srgb, var(--text-secondary) 72%, transparent) 50%
+    ),
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--text-secondary) 72%, transparent) 50%,
+      transparent 50%
+    );
+  background-position:
+    calc(100% - 1.35rem) calc(50% - 0.25rem),
+    calc(100% - 0.85rem) calc(50% - 0.25rem);
+  background-size: 0.65rem 0.65rem;
+  background-repeat: no-repeat;
+  background-origin: border-box;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--surface-inverse) 6%, transparent),
+    0 10px 22px -18px color-mix(in srgb, var(--surface-inverse) 35%, transparent);
+  cursor: pointer;
+  transition:
+    background-color 180ms ease,
+    border-color 180ms ease,
+    box-shadow 220ms ease;
+}
+
+.app-select:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--surface-card) 96%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border-subtle));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--accent) 16%, transparent),
+    0 16px 32px -22px color-mix(in srgb, var(--surface-inverse) 45%, transparent);
+}
+
+.app-select:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--accent) 32%, transparent);
+  outline-offset: 2px;
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border-subtle));
+  background-color: color-mix(in srgb, var(--surface-card) 98%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent),
+    0 0 0 4px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.app-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  border-color: color-mix(in srgb, var(--border-subtle) 60%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--surface-inverse) 4%, transparent);
+  background-image:
+    linear-gradient(
+      45deg,
+      transparent 50%,
+      color-mix(in srgb, var(--text-muted) 45%, transparent) 50%
+    ),
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--text-muted) 45%, transparent) 50%,
+      transparent 50%
+    );
+}
+
+.app-select option {
+  color: var(--text-primary);
+  background-color: var(--surface-card);
+}
+
+.app-select[multiple],
+.app-select[size]:not([size='1']) {
+  padding-inline-end: 1.1rem;
+  background-image: none;
+  min-height: 7.5rem;
+  cursor: default;
+}
+
+.dark .app-select {
+  background-color: color-mix(in srgb, var(--surface-layer-2) 92%, transparent);
+  border-color: color-mix(in srgb, var(--border-overlay) 78%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--surface-inverse) 20%, transparent),
+    0 14px 28px -22px color-mix(in srgb, var(--surface-inverse) 50%, transparent);
+  background-image:
+    linear-gradient(
+      45deg,
+      transparent 50%,
+      color-mix(in srgb, var(--text-inverse-tertiary) 70%, transparent) 50%
+    ),
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--text-inverse-tertiary) 70%, transparent) 50%,
+      transparent 50%
+    );
+}
+
+.dark .app-select:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--surface-layer-3) 96%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--border-overlay));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent),
+    0 18px 36px -24px color-mix(in srgb, var(--surface-inverse) 60%, transparent);
+}
+
+.dark .app-select:focus-visible {
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--accent) 32%, transparent),
+    0 0 0 4px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.dark .app-select option {
+  background-color: color-mix(in srgb, var(--surface-layer-3) 94%, transparent);
+}
+
+.app-select::-ms-expand {
+  display: none;
 }
 
 .form-actions {

--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -656,7 +656,7 @@
   width: 100%;
   border-radius: 1.25rem;
   border: 1px solid var(--border-subtle);
-  background: var(--surface);
+  background-color: var(--surface);
   padding: var(--space-sm) var(--space-md);
   font-size: 0.875rem;
   transition:
@@ -664,9 +664,9 @@
     background-color 150ms ease;
 }
 
-.subtask-editor__input:focus,
-.comment-form__input:focus,
-.comment-form__textarea:focus {
+.subtask-editor__input:focus-visible,
+.comment-form__input:focus-visible,
+.comment-form__textarea:focus-visible {
   outline: 3px solid color-mix(in srgb, var(--accent) 24%, transparent);
   outline-offset: 2px;
   border-color: var(--accent);


### PR DESCRIPTION
## Summary
- add a shared `.app-select` style with modern spacing, hover, and dark mode states for select controls
- apply the new select styling across board, analyze, reports, settings, and admin templates and align focus handling

## Testing
- npm run format:check *(fails: pre-existing formatting warnings in untouched files)*
- npx prettier --check "src/app/features/admin/page.html" "src/styles/pages/_base.scss"
- npm run test:ci *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e1edfdb2508320909bdaf556bc7b54