### PR TITLE
Add stylish favicons for frontend and backend

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -59,3 +59,8 @@ def get_db() -> Iterator[Session]:
         yield db
     finally:
         db.close()
+
+
+# Backwards-compatible handles expected by the rest of the application
+engine = get_engine()
+SessionLocal = _get_session_factory()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import logging
 from contextlib import asynccontextmanager
 
+from pathlib import Path
+
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from fastapi.requests import Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -37,6 +39,8 @@ from .routers import (
     workspace_templates,
 )
 
+FAVICON_PATH = Path(__file__).resolve().parent.parent / "favicon.svg"
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
@@ -67,6 +71,7 @@ app = FastAPI(
     description="API for transforming unstructured input into actionable task boards.",
     version="0.1.0",
     lifespan=lifespan,
+    swagger_favicon_url="/favicon.svg",
 )
 
 app.add_middleware(
@@ -110,6 +115,16 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
     logger.exception("Unhandled error", exc_info=exc)
     resp = JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
     return _apply_cors(resp, request)
+
+
+@app.get("/favicon.svg", include_in_schema=False)
+async def favicon_svg() -> FileResponse:
+    return FileResponse(FAVICON_PATH, media_type="image/svg+xml")
+
+
+@app.get("/favicon.ico", include_in_schema=False)
+async def favicon_ico() -> RedirectResponse:
+    return RedirectResponse(url="/favicon.svg")
 
 
 # include routers

--- a/backend/favicon.svg
+++ b/backend/favicon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Verbalize Yourself icon">
+  <defs>
+    <linearGradient id="accent" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#241d68" />
+      <stop offset="50%" stop-color="#5c3dff" />
+      <stop offset="100%" stop-color="#2cd0ff" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="rgba(12, 15, 40, 0.35)" />
+    </filter>
+  </defs>
+  <rect width="56" height="56" x="4" y="4" rx="18" fill="url(#accent)" filter="url(#shadow)" />
+  <path
+    fill="#fff"
+    d="M22.1 18.5 32 40.2l9.9-21.7h7.2L33.4 47.5h-2.8L14.9 18.5h7.2zm1 0"
+  />
+  <path
+    fill="#cfe8ff"
+    d="M25 18.5h-5.8l10.3 22.4 1.5 3.3 1.5-3.3L42.8 18.5H37l-7.6 16.6L25 18.5z"
+    opacity="0.65"
+  />
+</svg>

--- a/frontend/favicon.svg
+++ b/frontend/favicon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Verbalize Yourself icon">
+  <defs>
+    <linearGradient id="accent" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#241d68" />
+      <stop offset="50%" stop-color="#5c3dff" />
+      <stop offset="100%" stop-color="#2cd0ff" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="rgba(12, 15, 40, 0.35)" />
+    </filter>
+  </defs>
+  <rect width="56" height="56" x="4" y="4" rx="18" fill="url(#accent)" filter="url(#shadow)" />
+  <path
+    fill="#fff"
+    d="M22.1 18.5 32 40.2l9.9-21.7h7.2L33.4 47.5h-2.8L14.9 18.5h7.2zm1 0"
+  />
+  <path
+    fill="#cfe8ff"
+    d="M25 18.5h-5.8l10.3 22.4 1.5 3.3 1.5-3.3L42.8 18.5H37l-7.6 16.6L25 18.5z"
+    opacity="0.65"
+  />
+</svg>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Verbalize Yourself icon">
+  <defs>
+    <linearGradient id="accent" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#241d68" />
+      <stop offset="50%" stop-color="#5c3dff" />
+      <stop offset="100%" stop-color="#2cd0ff" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="rgba(12, 15, 40, 0.35)" />
+    </filter>
+  </defs>
+  <rect width="56" height="56" x="4" y="4" rx="18" fill="url(#accent)" filter="url(#shadow)" />
+  <path
+    fill="#fff"
+    d="M22.1 18.5 32 40.2l9.9-21.7h7.2L33.4 47.5h-2.8L14.9 18.5h7.2zm1 0"
+  />
+  <path
+    fill="#cfe8ff"
+    d="M25 18.5h-5.8l10.3 22.4 1.5 3.3 1.5-3.3L42.8 18.5H37l-7.6 16.6L25 18.5z"
+    opacity="0.65"
+  />
+</svg>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
     <meta name="verbalize:api-base-url" content="https://verbalize-yourself-peach.vercel.app" />
-    <link rel="icon" type="image/svg+xml" href="/gemini.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <script>
       (function () {
         if (typeof window === 'undefined') {


### PR DESCRIPTION
## Summary
- add a shared gradient favicon asset to both the frontend and backend roots
- wire the Angular index page to serve the new favicon and expose it through the public assets folder
- expose the favicon from FastAPI, reuse it for Swagger UI, and restore database engine exports required by app startup

## Testing
- pytest backend/tests


------
https://chatgpt.com/codex/tasks/task_e_68e2a368aa748320b831bdf98e08c312