### PR TITLE
Allow production frontend to call hosted backend

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -44,7 +44,10 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("SECRET_ENCRYPTION_KEY", "secret_encryption_key"),
     )
     allowed_origins: str | list[str] = Field(
-        default_factory=lambda: ["http://localhost:4200"],
+        default_factory=lambda: [
+            "http://localhost:4200",
+            "https://verbalize-yourself.vercel.app",
+        ],
         validation_alias=AliasChoices("ALLOWED_ORIGINS", "allowed_origins"),
     )
     recommendation_label_weight: float = Field(

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -6,7 +6,31 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
+    <meta name="verbalize:api-base-url" content="https://verbalize-yourself-peach.vercel.app" />
     <link rel="icon" type="image/svg+xml" href="/gemini.svg" />
+    <script>
+      (function () {
+        if (typeof window === 'undefined') {
+          return;
+        }
+
+        try {
+          var hostname = window.location && window.location.hostname;
+          if (!hostname) {
+            return;
+          }
+
+          if (hostname === 'localhost' || hostname === '127.0.0.1') {
+            var apiMeta = document.querySelector('meta[name="verbalize:api-base-url"]');
+            if (apiMeta && apiMeta.parentNode) {
+              apiMeta.parentNode.removeChild(apiMeta);
+            }
+          }
+        } catch (error) {
+          // Ignore failures while resolving the runtime host.
+        }
+      })();
+    </script>
     <script>
       (function () {
         var THEME_STORAGE_KEY = 'verbalize-yourself:theme-preference';


### PR DESCRIPTION
## Summary
- include the deployed frontend domain in the FastAPI CORS defaults so production browsers are accepted
- expose the deployed API base URL in the Angular index while stripping it for localhost development

## Testing
- black --check backend/app/config.py
- ruff check backend/app/config.py
- pytest backend/tests
- cd frontend && npx prettier --check src/index.html
- cd frontend && npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e239176b408320982f42113cc62a74