### PR TITLE
Refine select styling with layered gradient chrome

### DIFF
--- a/frontend/src/app/features/admin/page.html
+++ b/frontend/src/app/features/admin/page.html
@@ -126,7 +126,7 @@
           </label>
           <label class="form-field">
             <span class="form-field__label">レベル</span>
-            <select class="form-control" name="competency-level" formControlName="level">
+            <select class="form-control app-select" name="competency-level" formControlName="level">
               <option value="junior">初級 (3段階)</option>
               <option value="intermediate">中級 (5段階)</option>
             </select>
@@ -215,7 +215,12 @@
         <div class="form-grid form-grid--two">
           <label class="form-field">
             <span class="form-field__label">対象ユーザ</span>
-            <select class="form-control" formControlName="userId" name="evaluation-user" required>
+            <select
+              class="form-control app-select"
+              formControlName="userId"
+              name="evaluation-user"
+              required
+            >
               <option value="">選択してください</option>
               @for (user of users(); track user.id) {
                 <option [value]="user.id">{{ user.email }}</option>
@@ -225,7 +230,7 @@
           <label class="form-field">
             <span class="form-field__label">コンピテンシー</span>
             <select
-              class="form-control"
+              class="form-control app-select"
               formControlName="competencyId"
               name="evaluation-competency"
               required
@@ -417,7 +422,7 @@
       <form class="page-form" [formGroup]="apiForm" (submit)="updateApiCredential($event)">
         <label class="form-field">
           <span class="form-field__label">利用モデル</span>
-          <select class="form-control" name="api-model" formControlName="model">
+          <select class="form-control app-select" name="api-model" formControlName="model">
             @if (!isKnownModel(apiForm.controls.model.value)) {
               <option [value]="apiForm.controls.model.value">
                 {{ apiForm.controls.model.value }} (保存済み)

--- a/frontend/src/app/features/analyze/page.html
+++ b/frontend/src/app/features/analyze/page.html
@@ -260,7 +260,7 @@
                   <label class="form-field">
                     <span class="form-field__label">ステータス</span>
                     <select
-                      class="form-control"
+                      class="form-control app-select"
                       [value]="proposal.statusId"
                       (change)="updateProposalStatus(proposal.id, $any($event.target).value)"
                     >

--- a/frontend/src/app/features/board/page.html
+++ b/frontend/src/app/features/board/page.html
@@ -560,7 +560,7 @@
                     <label class="subtask-editor__field">
                       <span class="subtask-editor__field-label">ステータス</span>
                       <select
-                        class="subtask-editor__input"
+                        class="subtask-editor__input app-select"
                         [value]="task.status"
                         (change)="
                           changeSubtaskStatus(active.id, task.id, $any($event.target).value)
@@ -722,7 +722,7 @@
             <label class="subtask-editor__field">
               <span class="subtask-editor__field-label">ステータス</span>
               <select
-                class="subtask-editor__input"
+                class="subtask-editor__input app-select"
                 [value]="newSubtaskForm.controls.status.value()"
                 (change)="newSubtaskForm.controls.status.setValue($any($event.target).value)"
               >

--- a/frontend/src/app/features/reports/reports-page.component.html
+++ b/frontend/src/app/features/reports/reports-page.component.html
@@ -271,7 +271,7 @@
                     </div>
                     <div class="form-field">
                       <label class="form-field__label">優先度</label>
-                      <select class="form-control" formControlName="priority">
+                      <select class="form-control app-select" formControlName="priority">
                         <option value="urgent">urgent</option>
                         <option value="high">high</option>
                         <option value="medium">medium</option>

--- a/frontend/src/app/features/settings/page.html
+++ b/frontend/src/app/features/settings/page.html
@@ -246,7 +246,7 @@
                   >
                   <select
                     [attr.id]="'template-edit-status-' + template.id"
-                    class="form-control"
+                    class="form-control app-select"
                     [value]="templateEditForm.controls.defaultStatusId.value()"
                     (change)="
                       templateEditForm.controls.defaultStatusId.setValue($any($event.target).value)
@@ -425,7 +425,7 @@
           <span class="form-field__label" for="template-status">初期ステータス</span>
           <select
             id="template-status"
-            class="form-control"
+            class="form-control app-select"
             [value]="templateForm.controls.defaultStatusId.value()"
             (change)="templateForm.controls.defaultStatusId.setValue($any($event.target).value)"
           >

--- a/frontend/src/styles/pages/_base.scss
+++ b/frontend/src/styles/pages/_base.scss
@@ -52,11 +52,12 @@
   border: 1px solid var(--border-subtle);
   padding: 0.85rem 1.1rem;
   font-size: 0.95rem;
-  background: color-mix(in srgb, var(--surface-card) 80%, transparent);
+  background-color: color-mix(in srgb, var(--surface-card) 80%, transparent);
   color: var(--text-primary);
   transition:
     border-color 150ms ease,
-    background-color 150ms ease;
+    background-color 150ms ease,
+    box-shadow 180ms ease;
 }
 
 .form-control::placeholder {
@@ -79,6 +80,182 @@
   border-color: color-mix(in srgb, var(--danger) 55%, transparent);
   outline: 2px solid color-mix(in srgb, var(--danger) 24%, transparent);
   outline-offset: 2px;
+}
+
+.app-select {
+  --select-radius: 1.2rem;
+  --select-fill: color-mix(in srgb, var(--surface-card) 88%, transparent);
+  --select-border-start: color-mix(in srgb, var(--accent) 42%, var(--surface-card));
+  --select-border-end: color-mix(in srgb, var(--info) 34%, var(--surface-card));
+  --select-arrow-color: color-mix(in srgb, var(--text-secondary) 82%, transparent);
+  --select-shadow:
+    0 20px 48px -34px color-mix(in srgb, var(--surface-inverse) 48%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--surface-inverse) 6%, transparent);
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  display: block;
+  width: 100%;
+  min-height: 3rem;
+  border: 1px solid transparent;
+  border-radius: var(--select-radius);
+  padding: 0.85rem calc(1.1rem + 3.1rem) 0.85rem 1.1rem;
+  font-size: 0.95rem;
+  line-height: 1.35;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  color: var(--text-primary);
+  background-image:
+    radial-gradient(
+      circle at calc(100% - 1.7rem) 50%,
+      color-mix(in srgb, var(--accent) 16%, transparent),
+      transparent 68%
+    ),
+    linear-gradient(45deg, transparent 54%, var(--select-arrow-color) 54%),
+    linear-gradient(135deg, var(--select-arrow-color) 46%, transparent 46%),
+    linear-gradient(var(--select-fill), var(--select-fill)),
+    linear-gradient(135deg, var(--select-border-start), var(--select-border-end));
+  background-repeat: no-repeat;
+  background-origin: padding-box, padding-box, padding-box, padding-box, border-box;
+  background-clip: padding-box, padding-box, padding-box, padding-box, border-box;
+  background-size:
+    3rem 94%,
+    0.7rem 0.7rem,
+    0.7rem 0.7rem,
+    100% 100%,
+    100% 100%;
+  background-position:
+    calc(100% - 1.55rem) 50%,
+    calc(100% - 1.9rem) calc(50% - 0.3rem),
+    calc(100% - 1.25rem) calc(50% - 0.3rem),
+    0 0,
+    0 0;
+  box-shadow: var(--select-shadow);
+  cursor: pointer;
+  transition:
+    background-size 220ms ease,
+    background-position 220ms ease,
+    box-shadow 240ms ease,
+    color 160ms ease,
+    filter 200ms ease;
+}
+
+.app-select:hover:not(:disabled) {
+  --select-fill: color-mix(in srgb, var(--surface-card) 96%, transparent);
+  --select-border-start: color-mix(in srgb, var(--accent) 60%, var(--surface-card));
+  --select-border-end: color-mix(in srgb, var(--info) 48%, var(--surface-card));
+  --select-arrow-color: color-mix(in srgb, var(--accent-strong) 75%, var(--text-primary));
+  --select-shadow:
+    0 28px 58px -34px color-mix(in srgb, var(--surface-inverse) 52%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent) 16%, transparent);
+  background-size:
+    3.25rem 96%,
+    0.7rem 0.7rem,
+    0.7rem 0.7rem,
+    100% 100%,
+    100% 100%;
+}
+
+.app-select:focus-visible {
+  --select-fill: color-mix(in srgb, var(--surface-card) 98%, transparent);
+  --select-border-start: color-mix(in srgb, var(--accent) 74%, transparent);
+  --select-border-end: color-mix(in srgb, var(--info) 62%, transparent);
+  --select-arrow-color: color-mix(in srgb, var(--accent-strong) 85%, var(--text-primary));
+  --select-shadow:
+    0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent),
+    0 0 0 6px color-mix(in srgb, var(--accent) 12%, transparent);
+  background-size:
+    3.4rem 98%,
+    0.7rem 0.7rem,
+    0.7rem 0.7rem,
+    100% 100%,
+    100% 100%;
+  outline: none;
+}
+
+.app-select:disabled {
+  --select-fill: color-mix(in srgb, var(--surface-card) 90%, transparent);
+  --select-border-start: color-mix(in srgb, var(--border-subtle) 65%, transparent);
+  --select-border-end: color-mix(in srgb, var(--border-subtle) 48%, transparent);
+  --select-arrow-color: color-mix(in srgb, var(--text-muted) 55%, transparent);
+  --select-shadow: inset 0 0 0 1px color-mix(in srgb, var(--surface-inverse) 6%, transparent);
+  color: color-mix(in srgb, var(--text-muted) 74%, transparent);
+  cursor: not-allowed;
+}
+
+.app-select option {
+  color: var(--text-primary);
+  background-color: var(--surface-card);
+}
+
+.app-select[multiple],
+.app-select[size]:not([size='1']) {
+  --select-arrow-color: transparent;
+  min-height: 7.5rem;
+  padding-inline-end: 1.1rem;
+  cursor: default;
+  background-image:
+    linear-gradient(var(--select-fill), var(--select-fill)),
+    linear-gradient(135deg, var(--select-border-start), var(--select-border-end));
+  background-origin: padding-box, border-box;
+  background-clip: padding-box, border-box;
+  background-size:
+    100% 100%,
+    100% 100%;
+  background-position:
+    0 0,
+    0 0;
+}
+
+.dark .app-select {
+  --select-fill: color-mix(in srgb, var(--surface-layer-2) 92%, transparent);
+  --select-border-start: color-mix(in srgb, var(--accent) 56%, var(--surface-layer-3));
+  --select-border-end: color-mix(in srgb, var(--info) 48%, var(--surface-layer-3));
+  --select-arrow-color: color-mix(in srgb, var(--text-inverse-secondary) 82%, transparent);
+  --select-shadow:
+    0 24px 60px -36px color-mix(in srgb, var(--surface-inverse) 70%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--surface-inverse) 18%, transparent);
+}
+
+.dark .app-select:hover:not(:disabled) {
+  --select-fill: color-mix(in srgb, var(--surface-layer-3) 96%, transparent);
+  --select-border-start: color-mix(in srgb, var(--accent) 70%, var(--surface-layer-2));
+  --select-border-end: color-mix(in srgb, var(--info) 62%, var(--surface-layer-2));
+  --select-arrow-color: color-mix(in srgb, var(--accent-strong) 80%, var(--text-inverse-primary));
+  --select-shadow:
+    0 28px 66px -36px color-mix(in srgb, var(--surface-inverse) 72%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.dark .app-select:focus-visible {
+  --select-fill: color-mix(in srgb, var(--surface-layer-3) 98%, transparent);
+  --select-border-start: color-mix(in srgb, var(--accent) 78%, transparent);
+  --select-border-end: color-mix(in srgb, var(--info) 68%, transparent);
+  --select-shadow:
+    0 0 0 3px color-mix(in srgb, var(--accent) 26%, transparent),
+    0 0 0 6px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.dark .app-select:disabled {
+  --select-fill: color-mix(in srgb, var(--surface-layer-2) 88%, transparent);
+  --select-border-start: color-mix(in srgb, var(--border-overlay) 70%, transparent);
+  --select-border-end: color-mix(in srgb, var(--border-overlay) 60%, transparent);
+  --select-arrow-color: color-mix(in srgb, var(--text-inverse-muted) 55%, transparent);
+  color: color-mix(in srgb, var(--text-inverse-muted) 76%, transparent);
+}
+
+.dark .app-select option {
+  background-color: color-mix(in srgb, var(--surface-layer-3) 94%, transparent);
+}
+
+.app-select::-ms-expand {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-select {
+    transition: none;
+  }
 }
 
 .form-actions {

--- a/frontend/src/styles/pages/_base.scss
+++ b/frontend/src/styles/pages/_base.scss
@@ -83,13 +83,16 @@
 }
 
 .app-select {
-  --select-radius: 1.2rem;
-  --select-fill: color-mix(in srgb, var(--surface-card) 88%, transparent);
+  --select-radius: 1.25rem;
+  --select-padding-x: 1.15rem;
+  --select-button-width: 2.85rem;
+  --select-fill: color-mix(in srgb, var(--surface-card) 90%, transparent);
+  --select-button-fill: color-mix(in srgb, var(--accent) 12%, var(--select-fill));
   --select-border-start: color-mix(in srgb, var(--accent) 42%, var(--surface-card));
   --select-border-end: color-mix(in srgb, var(--info) 34%, var(--surface-card));
-  --select-arrow-color: color-mix(in srgb, var(--text-secondary) 82%, transparent);
+  --select-arrow-color: color-mix(in srgb, var(--text-secondary) 80%, transparent);
   --select-shadow:
-    0 20px 48px -34px color-mix(in srgb, var(--surface-inverse) 48%, transparent),
+    0 22px 48px -34px color-mix(in srgb, var(--surface-inverse) 48%, transparent),
     inset 0 0 0 1px color-mix(in srgb, var(--surface-inverse) 6%, transparent);
   appearance: none;
   -webkit-appearance: none;
@@ -99,82 +102,60 @@
   min-height: 3rem;
   border: 1px solid transparent;
   border-radius: var(--select-radius);
-  padding: 0.85rem calc(1.1rem + 3.1rem) 0.85rem 1.1rem;
+  padding: 0.85rem calc(var(--select-padding-x) + var(--select-button-width)) 0.85rem
+    var(--select-padding-x);
   font-size: 0.95rem;
   line-height: 1.35;
   font-weight: 500;
   letter-spacing: 0.01em;
   color: var(--text-primary);
-  background-image:
-    radial-gradient(
-      circle at calc(100% - 1.7rem) 50%,
-      color-mix(in srgb, var(--accent) 16%, transparent),
-      transparent 68%
-    ),
-    linear-gradient(45deg, transparent 54%, var(--select-arrow-color) 54%),
-    linear-gradient(135deg, var(--select-arrow-color) 46%, transparent 46%),
-    linear-gradient(var(--select-fill), var(--select-fill)),
-    linear-gradient(135deg, var(--select-border-start), var(--select-border-end));
-  background-repeat: no-repeat;
-  background-origin: padding-box, padding-box, padding-box, padding-box, border-box;
-  background-clip: padding-box, padding-box, padding-box, padding-box, border-box;
-  background-size:
-    3rem 94%,
-    0.7rem 0.7rem,
-    0.7rem 0.7rem,
-    100% 100%,
-    100% 100%;
-  background-position:
-    calc(100% - 1.55rem) 50%,
-    calc(100% - 1.9rem) calc(50% - 0.3rem),
-    calc(100% - 1.25rem) calc(50% - 0.3rem),
-    0 0,
-    0 0;
+  background:
+    linear-gradient(135deg, transparent 47%, var(--select-arrow-color) 47% 53%, transparent 53%)
+      calc(100% - (var(--select-button-width) / 2) + 0.32rem) 52% / 0.65rem 0.65rem no-repeat,
+    linear-gradient(45deg, transparent 47%, var(--select-arrow-color) 47% 53%, transparent 53%)
+      calc(100% - (var(--select-button-width) / 2) - 0.32rem) 52% / 0.65rem 0.65rem no-repeat,
+    linear-gradient(
+        to right,
+        var(--select-fill) 0 calc(100% - var(--select-button-width)),
+        var(--select-button-fill) calc(100% - var(--select-button-width)) 100%
+      )
+      padding-box no-repeat,
+    linear-gradient(135deg, var(--select-border-start), var(--select-border-end)) border-box
+      no-repeat;
   box-shadow: var(--select-shadow);
   cursor: pointer;
   transition:
-    background-size 220ms ease,
-    background-position 220ms ease,
-    box-shadow 240ms ease,
-    color 160ms ease,
-    filter 200ms ease;
+    box-shadow 220ms ease,
+    color 150ms ease,
+    filter 220ms ease;
 }
 
 .app-select:hover:not(:disabled) {
   --select-fill: color-mix(in srgb, var(--surface-card) 96%, transparent);
+  --select-button-fill: color-mix(in srgb, var(--accent) 20%, var(--select-fill));
   --select-border-start: color-mix(in srgb, var(--accent) 60%, var(--surface-card));
   --select-border-end: color-mix(in srgb, var(--info) 48%, var(--surface-card));
   --select-arrow-color: color-mix(in srgb, var(--accent-strong) 75%, var(--text-primary));
   --select-shadow:
     0 28px 58px -34px color-mix(in srgb, var(--surface-inverse) 52%, transparent),
     inset 0 0 0 1px color-mix(in srgb, var(--accent) 16%, transparent);
-  background-size:
-    3.25rem 96%,
-    0.7rem 0.7rem,
-    0.7rem 0.7rem,
-    100% 100%,
-    100% 100%;
 }
 
 .app-select:focus-visible {
   --select-fill: color-mix(in srgb, var(--surface-card) 98%, transparent);
+  --select-button-fill: color-mix(in srgb, var(--accent) 26%, var(--select-fill));
   --select-border-start: color-mix(in srgb, var(--accent) 74%, transparent);
   --select-border-end: color-mix(in srgb, var(--info) 62%, transparent);
   --select-arrow-color: color-mix(in srgb, var(--accent-strong) 85%, var(--text-primary));
   --select-shadow:
     0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent),
     0 0 0 6px color-mix(in srgb, var(--accent) 12%, transparent);
-  background-size:
-    3.4rem 98%,
-    0.7rem 0.7rem,
-    0.7rem 0.7rem,
-    100% 100%,
-    100% 100%;
   outline: none;
 }
 
 .app-select:disabled {
   --select-fill: color-mix(in srgb, var(--surface-card) 90%, transparent);
+  --select-button-fill: color-mix(in srgb, var(--surface-card) 88%, transparent);
   --select-border-start: color-mix(in srgb, var(--border-subtle) 65%, transparent);
   --select-border-end: color-mix(in srgb, var(--border-subtle) 48%, transparent);
   --select-arrow-color: color-mix(in srgb, var(--text-muted) 55%, transparent);
@@ -190,25 +171,19 @@
 
 .app-select[multiple],
 .app-select[size]:not([size='1']) {
-  --select-arrow-color: transparent;
+  --select-button-width: 0rem;
   min-height: 7.5rem;
-  padding-inline-end: 1.1rem;
+  padding-inline-end: var(--select-padding-x);
   cursor: default;
-  background-image:
-    linear-gradient(var(--select-fill), var(--select-fill)),
-    linear-gradient(135deg, var(--select-border-start), var(--select-border-end));
-  background-origin: padding-box, border-box;
-  background-clip: padding-box, border-box;
-  background-size:
-    100% 100%,
-    100% 100%;
-  background-position:
-    0 0,
-    0 0;
+  background:
+    linear-gradient(var(--select-fill), var(--select-fill)) padding-box no-repeat,
+    linear-gradient(135deg, var(--select-border-start), var(--select-border-end)) border-box
+      no-repeat;
 }
 
 .dark .app-select {
   --select-fill: color-mix(in srgb, var(--surface-layer-2) 92%, transparent);
+  --select-button-fill: color-mix(in srgb, var(--accent) 16%, var(--select-fill));
   --select-border-start: color-mix(in srgb, var(--accent) 56%, var(--surface-layer-3));
   --select-border-end: color-mix(in srgb, var(--info) 48%, var(--surface-layer-3));
   --select-arrow-color: color-mix(in srgb, var(--text-inverse-secondary) 82%, transparent);
@@ -219,6 +194,7 @@
 
 .dark .app-select:hover:not(:disabled) {
   --select-fill: color-mix(in srgb, var(--surface-layer-3) 96%, transparent);
+  --select-button-fill: color-mix(in srgb, var(--accent) 26%, var(--select-fill));
   --select-border-start: color-mix(in srgb, var(--accent) 70%, var(--surface-layer-2));
   --select-border-end: color-mix(in srgb, var(--info) 62%, var(--surface-layer-2));
   --select-arrow-color: color-mix(in srgb, var(--accent-strong) 80%, var(--text-inverse-primary));
@@ -229,6 +205,7 @@
 
 .dark .app-select:focus-visible {
   --select-fill: color-mix(in srgb, var(--surface-layer-3) 98%, transparent);
+  --select-button-fill: color-mix(in srgb, var(--accent) 32%, var(--select-fill));
   --select-border-start: color-mix(in srgb, var(--accent) 78%, transparent);
   --select-border-end: color-mix(in srgb, var(--info) 68%, transparent);
   --select-shadow:
@@ -238,6 +215,7 @@
 
 .dark .app-select:disabled {
   --select-fill: color-mix(in srgb, var(--surface-layer-2) 88%, transparent);
+  --select-button-fill: color-mix(in srgb, var(--surface-layer-2) 86%, transparent);
   --select-border-start: color-mix(in srgb, var(--border-overlay) 70%, transparent);
   --select-border-end: color-mix(in srgb, var(--border-overlay) 60%, transparent);
   --select-arrow-color: color-mix(in srgb, var(--text-inverse-muted) 55%, transparent);

--- a/frontend/src/styles/pages/_board.scss
+++ b/frontend/src/styles/pages/_board.scss
@@ -655,18 +655,23 @@
 .comment-form__textarea {
   width: 100%;
   border-radius: 1.25rem;
-  border: 1px solid var(--border-subtle);
-  background: var(--surface);
-  padding: var(--space-sm) var(--space-md);
-  font-size: 0.875rem;
   transition:
     border-color 150ms ease,
     background-color 150ms ease;
 }
 
-.subtask-editor__input:focus,
-.comment-form__input:focus,
-.comment-form__textarea:focus {
+.subtask-editor__input:not(.app-select),
+.comment-form__input,
+.comment-form__textarea {
+  padding: var(--space-sm) var(--space-md);
+  font-size: 0.875rem;
+  border: 1px solid var(--border-subtle);
+  background-color: var(--surface);
+}
+
+.subtask-editor__input:not(.app-select):focus-visible,
+.comment-form__input:focus-visible,
+.comment-form__textarea:focus-visible {
   outline: 3px solid color-mix(in srgb, var(--accent) 24%, transparent);
   outline-offset: 2px;
   border-color: var(--accent);
@@ -1145,7 +1150,7 @@
   border-color: color-mix(in srgb, var(--neutral-border-strong) 80%, transparent);
 }
 
-.dark .board-page .subtask-editor__input,
+.dark .board-page .subtask-editor__input:not(.app-select),
 .dark .board-page .comment-form__input,
 .dark .board-page .comment-form__textarea {
   background: color-mix(in srgb, var(--surface) 80%, transparent);


### PR DESCRIPTION
## Summary
- restyle the shared `.app-select` with gradient borders, custom arrow accents, and refreshed hover/focus treatments in light and dark themes
- adjust board subtask input rules so enhanced select styling retains its spacing and dark-mode colors

## Testing
- npx prettier --check "frontend/src/styles/pages/_base.scss" "frontend/src/styles/pages/_board.scss"
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e1edfdb2508320909bdaf556bc7b54